### PR TITLE
Fix multiple ID selectors

### DIFF
--- a/partials/accept-terms.html
+++ b/partials/accept-terms.html
@@ -15,19 +15,19 @@
 		{{/if}}
 
 		{{#if isCorpSignup}}
-		<p id="terms-corp-signup">Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.</p>
-		<p id="terms-corp-signup">Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.</p>
-		<p id="terms-corp-signup">myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.</p>
+		<p class="terms-corp-signup">Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.</p>
+		<p class="terms-corp-signup">Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.</p>
+		<p class="terms-corp-signup">myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.</p>
 		{{/if}}
 
 		{{#if isSignup}}
 			{{#if isPrintProduct}}
-		<p id="terms-print">Credit for deliver suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issies per yearly subscription terms (4 issues per yealry FT Weekend subscription term).</p>
-		<p id="terms-print">Find out more about your delivery start date in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">Terms &amp; Conditions</a>.</p>
+		<p class="terms-print">Credit for deliver suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issies per yearly subscription terms (4 issues per yealry FT Weekend subscription term).</p>
+		<p class="terms-print">Find out more about your delivery start date in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">Terms &amp; Conditions</a>.</p>
 			{{else if isExtended}}
-		<p id="terms-signup">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting customer service or emailing <a class="su-link-external" href="mailto:help@ft.com" target="_blank" rel="noopener">help@ft.com</a>.</p>
-		<p id="terms-signup">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</p>
-		<p id="terms-signup">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">Terms &amp; Conditions</a>.</p>
+		<p class="terms-signup">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting customer service or emailing <a class="su-link-external" href="mailto:help@ft.com" target="_blank" rel="noopener">help@ft.com</a>.</p>
+		<p class="terms-signup">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</p>
+		<p class="terms-signup">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">Terms &amp; Conditions</a>.</p>
 			{{/if}}
 			{{#if specialTerms}}
 		<p id="terms-special">{{specialTerms}}</p>

--- a/tests/partials/accept-terms.spec.js
+++ b/tests/partials/accept-terms.spec.js
@@ -5,11 +5,11 @@ const {
 } = require('../helpers');
 
 const SELECTOR_STANDARD_TERMS = 'label p#terms-default';
-const SELECTOR_PRINT_TERMS = 'label p#terms-print';
-const SELECTOR_SIGNUP_TERMS = 'label p#terms-signup';
+const SELECTOR_PRINT_TERMS = 'label p.terms-print';
+const SELECTOR_SIGNUP_TERMS = 'label p.terms-signup';
 const SELECTOR_SPECIAL_TERMS = 'label p#terms-special';
 const SELECTOR_B2B_TERMS = 'label p#terms-b2b';
-const SELECTOR_CORP_TERMS = 'label p#terms-corp';
+const SELECTOR_CORP_TERMS = 'label p.terms-corp-signup';
 const SELECTOR_ACCEPT_TERMS_FIELD = '#acceptTermsField';
 const SELECTOR_CHECKBOX = 'input';
 const SELECTOR_ANCHOR = 'a';
@@ -120,7 +120,18 @@ describe('accept-terms template', () => {
 		it('should have just the b2b terms', () => {
 			const $ = context.template(params);
 
-			expectTerms($, {b2b:1});
+			expectTerms($, { b2b:1 });
+		});
+	});
+
+	describe('Corp Signup', () => {
+		const params = {
+			isCorpSignup: true
+		};
+
+		it('should have default and corp-signup terms', () => {
+			const $ = context.template(params);
+			expectTerms($, { standard: 1, corp: 3 });
 		});
 	});
 


### PR DESCRIPTION
## Feature Description

Pa11y was failing on corp-signup due to the terms having multiple IDs of the same value.

## Link to Ticket / Card:

 🐿 v2.8.0