### PR TITLE
Confirm email address for emails

### DIFF
--- a/demos/app.js
+++ b/demos/app.js
@@ -102,7 +102,7 @@ function compilePartial (partial) {
 			${rendered}
 		</form>
 
-		${partialData ? `<p style="font-family: monospace;">{{> ${partial}${exampleParams} }}</p>` : ''}
+		<textarea style="width:100%" readonly>{{> ${partial}${exampleParams} }}</textarea>
 	</body>
 </html>
 	`;

--- a/demos/data.json
+++ b/demos/data.json
@@ -60,5 +60,8 @@
       "name": "foo",
       "value": "bar"
     }]
+  },
+  "email": {
+    "showConfirm": true
   }
 }

--- a/partials/email.html
+++ b/partials/email.html
@@ -20,3 +20,16 @@
 	<div class="o-forms__errortext">This email address is not valid</div>
 
 </div>
+{{#if showConfirm}}
+<div id="emailConfirmField" class="o-forms o-forms--wide ncf__field js-field{{#if hasConfirmError}} o-forms--error{{/if}}" data-validate="required,email">
+
+	<label for="email" class="o-forms__label">
+		Confirm email address
+	</label>
+
+	<input type="email" id="emailConfirm" name="emailConfirm" value="" placeholder="Confirm your email address" class="no-mouseflow o-forms__text js-field__input js-item__value" data-trackable="field-emailConfrm" aria-required="true" required>
+
+	<div class="o-forms__errortext">This email address does not match</div>
+
+</div>
+{{/if}}

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -146,7 +146,7 @@ const shouldContainPartials = function (context, partials) {
 	});
 };
 
-const shouldError = function (context) {
+const shouldError = function (context, errorParams = { hasError: true }) {
 	it('should not have error class by default', () => {
 		const $ = context.template({});
 
@@ -154,9 +154,7 @@ const shouldError = function (context) {
 	});
 
 	it('should have error class if hasError is passed', () => {
-		const $ = context.template({
-			hasError: true
-		});
+		const $ = context.template(errorParams);
 
 		expect($(`.${ERROR_CLASS}`).length).to.equal(1);
 	});

--- a/tests/partials/email.spec.js
+++ b/tests/partials/email.spec.js
@@ -70,4 +70,23 @@ describe('email template', () => {
 	});
 
 	shouldError(context);
+
+	it('should not show the confirm email by default', () => {
+		const $ = context.template({});
+
+		expect($('#emailConfirmField').length).to.equal(0);
+	});
+
+	it('should show the confirm email if asked', () => {
+		const $ = context.template({
+			showConfirm: true
+		});
+
+		expect($('#emailConfirmField').length).to.equal(1);
+	});
+
+	shouldError(context, {
+		showConfirm: true,
+		hasConfirmError: true
+	});
 });


### PR DESCRIPTION
 ## Feature Description
Adds the ability to have a confirm email address in the email moustache template. Adds `showConfirm` and `hasConfirmError` parameters to allow this.

Also changed the demo to display the implementation code in a textarea for easier distinction from the main component and ease of copy paste.

## Link to Ticket / Card:
https://trello.com/c/BZMtdexU/609-add-confirm-email-address-to-n-conversion-forms

## Screenshots:
<img width="516" alt="screen shot 2018-09-13 at 15 12 40" src="https://user-images.githubusercontent.com/1721150/45493800-7d823580-b767-11e8-81c6-3ecfad2841f2.png">

