### PR TITLE
Adding message template and styles

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "o-forms": "^5.7.2",
     "n-ui-foundations": "^3.0.1",
-    "o-buttons": "^5.12.0"
+    "o-buttons": "^5.12.0",
+    "o-message": "^2.3.5"
   }
 }

--- a/demos/data.json
+++ b/demos/data.json
@@ -54,5 +54,7 @@
       "value": "AGO",
       "label": "Angola"
     }
-  ]
+  ],
+  "isError": true,
+  "message": "The quick brown fox jumped over the lazy hare!"
 }

--- a/main.scss
+++ b/main.scss
@@ -2,12 +2,14 @@
 @import 'o-typography/main';
 @import 'o-forms/main';
 @import 'o-buttons/main';
+@import 'o-message/main';
 
 @include oFormsBaseFeatures();
 @include oFormsRadioCheckboxFeatures();
 @include oFormsSuffixFeature();
 @include oFormsSectionFeature();
 @include oFormsWideFeature();
+@include oMessage($types: 'alert');
 
 // Custom styles
 .ncf {

--- a/partials/message.html
+++ b/partials/message.html
@@ -1,0 +1,7 @@
+<div class="o-forms o-forms--wide o-message o-message--alert{{#if isError}} o-message--error{{/if}}" data-o-component="o-message">
+	<div class="o-message__container">
+		<div class="o-message__content">
+			<p class="o-message__content-main">{{message}}</p>
+		</div>
+	</div>
+</div>

--- a/partials/message.html
+++ b/partials/message.html
@@ -1,4 +1,4 @@
-<div class="o-forms o-forms--wide o-message o-message--alert{{#if isError}} o-message--error{{/if}}{{#if isSuccess}} o-message--success{{/if}}" data-o-component="o-message">
+<div class="o-forms o-forms--wide o-message o-message--alert{{#if isError}} o-message--error{{else if isSuccess}} o-message--success{{else}} o-message--neutral{{/if}}" data-o-component="o-message">
 	<div class="o-message__container">
 		<div class="o-message__content">
 			<p class="o-message__content-main">{{message}}</p>

--- a/partials/message.html
+++ b/partials/message.html
@@ -1,4 +1,4 @@
-<div class="o-forms o-forms--wide o-message o-message--alert{{#if isError}} o-message--error{{/if}}" data-o-component="o-message">
+<div class="o-forms o-forms--wide o-message o-message--alert{{#if isError}} o-message--error{{/if}}{{#if isSuccess}} o-message--success{{/if}}" data-o-component="o-message">
 	<div class="o-message__container">
 		<div class="o-message__content">
 			<p class="o-message__content-main">{{message}}</p>

--- a/tests/partials/message.spec.js
+++ b/tests/partials/message.spec.js
@@ -3,6 +3,7 @@ const { fetchPartial } = require('../helpers');
 
 const CLASS_ERROR = 'o-message--error';
 const CLASS_SUCCESS = 'o-message--success';
+const CLASS_NEUTRAL = 'o-message--neutral';
 const SELECTOR_MESSAGE = '.o-message__content-main';
 const SELECTOR_CONTAINER = '.o-message';
 
@@ -28,13 +29,6 @@ describe('message template', () => {
 		expect($(SELECTOR_MESSAGE).text()).to.equal(message);
 	});
 
-	it('should not have the error or success classes by default', () => {
-		const $ = context.template({});
-
-		expect($(SELECTOR_CONTAINER).attr('class')).to.not.contain(CLASS_ERROR);
-		expect($(SELECTOR_CONTAINER).attr('class')).to.not.contain(CLASS_SUCCESS);
-	});
-
 	it('should have the error class if isError passed', () => {
 		const $ = context.template({
 			isError: true
@@ -42,14 +36,24 @@ describe('message template', () => {
 
 		expect($(SELECTOR_CONTAINER).attr('class')).to.contain(CLASS_ERROR);
 		expect($(SELECTOR_CONTAINER).attr('class')).to.not.contain(CLASS_SUCCESS);
+		expect($(SELECTOR_CONTAINER).attr('class')).to.not.contain(CLASS_NEUTRAL);
 	});
 
-	it('should have the error class if isError passed', () => {
+	it('should have the success class if isSuccess passed', () => {
 		const $ = context.template({
 			isSuccess: true
 		});
 
 		expect($(SELECTOR_CONTAINER).attr('class')).to.not.contain(CLASS_ERROR);
 		expect($(SELECTOR_CONTAINER).attr('class')).to.contain(CLASS_SUCCESS);
+		expect($(SELECTOR_CONTAINER).attr('class')).to.not.contain(CLASS_NEUTRAL);
+	});
+
+	it('should have the neutral class by default', () => {
+		const $ = context.template({});
+
+		expect($(SELECTOR_CONTAINER).attr('class')).to.not.contain(CLASS_ERROR);
+		expect($(SELECTOR_CONTAINER).attr('class')).to.not.contain(CLASS_SUCCESS);
+		expect($(SELECTOR_CONTAINER).attr('class')).to.contain(CLASS_NEUTRAL);
 	});
 });

--- a/tests/partials/message.spec.js
+++ b/tests/partials/message.spec.js
@@ -1,0 +1,43 @@
+const { expect } = require('chai');
+const { fetchPartial } = require('../helpers');
+
+const CLASS_ERROR = 'o-message--error';
+const SELECTOR_MESSAGE = '.o-message__content-main';
+const SELECTOR_CONTAINER = '.o-message';
+
+let context = {};
+
+describe('message template', () => {
+	before(async () => {
+		context.template = await fetchPartial('message.html');
+	});
+
+	it('should say nothing by default', () => {
+		const $ = context.template({});
+
+		expect($(SELECTOR_MESSAGE).text()).to.equal('');
+	});
+
+	it('should output the message if passed', () => {
+		const message = 'This is an example message for testing';
+		const $ = context.template({
+			message
+		});
+
+		expect($(SELECTOR_MESSAGE).text()).to.equal(message);
+	});
+
+	it('should not have the error class if isError is not passed', () => {
+		const $ = context.template({});
+
+		expect($(SELECTOR_CONTAINER).attr('class')).to.not.contain(CLASS_ERROR);
+	});
+
+	it('should have the error class if isError passed', () => {
+		const $ = context.template({
+			isError: true
+		});
+
+		expect($(SELECTOR_CONTAINER).attr('class')).to.contain(CLASS_ERROR);
+	});
+});

--- a/tests/partials/message.spec.js
+++ b/tests/partials/message.spec.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 const { fetchPartial } = require('../helpers');
 
 const CLASS_ERROR = 'o-message--error';
+const CLASS_SUCCESS = 'o-message--success';
 const SELECTOR_MESSAGE = '.o-message__content-main';
 const SELECTOR_CONTAINER = '.o-message';
 
@@ -27,10 +28,11 @@ describe('message template', () => {
 		expect($(SELECTOR_MESSAGE).text()).to.equal(message);
 	});
 
-	it('should not have the error class if isError is not passed', () => {
+	it('should not have the error or success classes by default', () => {
 		const $ = context.template({});
 
 		expect($(SELECTOR_CONTAINER).attr('class')).to.not.contain(CLASS_ERROR);
+		expect($(SELECTOR_CONTAINER).attr('class')).to.not.contain(CLASS_SUCCESS);
 	});
 
 	it('should have the error class if isError passed', () => {
@@ -39,5 +41,15 @@ describe('message template', () => {
 		});
 
 		expect($(SELECTOR_CONTAINER).attr('class')).to.contain(CLASS_ERROR);
+		expect($(SELECTOR_CONTAINER).attr('class')).to.not.contain(CLASS_SUCCESS);
+	});
+
+	it('should have the error class if isError passed', () => {
+		const $ = context.template({
+			isSuccess: true
+		});
+
+		expect($(SELECTOR_CONTAINER).attr('class')).to.not.contain(CLASS_ERROR);
+		expect($(SELECTOR_CONTAINER).attr('class')).to.contain(CLASS_SUCCESS);
 	});
 });


### PR DESCRIPTION
## Feature Description
Adds a `o-message` message template and styles to `ncf` for `next-profile` originally but will be used across all forms.

## Link to Ticket / Card:
https://trello.com/c/StvBSqtX/509-next-profile-page-shows-error-message-without-styling

## Screenshots:
<img width="479" alt="screen shot 2018-08-17 at 09 25 56" src="https://user-images.githubusercontent.com/1721150/44255968-a6161e80-a1ff-11e8-9080-ac4134c897a0.png">
<img width="479" alt="screen shot 2018-08-17 at 09 26 50" src="https://user-images.githubusercontent.com/1721150/44255984-b201e080-a1ff-11e8-85bc-c2f1343cd680.png">
<img width="479" alt="screen shot 2018-08-17 at 15 24 19" src="https://user-images.githubusercontent.com/1721150/44271288-a7f8d580-a231-11e8-99ed-6a97ec2f3642.png">
