### PR TITLE
Changing password rules copy

### DIFF
--- a/partials/password.html
+++ b/partials/password.html
@@ -1,7 +1,7 @@
 <div id="passwordField" class="o-forms o-forms--wide ncf__field js-field{{#if unknownUser}} js-unknown-user-field{{/if}}{{#if hasError}} o-forms--error{{/if}}" data-ui-item="form-field" data-ui-item-name="password" data-validate="required,password">
 
 	<label for="password" class="o-forms__label">Password</label>
-	<small id="password-description" class="o-forms__additional-info">At least 6 characters including both letters &amp; numbers</small>
+	<small id="password-description" class="o-forms__additional-info">Use 8 or more characters with a mix of letters, numbers &amp; symbols</small>
 
 	<div class="o-forms__affix-wrapper js-show-password">
 		<input type="password" id="password" name="password" placeholder="Enter a password" class="no-mouseflow o-forms__text o-forms__text--suffixed js-field__input js-show-password__password-input js-item__value" data-trackable="field-password" aria-describedby="password-description" aria-required="true" required>


### PR DESCRIPTION
 🐿 v2.9.0

## Feature Description
The rules for passwords in the FT are as the copy specifies, this requires a change in `next-signup` that will be done in conjunction with this.

## Link to Ticket / Card:
https://trello.com/c/Zh0QEVJO/500-updating-security-rules-around-our-passwords

