### PR TITLE
Overridding o-forms padding

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -14,6 +14,7 @@
 
 	&__fieldset {
 		padding: 0;
+		margin: 0;
 		border: 0;
 	}
 

--- a/main.scss
+++ b/main.scss
@@ -35,4 +35,12 @@
 		@include oButtonsSize('big');
 		@include oButtonsTheme('primary');
 	}
+
+	// Override o-forms padding set at certain screen sizes
+	// This should be removed when Origami remove this from o-forms
+	.o-forms {
+		@include oGridRespondTo(S) {
+			padding: 0;
+		}
+	}
 }


### PR DESCRIPTION
This wrongly indents fields against titles, raised with origami so should hopefully be fixed in future versions.

 🐿 v2.9.0