### PR TITLE
Add postcode partial and add styling for form wrapper

### DIFF
--- a/demos/data.json
+++ b/demos/data.json
@@ -54,7 +54,6 @@
   "package-change": {
     "changePackageUrl": "/foo",
     "currentPackage": "Digital",
-    "currentPrice": "£5.60 per week",
     "class": "extra-css-classes-here space-separated",
     "formData": [{
       "name": "foo",

--- a/main.scss
+++ b/main.scss
@@ -1,3 +1,4 @@
+@import 'o-icons/main';
 @import 'o-colors/main';
 @import 'o-normalise/main';
 @import 'o-typography/main';
@@ -16,6 +17,11 @@
 // Custom styles
 .ncf {
 	@include oTypographySans($scale: 0);
+
+	&__wrapper {
+		background: oColorsGetPaletteColor('white');
+		padding: 50px;
+	}
 
 	&__fieldset {
 		padding: 0;
@@ -93,10 +99,10 @@
 			content: '';
 			display: block;
 			height: 2px;
-			left: 33px;
+			left: 30px;
 			position: absolute;
 			top: 12px;
-			width: calc(100% - 70px);
+			width: calc(100% - 60px);
 		}
 
 		&__button {

--- a/partials/email.html
+++ b/partials/email.html
@@ -27,7 +27,7 @@
 		Confirm email address
 	</label>
 
-	<input type="email" id="emailConfirm" name="emailConfirm" value="" placeholder="Confirm your email address" class="no-mouseflow o-forms__text js-field__input js-item__value" data-trackable="field-emailConfrm" aria-required="true" required>
+	<input type="email" id="emailConfirm" name="emailConfirm" value="{{value}}" placeholder="Confirm your email address" class="no-mouseflow o-forms__text js-field__input js-item__value" data-trackable="field-emailConfrm" aria-required="true" required>
 
 	<div class="o-forms__errortext">This email address does not match</div>
 

--- a/partials/email.html
+++ b/partials/email.html
@@ -27,7 +27,7 @@
 		Confirm email address
 	</label>
 
-	<input type="email" id="emailConfirm" name="emailConfirm" value="{{value}}" placeholder="Confirm your email address" class="no-mouseflow o-forms__text js-field__input js-item__value" data-trackable="field-emailConfrm" aria-required="true" required>
+	<input type="email" id="emailConfirm" name="emailConfirm" placeholder="Confirm your email address" class="no-mouseflow o-forms__text js-field__input js-item__value" data-trackable="field-emailConfrm" aria-required="true" required>
 
 	<div class="o-forms__errortext">This email address does not match</div>
 

--- a/partials/form.html
+++ b/partials/form.html
@@ -1,3 +1,5 @@
-<form class="ncf" action="{{action}}" method="{{#if method}}{{method}}{{else}}POST{{/if}}">
-	{{> fields }}
-</form>
+<div class="ncf__wrapper">
+	<form class="ncf" action="{{action}}" method="{{#if method}}{{method}}{{else}}POST{{/if}}">
+		{{> fields }}
+	</form>
+</div>

--- a/partials/postcode.html
+++ b/partials/postcode.html
@@ -1,0 +1,9 @@
+<div id="postCodeField" class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}" data-ui-item="form-field" data-ui-item-name="postCode" data-validate="required">
+
+	<label for="postCode" class="o-forms__label">Post code</label>
+
+	<input type="text" id="postCode" name="postCode" value="{{value}}" placeholder="Post code" class="o-forms__text js-field__input js-item__value" data-trackable="post-code" aria-required="true" required>
+
+	<div class="o-forms__errortext">Please enter your post code</div>
+
+</div>

--- a/tests/partials/post-code.spec.js
+++ b/tests/partials/post-code.spec.js
@@ -1,0 +1,20 @@
+const {
+	fetchPartial,
+	shouldBeRequired,
+	shouldPopulateValue,
+	shouldError
+} = require('../helpers');
+
+let context = {};
+
+describe('postcode template', () => {
+	before(async () => {
+		context.template = await fetchPartial('postcode.html');
+	});
+
+	shouldPopulateValue(context);
+
+	shouldBeRequired(context, 'input');
+
+	shouldError(context);
+});


### PR DESCRIPTION
 🐿 v2.10.3

## Feature Description

Adds postcode field and adds styling for the form wrapper.

## Link to Ticket / Card:

https://trello.com/c/vyUcLmgO/536-details-form-page-filling-in-the-fields

## Screenshots:

<img width="574" alt="1538987811" src="https://user-images.githubusercontent.com/708296/46598912-b8b12380-cadd-11e8-81ab-67692b786410.png">
