### PR TITLE
Add package-change component and update demo functionality slightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,7 @@ To contribute to this project, clone this repository locally and commit your cod
 ```bash
 make test # runs linter and unit tests
 ```
+
+### Passing data to the demo components
+
+Add any component properties under the key of the template you're adding/working on to [demos/data.json].

--- a/demos/data.json
+++ b/demos/data.json
@@ -1,60 +1,64 @@
 {
-  "industries": [
-    {
-      "value": "ACC",
-      "label": "Accountancy & tax advisory"
-    },
-    {
-      "value": "DEF",
-      "label": "Aerospace & defence"
-    },
-    {
-      "value": "CAR",
-      "label": "Automobiles"
-    }
-  ],
-  "positions": [
-    {
-      "value": "AN",
-      "label": "Analyst"
-    },
-    {
-      "value": "AS",
-      "label": "Associate"
-    },
-    {
-      "value": "BR",
-      "label": "Broker/Trader/Advisor"
-    }
-  ],
-  "responsibilities": [
-    {
-      "value": "FIN",
-      "label": "Accounting/finance"
-    },
-    {
-      "value": "ADL",
-      "label": "Administration"
-    },
-    {
-      "value": "RES",
-      "label": "Broker/trader"
-    }
-  ],
-  "countries": [
-    {
+  "industry": {
+    "options": [{
+        "value": "ACC",
+        "label": "Accountancy & tax advisory"
+      }, {
+        "value": "DEF",
+        "label": "Aerospace & defence"
+      }, {
+        "value": "CAR",
+        "label": "Automobiles"
+      }
+    ]},
+  "position": {
+    "options": [{
+        "value": "AN",
+        "label": "Analyst"
+      }, {
+        "value": "AS",
+        "label": "Associate"
+      }, {
+        "value": "BR",
+        "label": "Broker/Trader/Advisor"
+      }
+    ]},
+  "responsibility": {
+    "options": [{
+        "value": "FIN",
+        "label": "Accounting/finance"
+      }, {
+        "value": "ADL",
+        "label": "Administration"
+      }, {
+        "value": "RES",
+        "label": "Broker/trader"
+      }
+    ]},
+  "country": {
+    "options": [{
       "value": "ABW",
       "label": "Aruba"
-    },
-    {
+    }, {
       "value": "AFG",
       "label": "Afghanistan"
-    },
-    {
+    }, {
       "value": "AGO",
       "label": "Angola"
-    }
-  ],
-  "isError": true,
-  "message": "The quick brown fox jumped over the lazy hare!"
+    }]
+  },
+  "message": {
+    "isError": true,
+    "message": "The quick brown fox jumped over the lazy dog!"
+  },
+  "package-change": {
+    "action": "/foo",
+    "currentPackage": "Digital",
+    "currentPrice": "£5.60 per week",
+    "class": "extra-css-classes-here space-separated",
+    "formInfo": [{
+      "name": "foo",
+      "value": "bar"
+    }]
+  }
 }

--- a/main.scss
+++ b/main.scss
@@ -9,7 +9,7 @@
 @include oFormsSuffixFeature();
 @include oFormsSectionFeature();
 @include oFormsWideFeature();
-@include oMessage($types: 'alert');
+@include oMessage($types: ('alert', 'notice-bleed'), $status: ('error', 'inform', 'success'));
 
 // Custom styles
 .ncf {
@@ -53,6 +53,11 @@
 			@include oButtonsTheme('primary');
 		}
 
+		&--mono {
+			@include oButtonsSize('default');
+			@include oButtonsTheme('mono');
+		}
+
 		&--google {
 			@include oButtonsTheme('secondary');
 			background-color: oColorsGetPaletteColor('white');
@@ -66,6 +71,19 @@
 				width: 18px;
 				height: 18px;
 			}
+		}
+	}
+
+	&__package-change {
+		.o-message__content {
+			align-items: center;
+			display: flex;
+		}
+		.o-message__content-main {
+			flex: 1;
+		}
+		.o-message__actions {
+			padding-bottom: 0;
 		}
 	}
 

--- a/partials/package-change.html
+++ b/partials/package-change.html
@@ -1,0 +1,13 @@
+<div class="ncf__package-change o-message o-message--notice-bleed o-message--inform{{#if class}} {{class}}{{/if}}" data-o-component="o-message">
+	<div class="o-message__container">
+		<div class="o-message__content">
+			<p class="o-message__content-main">You have chosen <strong>{{currentPackage}}</strong> {{currentPrice}}</p>
+			<div class="o-message__actions">
+				<form action="{{action}}">
+					{{#each formInfo}}<input type="hidden" name="{{name}}" value="{{value}}" />{{/each}}
+					<button class="ncf__button ncf__button--mono" data-trackable="change" type="submit">Change</button>
+				</form>
+			</div>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
🐿 v2.10.3

## Feature Description

+ Adds the `package-change` component that will be used in the new buy flow journey. Had to add the ability to pass in a class due to the fact that this will need to bleed out to the edges of the screen, yet be the same width as the form.
+ Changes the way the demo data works slightly so you can specify it per-component and it will automagically get passed in based on the name.
+ Adds example handlebars code for components that have parameters (see screenshot below for an example).

## Link to Ticket / Card

https://trello.com/c/ZpNdya65/537-select-package-component-top-bar

## Screenshots:

<img width="526" alt="1536680025" src="https://user-images.githubusercontent.com/708296/45370626-7f6dbc80-b5e0-11e8-938f-29fea0779d54.png">
