### PR TITLE
Adding copy for unmasking, this is only used there currently

### DIFF
--- a/partials/cookie-privacy.html
+++ b/partials/cookie-privacy.html
@@ -1,4 +1,5 @@
 <div class="o-forms o-forms--wide" id="cookie-privacy">
+	Free trial offer available for new readers only.<br />
 	For more information about how we use your data, please refer to our
 	<a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/privacy/" target="_blank" rel="noopener" data-trackable="privacy">privacy</a> and
 	<a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/cookies/" target="_blank" rel="noopener" data-trackable="cookie">cookie</a> policies.


### PR DESCRIPTION
I don't like this as it's tying the use case directly to the component, can't think of a cleaner way of doing this currently and it may die if unmasking fails.

<img width="522" alt="screen shot 2018-08-06 at 14 06 53" src="https://user-images.githubusercontent.com/1721150/43718250-fe19dd78-9981-11e8-93da-0e0bfcb0a537.png">


 🐿 v2.9.0