### PR TITLE
Renaming usa to extended terms

### DIFF
--- a/partials/accept-terms.html
+++ b/partials/accept-terms.html
@@ -24,9 +24,9 @@
 			{{#if offer.isPrintProduct}}
 		<p id="terms-print">Savings quoted based on Financial Times’ weekly cover price and FT.com’s equivalent weekly price where applicable. Offer open to new individual customers only and is only available in the UK. Only 1 subscription available per customer. Subscriptions are non-refundable and cannot be transferred or resold. Credit for suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription term (4 issues per yearly FT Weekend subscription term). Vouchers to redeem subscriptions may not be purchased by retailers of the Financial Times. Your subscription lasts for <span class="tc-term">{{requestedTerm}}</span>. To give you uninterrupted access we will automatically renew it using the payment method you provided, unless you cancel before your renewal date.</p>
 			{{else}}
-				{{#if isUsa}}
-		<p id="terms-usa">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting customer service or emailing <a class="su-link-external" href="mailto:help@ft.com" target="_blank" rel="noopener">help@ft.com</a>.</p>
-		<p id="terms-usa">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</p>
+				{{#if isExtendedTerms}}
+		<p id="terms-extended">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting customer service or emailing <a class="su-link-external" href="mailto:help@ft.com" target="_blank" rel="noopener">help@ft.com</a>.</p>
+		<p id="terms-extended">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</p>
 				{{else}}
 		<p id="terms-signup">&dagger; Your subscription lasts for <span class="tc-term">{{requestedTerm}}</span>. To give you uninterrupted access we will automatically renew it using the payment method you provided, unless you cancel before your renewal date.</p>
 				{{/if}}

--- a/partials/accept-terms.html
+++ b/partials/accept-terms.html
@@ -9,7 +9,7 @@
 		</p>
 		{{else}}
 		<p id="terms-default">
-			I confirm I am {{#if offer.ageRestriction}}{{offer.ageRestriction}}{{else}}16{{/if}} years or older and have read and agree to the
+			I confirm I am {{#if ageRestriction}}{{ageRestriction}}{{else}}16{{/if}} years or older and have read and agree to the
 			<a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener" data-trackable="terms-and-conditions">Terms &amp; Conditions</a>
 		</p>
 		{{/if}}
@@ -21,19 +21,15 @@
 		{{/if}}
 
 		{{#if isSignup}}
-			{{#if offer.isPrintProduct}}
-		<p id="terms-print">Savings quoted based on Financial Times’ weekly cover price and FT.com’s equivalent weekly price where applicable. Offer open to new individual customers only and is only available in the UK. Only 1 subscription available per customer. Subscriptions are non-refundable and cannot be transferred or resold. Credit for suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription term (4 issues per yearly FT Weekend subscription term). Vouchers to redeem subscriptions may not be purchased by retailers of the Financial Times. Your subscription lasts for <span class="tc-term">{{requestedTerm}}</span>. To give you uninterrupted access we will automatically renew it using the payment method you provided, unless you cancel before your renewal date.</p>
-			{{else}}
-				{{#if isExtendedTerms}}
-		<p id="terms-extended">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting customer service or emailing <a class="su-link-external" href="mailto:help@ft.com" target="_blank" rel="noopener">help@ft.com</a>.</p>
-		<p id="terms-extended">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</p>
-				{{else}}
-		<p id="terms-signup">&dagger; Your subscription lasts for <span class="tc-term">{{requestedTerm}}</span>. To give you uninterrupted access we will automatically renew it using the payment method you provided, unless you cancel before your renewal date.</p>
-				{{/if}}
+			{{#if isPrintProduct}}
+		<p id="terms-print">Credit for deliver suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issies per yearly subscription terms (4 issues per yealry FT Weekend subscription term).</p>
+		<p id="terms-print">Find out more about your delivery start data in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">Terms &amp; Conditions</a></p>
+			{{else if isExtended}}
+		<p id="terms-signup">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting customer service or emailing <a class="su-link-external" href="mailto:help@ft.com" target="_blank" rel="noopener">help@ft.com</a>.</p>
+		<p id="terms-signup">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</p>
 			{{/if}}
-		<p id="terms-cancellation">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">Terms &amp; Conditions</a></p>
-			{{#if offer.hasSpecialTerms}}
-		<p id="terms-special">{{offer.specialTerms}}</p>
+			{{#if specialTerms}}
+		<p id="terms-special">{{specialTerms}}</p>
 			{{/if}}
 		{{/if}}
 	</label>

--- a/tests/partials/accept-terms.spec.js
+++ b/tests/partials/accept-terms.spec.js
@@ -7,22 +7,14 @@ const {
 const SELECTOR_STANDARD_TERMS = 'label p#terms-default';
 const SELECTOR_PRINT_TERMS = 'label p#terms-print';
 const SELECTOR_SIGNUP_TERMS = 'label p#terms-signup';
-const SELECTOR_CANCELLATION_TERMS = 'label p#terms-cancellation';
 const SELECTOR_SPECIAL_TERMS = 'label p#terms-special';
 const SELECTOR_B2B_TERMS = 'label p#terms-b2b';
 const SELECTOR_CORP_TERMS = 'label p#terms-corp';
 const SELECTOR_ACCEPT_TERMS_FIELD = '#acceptTermsField';
-const SELECTOR_EXTENDED_TERMS = 'label p#terms-extended';
 const SELECTOR_CHECKBOX = 'input';
 const SELECTOR_ANCHOR = 'a';
 
 let context = {};
-const offer = {
-	ageRestriction: 18,
-	hasSpecialTerms: false,
-	specialTerms: '',
-	isPrintProduct: false
-};
 
 describe('accept-terms template', () => {
 	before(async () => {
@@ -37,10 +29,11 @@ describe('accept-terms template', () => {
 	});
 
 	it('should use the given restricted age in the copy', () => {
-		const ageRestrictionText = '18 years';
+		const ageRestriction = 18;
+		const ageRestrictionText = `${ageRestriction} years`;
 
 		const $ = context.template({
-			offer: offer
+			ageRestriction
 		});
 
 		expect($(SELECTOR_STANDARD_TERMS).text().trim()).to.contain(ageRestrictionText);
@@ -83,7 +76,7 @@ describe('accept-terms template', () => {
 	describe('signup', () => {
 		const params = {
 			isSignup: true,
-			offer: offer
+			isExtended: true, // @todo Remove once extended terms test has been completed
 		};
 
 		it('should use the signup data tracking if the isSignup is true', () => {
@@ -92,30 +85,30 @@ describe('accept-terms template', () => {
 			expect($(SELECTOR_ACCEPT_TERMS_FIELD).data('trackable')).to.equal('sign-up-terms');
 		});
 
-		it('should have default, signup, cancellation and marketing terms by default', () => {
+		it('should have default and signup terms by default', () => {
 			const $ = context.template(params);
 
-			expectTerms($, {standard:1, cancellation:1, signup:1});
+			expectTerms($, {standard:1, signup:2});
 		});
 
 		it('should have print related copy if a print product', () => {
-			const $ = context.template({...params, offer: {...offer, isPrintProduct: true}});
+			const $ = context.template({
+				...params,
+				isPrintProduct: true
+			});
 
-			expectTerms($, {standard:1, cancellation:1, print:1});
+			expectTerms($, {standard:1, print:2});
 		});
 
-		it('should only show the extended terms when isExtendedTerms set', () => {
-			const $ = context.template({...params, offer: {...offer}, isExtendedTerms: true});
-
-			expectTerms($, {standard:1, cancellation:1, extended:2});
-		});
-
-		it('should have special offer terms copy if supplied', () => {
-			const specialTerms = 'These are some special terms that an offer supplies';
-			const $ = context.template({...params, offer: {...offer, hasSpecialTerms: true, specialTerms: specialTerms}});
+		it('should have special terms copy if supplied', () => {
+			const specialTerms = 'These are some special terms can be supplied';
+			const $ = context.template({
+				...params,
+				specialTerms
+			});
 
 			expect($(SELECTOR_SPECIAL_TERMS).text().trim()).to.contain(specialTerms);
-			expectTerms($, {standard:1, cancellation:1, signup:1, special:1});
+			expectTerms($, {standard:1, signup:2, special:1});
 		});
 	});
 
@@ -162,13 +155,11 @@ describe('accept-terms template', () => {
 	shouldError(context);
 });
 
-function expectTerms ($, { standard=0, print=0, signup=0, cancellation=0, special=0, b2b=0, corp=0, extended=0 }) {
+function expectTerms ($, { standard=0, print=0, signup=0, special=0, b2b=0, corp=0 }) {
 	expect($(SELECTOR_STANDARD_TERMS).length).to.equal(standard);
 	expect($(SELECTOR_PRINT_TERMS).length).to.equal(print);
 	expect($(SELECTOR_SIGNUP_TERMS).length).to.equal(signup);
-	expect($(SELECTOR_CANCELLATION_TERMS).length).to.equal(cancellation);
 	expect($(SELECTOR_SPECIAL_TERMS).length).to.equal(special);
 	expect($(SELECTOR_B2B_TERMS).length).to.equal(b2b);
 	expect($(SELECTOR_CORP_TERMS).length).to.equal(corp);
-	expect($(SELECTOR_EXTENDED_TERMS).length).to.equal(extended);
 }

--- a/tests/partials/accept-terms.spec.js
+++ b/tests/partials/accept-terms.spec.js
@@ -12,7 +12,7 @@ const SELECTOR_SPECIAL_TERMS = 'label p#terms-special';
 const SELECTOR_B2B_TERMS = 'label p#terms-b2b';
 const SELECTOR_CORP_TERMS = 'label p#terms-corp';
 const SELECTOR_ACCEPT_TERMS_FIELD = '#acceptTermsField';
-const SELECTOR_USA_TERMS = 'label p#terms-usa';
+const SELECTOR_EXTENDED_TERMS = 'label p#terms-extended';
 const SELECTOR_CHECKBOX = 'input';
 const SELECTOR_ANCHOR = 'a';
 
@@ -104,10 +104,10 @@ describe('accept-terms template', () => {
 			expectTerms($, {standard:1, cancellation:1, print:1});
 		});
 
-		it('should only show the USA terms when isUsa set', () => {
-			const $ = context.template({...params, offer: {...offer}, isUsa: true});
+		it('should only show the extended terms when isExtendedTerms set', () => {
+			const $ = context.template({...params, offer: {...offer}, isExtendedTerms: true});
 
-			expectTerms($, {standard:1, cancellation:1, usa:2});
+			expectTerms($, {standard:1, cancellation:1, extended:2});
 		});
 
 		it('should have special offer terms copy if supplied', () => {
@@ -162,7 +162,7 @@ describe('accept-terms template', () => {
 	shouldError(context);
 });
 
-function expectTerms ($, { standard=0, print=0, signup=0, cancellation=0, special=0, b2b=0, corp=0, usa=0 }) {
+function expectTerms ($, { standard=0, print=0, signup=0, cancellation=0, special=0, b2b=0, corp=0, extended=0 }) {
 	expect($(SELECTOR_STANDARD_TERMS).length).to.equal(standard);
 	expect($(SELECTOR_PRINT_TERMS).length).to.equal(print);
 	expect($(SELECTOR_SIGNUP_TERMS).length).to.equal(signup);
@@ -170,5 +170,5 @@ function expectTerms ($, { standard=0, print=0, signup=0, cancellation=0, specia
 	expect($(SELECTOR_SPECIAL_TERMS).length).to.equal(special);
 	expect($(SELECTOR_B2B_TERMS).length).to.equal(b2b);
 	expect($(SELECTOR_CORP_TERMS).length).to.equal(corp);
-	expect($(SELECTOR_USA_TERMS).length).to.equal(usa);
+	expect($(SELECTOR_EXTENDED_TERMS).length).to.equal(extended);
 }


### PR DESCRIPTION
 🐿 v2.9.0

## Feature Description
As part of rolling out longer terms to the rest of the world we need to refresh the terms across the board. This includes reducing the current terms and adding these new terms to only a test sample of people. This PR also removes the knowledge of offers from the terms selector, this is to reduce the reliance on other data structures.

## Link to Ticket / Card:
https://trello.com/c/5EPnjhfb/526-change-the-longer-terms-copy-to-show-to-usa-a-b-rest-of-world

