### PR TITLE
remove weekly price from package-change

### DIFF
--- a/partials/package-change.html
+++ b/partials/package-change.html
@@ -1,7 +1,7 @@
 <div class="ncf__package-change o-message o-message--notice-bleed o-message--inform" data-o-component="o-message">
 	<div class="o-message__container">
 		<div class="o-message__content">
-			<p class="o-message__content-main">You have chosen <strong>{{currentPackage}}</strong> {{currentPrice}}</p>
+			<p class="o-message__content-main">You have chosen <strong>{{currentPackage}}</strong></p>
 			<div class="o-message__actions">
 				<form action="{{changePackageUrl}}" method="POST">
 					{{#each formData}}<input type="hidden" name="{{name}}" value="{{value}}" />{{/each}}

--- a/tests/partials/package-change.spec.js
+++ b/tests/partials/package-change.spec.js
@@ -20,13 +20,11 @@ describe('package-change template', () => {
 
 	it('should display package name and price when passed', () => {
 		const data = {
-			currentPackage: 'Digital',
-			currentPrice: '£5.60 per week'
+			currentPackage: 'Digital'
 		};
 		const $ = context.template(data);
 
 		expect($('.ncf__package-change').text()).to.contain(data.currentPackage);
-		expect($('.ncf__package-change').text()).to.contain(data.currentPrice);
 	});
 
 	it('should display package name and price when passed', () => {


### PR DESCRIPTION
 🐿 v2.10.0

## Feature Description
Removing the price from the package change component as this is no longer part of the design

## Link to Ticket / Card:
Doing as part of this - https://trello.com/c/MMzEyGiM

## Screenshots:
![image](https://user-images.githubusercontent.com/17846996/46469352-07ec1100-c7cb-11e8-80e5-4363202f85f8.png)
