### PR TITLE
Adding corp signup differences

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -23,6 +23,11 @@
 		&--center {
 			text-align: center;
 		}
+
+		&--flex {
+			display: flex;
+			justify-content: space-between;
+		}
 	}
 
 	&__terms {
@@ -38,10 +43,13 @@
 		@include oTypographyLinkExternal;
 	}
 
-	&__submit {
+	&__button {
 		@include oButtons;
 		@include oButtonsSize('big');
-		@include oButtonsTheme('primary');
+
+		&--submit {
+			@include oButtonsTheme('primary');
+		}
 	}
 
 	// Override o-forms padding set at certain screen sizes

--- a/partials/accept-terms.html
+++ b/partials/accept-terms.html
@@ -14,6 +14,12 @@
 		</p>
 		{{/if}}
 
+		{{#if isCorpSignup}}
+		<p id="terms-corp-signup">Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.</p>
+		<p id="terms-corp-signup">Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.</p>
+		<p id="terms-corp-signup">myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.</p>
+		{{/if}}
+
 		{{#if isSignup}}
 			{{#if offer.isPrintProduct}}
 		<p id="terms-print">Savings quoted based on Financial Times’ weekly cover price and FT.com’s equivalent weekly price where applicable. Offer open to new individual customers only and is only available in the UK. Only 1 subscription available per customer. Subscriptions are non-refundable and cannot be transferred or resold. Credit for suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription term (4 issues per yearly FT Weekend subscription term). Vouchers to redeem subscriptions may not be purchased by retailers of the Financial Times. Your subscription lasts for <span class="tc-term">{{requestedTerm}}</span>. To give you uninterrupted access we will automatically renew it using the payment method you provided, unless you cancel before your renewal date.</p>

--- a/partials/fieldset.html
+++ b/partials/fieldset.html
@@ -1,7 +1,7 @@
 <fieldset {{#if name}}name="{{name}}" {{/if}}class="ncf__fieldset">
 
 	{{#if legend}}
-	<legend class="o-forms__label">{{legend}}</legend>
+	<legend class="o-forms__label{{#if hideLegend}} o-normalise-visually-hidden{{/if}}">{{legend}}</legend>
 	{{/if}}
 
 	<div class="o-forms__group">

--- a/partials/submit.html
+++ b/partials/submit.html
@@ -1,5 +1,9 @@
-<div class="o-forms o-forms--wide ncf__field{{#if isCentered}} ncf__field--center{{/if}}">
+<div class="o-forms o-forms--wide ncf__field{{#if isCentered}} ncf__field--center{{/if}}{{#if backButtonUrl}} ncf__field--flex{{/if}}">
 
-	<button class="ncf__submit" data-trackable="submit" type="submit">{{#if label}}{{label}}{{else}}Continue{{/if}}</button>
+	{{#if backButtonUrl }}
+	<a class="ncf__button" href="{{ backButtonUrl }}" target="_parent" data-trackable="link">Back</a>
+	{{/if}}
+
+	<button class="ncf__button ncf__button--submit" data-trackable="submit" type="submit">{{#if label}}{{label}}{{else}}Continue{{/if}}</button>
 
 </div>

--- a/tests/partials/accept-terms.spec.js
+++ b/tests/partials/accept-terms.spec.js
@@ -4,6 +4,17 @@ const {
 	shouldError
 } = require('../helpers');
 
+const SELECTOR_STANDARD_TERMS = 'label p#terms-default';
+const SELECTOR_PRINT_TERMS = 'label p#terms-print';
+const SELECTOR_SIGNUP_TERMS = 'label p#terms-signup';
+const SELECTOR_CANCELLATION_TERMS = 'label p#terms-cancellation';
+const SELECTOR_SPECIAL_TERMS = 'label p#terms-special';
+const SELECTOR_B2B_TERMS = 'label p#terms-b2b';
+const SELECTOR_CORP_TERMS = 'label p#terms-corp';
+const SELECTOR_ACCEPT_TERMS_FIELD = '#acceptTermsField';
+const SELECTOR_CHECKBOX = 'input';
+const SELECTOR_ANCHOR = 'a';
+
 let context = {};
 const offer = {
 	ageRestriction: 18,
@@ -21,7 +32,7 @@ describe('accept-terms template', () => {
 		const ageRestrictionText = '16 years';
 		const $ = context.template({});
 
-		expect($('label').text().trim()).to.contain(ageRestrictionText);
+		expect($(SELECTOR_STANDARD_TERMS).text().trim()).to.contain(ageRestrictionText);
 	});
 
 	it('should use the given restricted age in the copy', () => {
@@ -31,7 +42,7 @@ describe('accept-terms template', () => {
 			offer: offer
 		});
 
-		expect($('label').text().trim()).to.contain(ageRestrictionText);
+		expect($(SELECTOR_STANDARD_TERMS).text().trim()).to.contain(ageRestrictionText);
 	});
 
 	describe('not register or signup', () => {
@@ -40,18 +51,13 @@ describe('accept-terms template', () => {
 		it('should use no div data tracking', () => {
 			const $ = context.template(params);
 
-			expect($('#acceptTermsField').data('trackable')).to.be.undefined;
+			expect($(SELECTOR_ACCEPT_TERMS_FIELD).data('trackable')).to.be.undefined;
 		});
 
 		it('should have default terms and nothing else', () => {
 			const $ = context.template(params);
 
-			expect($('label p#terms-default').length).to.equal(1);
-			expect($('label p#terms-print').length).to.equal(0);
-			expect($('label p#terms-signup').length).to.equal(0);
-			expect($('label p#terms-cancellation').length).to.equal(0);
-			expect($('label p#terms-special').length).to.equal(0);
-			expect($('label p#terms-b2b').length).to.equal(0);
+			expectTerms($, {standard: 1});
 		});
 	});
 
@@ -63,17 +69,13 @@ describe('accept-terms template', () => {
 		it('should use the register data tracking if isRegister is true', () => {
 			const $ = context.template(params);
 
-			expect($('#acceptTermsField').data('trackable')).to.equal('register-up-terms');
+			expect($(SELECTOR_ACCEPT_TERMS_FIELD).data('trackable')).to.equal('register-up-terms');
 		});
 
 		it('should have default terms', () => {
 			const $ = context.template(params);
-			expect($('label p#terms-default').length).to.equal(1);
-			expect($('label p#terms-print').length).to.equal(0);
-			expect($('label p#terms-signup').length).to.equal(0);
-			expect($('label p#terms-cancellation').length).to.equal(0);
-			expect($('label p#terms-special').length).to.equal(0);
-			expect($('label p#terms-b2b').length).to.equal(0);
+
+			expectTerms($, {standard: 1});
 		});
 	});
 
@@ -86,43 +88,27 @@ describe('accept-terms template', () => {
 		it('should use the signup data tracking if the isSignup is true', () => {
 			const $ = context.template(params);
 
-			expect($('#acceptTermsField').data('trackable')).to.equal('sign-up-terms');
+			expect($(SELECTOR_ACCEPT_TERMS_FIELD).data('trackable')).to.equal('sign-up-terms');
 		});
 
 		it('should have default, signup, cancellation and marketing terms by default', () => {
 			const $ = context.template(params);
 
-			expect($('label p#terms-default').length).to.equal(1);
-			expect($('label p#terms-print').length).to.equal(0);
-			expect($('label p#terms-signup').length).to.equal(1);
-			expect($('label p#terms-cancellation').length).to.equal(1);
-			expect($('label p#terms-special').length).to.equal(0);
-			expect($('label p#terms-b2b').length).to.equal(0);
+			expectTerms($, {standard:1, signup:1, cancellation:1});
 		});
 
 		it('should have print related copy if a print product', () => {
 			const $ = context.template({...params, offer: {...offer, isPrintProduct: true}});
 
-			expect($('label').text().trim()).to.contain('hand-delivered subscriptions');
-			expect($('label p#terms-default').length).to.equal(1);
-			expect($('label p#terms-print').length).to.equal(1);
-			expect($('label p#terms-signup').length).to.equal(0);
-			expect($('label p#terms-cancellation').length).to.equal(1);
-			expect($('label p#terms-special').length).to.equal(0);
-			expect($('label p#terms-b2b').length).to.equal(0);
+			expectTerms($, {standard:1, print:1, cancellation:1});
 		});
 
 		it('should have special offer terms copy if supplied', () => {
 			const specialTerms = 'These are some special terms that an offer supplies';
 			const $ = context.template({...params, offer: {...offer, hasSpecialTerms: true, specialTerms: specialTerms}});
 
-			expect($('label').text().trim()).to.contain(specialTerms);
-			expect($('label p#terms-default').length).to.equal(1);
-			expect($('label p#terms-print').length).to.equal(0);
-			expect($('label p#terms-signup').length).to.equal(1);
-			expect($('label p#terms-cancellation').length).to.equal(1);
-			expect($('label p#terms-special').length).to.equal(1);
-			expect($('label p#terms-b2b').length).to.equal(0);
+			expect($(SELECTOR_SPECIAL_TERMS).text().trim()).to.contain(specialTerms);
+			expectTerms($, {standard:1, signup:1, cancellation:1, special:1});
 		});
 	});
 
@@ -134,25 +120,20 @@ describe('accept-terms template', () => {
 		it('should have just the b2b terms', () => {
 			const $ = context.template(params);
 
-			expect($('label p#terms-default').length).to.equal(0);
-			expect($('label p#terms-print').length).to.equal(0);
-			expect($('label p#terms-signup').length).to.equal(0);
-			expect($('label p#terms-cancellation').length).to.equal(0);
-			expect($('label p#terms-special').length).to.equal(0);
-			expect($('label p#terms-b2b').length).to.equal(1);
+			expectTerms($, {b2b:1});
 		});
 	});
 
 	it('should be required by default', () => {
 		const $ = context.template({});
 
-		expect($('input').attr('required')).to.equal('required');
+		expect($(SELECTOR_CHECKBOX).attr('required')).to.equal('required');
 	});
 
 	it('should be unchecked by default', () => {
 		const $ = context.template({});
 
-		expect($('input').attr('checked')).to.be.undefined;
+		expect($(SELECTOR_CHECKBOX).attr('checked')).to.be.undefined;
 	});
 
 	it('should be checked if set', () => {
@@ -160,16 +141,26 @@ describe('accept-terms template', () => {
 			isChecked: true
 		});
 
-		expect($('input').attr('checked')).to.equal('checked');
+		expect($(SELECTOR_CHECKBOX).attr('checked')).to.equal('checked');
 	});
 
 	it('should have link targets of _blank', () => {
 		const $ = context.template({});
 
-		$('a').each((i, a) => {
+		$(SELECTOR_ANCHOR).each((i, a) => {
 			expect(a.attribs.target).to.equal('_blank');
 		});
 	});
 
 	shouldError(context);
 });
+
+function expectTerms ($, { standard=0, print=0, signup=0, cancellation=0, special=0, b2b=0, corp=0 }) {
+	expect($(SELECTOR_STANDARD_TERMS).length).to.equal(standard);
+	expect($(SELECTOR_PRINT_TERMS).length).to.equal(print);
+	expect($(SELECTOR_SIGNUP_TERMS).length).to.equal(signup);
+	expect($(SELECTOR_CANCELLATION_TERMS).length).to.equal(cancellation);
+	expect($(SELECTOR_SPECIAL_TERMS).length).to.equal(special);
+	expect($(SELECTOR_B2B_TERMS).length).to.equal(b2b);
+	expect($(SELECTOR_CORP_TERMS).length).to.equal(corp);
+}

--- a/tests/partials/fieldset.spec.js
+++ b/tests/partials/fieldset.spec.js
@@ -5,12 +5,18 @@ const {
 	unregisterPartial
 } = require('../helpers');
 
+const CLASS_VISUALLY_HIDDEN = 'o-normalise-visually-hidden';
+const SELECTOR_LEGEND = 'legend';
+const SELECTOR_FIELDSET = 'fieldset';
+const TEST_LEGEND = 'testing';
+const TEST_FIELDS_ID = 'testing';
+
 let context = {};
 
 describe('fieldset template', () => {
 	before(async () => {
 		context.template = await fetchPartial('fieldset.html');
-		registerPartial('fields', '<div id="testing"></div>');
+		registerPartial('fields', `<div id="${TEST_FIELDS_ID}"></div>`);
 	});
 
 	after(() => {
@@ -20,29 +26,46 @@ describe('fieldset template', () => {
 	it('should have no name or legend by default', () => {
 		const $ = context.template({});
 
-		expect($('legend').length).to.equal(0);
-		expect($('fieldset[name]').length).to.equal(0);
+		expect($(SELECTOR_LEGEND).length).to.equal(0);
+		expect($(SELECTOR_FIELDSET).attr('name')).to.be.undefined;
 	});
 
 	it('should have a name if passed', () => {
 		const $ = context.template({
-			name: 'testing'
+			name: TEST_LEGEND
 		});
 
-		expect($('fieldset').attr('name')).to.equal('testing');
+		expect($(SELECTOR_FIELDSET).attr('name')).to.equal(TEST_LEGEND);
 	});
 
 	it('should have a legend if passed', () => {
 		const $ = context.template({
-			legend: 'testing'
+			legend: TEST_LEGEND
 		});
 
-		expect($('legend').text()).to.equal('testing');
+		expect($(SELECTOR_LEGEND).text()).to.equal(TEST_LEGEND);
+	});
+
+	it('should visually display legend by default', () => {
+		const $ = context.template({
+			legend: TEST_LEGEND
+		});
+
+		expect($(SELECTOR_LEGEND).attr('class')).to.not.contain(CLASS_VISUALLY_HIDDEN);
+	});
+
+	it('should visually display legend by default', () => {
+		const $ = context.template({
+			legend: TEST_LEGEND,
+			hideLegend: true
+		});
+
+		expect($(SELECTOR_LEGEND).attr('class')).to.contain(CLASS_VISUALLY_HIDDEN);
 	});
 
 	it('should have feilds inner partial', () => {
 		const $ = context.template({});
 
-		expect($('#testing').length).to.equal(1);
+		expect($(`#${TEST_FIELDS_ID}`).length).to.equal(1);
 	});
 });

--- a/tests/partials/submit.spec.js
+++ b/tests/partials/submit.spec.js
@@ -1,6 +1,10 @@
 const { expect } = require('chai');
 const { fetchPartial } = require('../helpers');
 
+const SELECTOR_BUTTON = 'button';
+const SELECTOR_BACK_BUTTON = 'a.ncf__button';
+const SELECTOR_FIELD_CENTER = '.ncf__field--center';
+
 let context = {};
 
 describe('submit template', () => {
@@ -11,7 +15,7 @@ describe('submit template', () => {
 	it('should say Continue by default', () => {
 		const $ = context.template({});
 
-		expect($('button').text()).to.equal('Continue');
+		expect($(SELECTOR_BUTTON).text()).to.equal('Continue');
 	});
 
 	it('should display label if given', () => {
@@ -20,13 +24,13 @@ describe('submit template', () => {
 			label
 		});
 
-		expect($('button').text()).to.equal(label);
+		expect($(SELECTOR_BUTTON).text()).to.equal(label);
 	});
 
 	it('should not be centered by default', () => {
 		const $ = context.template({});
 
-		expect($('.ncf__field--center').length).to.equal(0);
+		expect($(SELECTOR_FIELD_CENTER).length).to.equal(0);
 	});
 
 	it('should be centered if set', () => {
@@ -34,6 +38,23 @@ describe('submit template', () => {
 			isCentered: true
 		});
 
-		expect($('.ncf__field--center').length).to.equal(1);
+		expect($(SELECTOR_FIELD_CENTER).length).to.equal(1);
+	});
+
+	it('should not show a back button by default', () => {
+		const $ = context.template({});
+
+		expect($(SELECTOR_BACK_BUTTON).length).to.equal(0);
+	});
+
+	it('should show a back button if URL supplied', () => {
+		const url = 'https://google.com';
+		const $ = context.template({
+			backButtonUrl: url
+		});
+
+		expect($(SELECTOR_BACK_BUTTON).attr('href')).to.equal(url);
+		// Forms can be embedded within an iframe so ensure the back button will affect the parent frame
+		expect($(SELECTOR_BACK_BUTTON).attr('target')).to.equal('_parent');
 	});
 });


### PR DESCRIPTION
- Adding back button to submit
- Add corp signup terms and conditions
- Ability to visually hide the label

 🐿 v2.9.0