### PR TITLE
Allow splitting countries by usage

### DIFF
--- a/demos/data.json
+++ b/demos/data.json
@@ -1,8 +1,8 @@
 {
-	"country": {
+  "country": {
     "filterList": ["GBR", "JPN", "USA", "FRA"]
-	},
-	"message": {
+  },
+  "message": {
     "isError": true,
     "message": "The quick brown fox jumped over the lazy dog!"
   },

--- a/demos/data.json
+++ b/demos/data.json
@@ -1,8 +1,8 @@
 {
-  "country": {
+	"country": {
     "filterList": ["GBR", "JPN", "USA", "FRA"]
-  },
-  "message": {
+	},
+	"message": {
     "isError": true,
     "message": "The quick brown fox jumped over the lazy dog!"
   },

--- a/helpers/ncf-countries.js
+++ b/helpers/ncf-countries.js
@@ -1,11 +1,37 @@
 const { countries } = require('n-common-static-data').billingCountries;
 
 module.exports = function ({ hash = {}, fn }) {
-	const data = Array.isArray(hash.filterList) ? countries.filter(countryInFilterList(hash.filterList)) : countries;
-	const context = Object.assign({ countries: data }, this);
+
+	let newContext = {};
+	if (Array.isArray(hash.filterList)) {
+		const data = countries.filter(countryInFilterList(hash.filterList));
+		newContext = { countries: data };
+	} else {
+		newContext = { ncfCountryGroups: splitIntoUsage(countries) };
+	}
+	const context = Object.assign(newContext, this);
 	return fn(context);
 };
 
 function countryInFilterList (filterList) {
 	return item => filterList.includes(item.code);
+}
+
+
+function splitIntoUsage (countries) {
+	const frequentCountries = ['GBR', 'USA', 'JPN', 'FRA', 'CAN'];
+	const grouped = countries.reduce((acc, item) => {
+		const key = frequentCountries.includes(item.code) ? 'frequent' : 'remainder';
+		acc[key].push(item);
+		return acc;
+	}, { frequent: [], remainder: [] });
+
+	grouped.frequent = grouped.frequent.sort((a, b) => {
+		return frequentCountries.indexOf(a.code) - frequentCountries.indexOf(b.code);
+	});
+
+	return [
+		{ label: 'Frequently Used', countries: grouped.frequent },
+		{ label: 'Alphabetical', countries: grouped.remainder }
+	];
 }

--- a/helpers/ncf-countries.js
+++ b/helpers/ncf-countries.js
@@ -6,7 +6,7 @@ const MINIMUM_TO_SHOW_SPLIT = 2;
 module.exports = function ({ hash = {}, fn }) {
 	let newContext = {};
 	const data = Array.isArray(hash.filterList) ? countries.filter(countryInFilterList(hash.filterList)) : countries;
-	newContext = data.length >= MINIMUM_TO_SPLIT ? splitIntoUsage(countries) : { countries: data };
+	newContext = data.length >= MINIMUM_TO_SPLIT ? splitIntoUsage(data) : { countries: data };
 	const context = Object.assign(newContext, this);
 	return fn(context);
 };
@@ -26,6 +26,7 @@ function splitIntoUsage (countries) {
 		return { countries };
 	}
 
+	// Sort the frequently used countries into the usage metrics order (as defined on L#19)
 	foundFrequent = foundFrequent.sort((a, b) => {
 		return frequentCountries.indexOf(a.code) - frequentCountries.indexOf(b.code);
 	});

--- a/helpers/ncf-countries.js
+++ b/helpers/ncf-countries.js
@@ -4,7 +4,6 @@ const MINIMUM_TO_SPLIT = 50;
 const MINIMUM_TO_SHOW_SPLIT = 2;
 
 module.exports = function ({ hash = {}, fn }) {
-	let newContext = {};
 	const data = Array.isArray(hash.filterList) ? countries.filter(countryInFilterList(hash.filterList)) : countries;
 	const newContext = data.length >= MINIMUM_TO_SPLIT ? splitIntoUsage(data) : { countries: data };
 	const context = Object.assign(newContext, this);

--- a/helpers/ncf-countries.js
+++ b/helpers/ncf-countries.js
@@ -6,7 +6,7 @@ const MINIMUM_TO_SHOW_SPLIT = 2;
 module.exports = function ({ hash = {}, fn }) {
 	let newContext = {};
 	const data = Array.isArray(hash.filterList) ? countries.filter(countryInFilterList(hash.filterList)) : countries;
-	newContext = data.length >= MINIMUM_TO_SPLIT ? splitIntoUsage(data) : { countries: data };
+	const newContext = data.length >= MINIMUM_TO_SPLIT ? splitIntoUsage(data) : { countries: data };
 	const context = Object.assign(newContext, this);
 	return fn(context);
 };

--- a/package.json
+++ b/package.json
@@ -24,22 +24,22 @@
     "n-common-static-data": "financial-times/n-common-static-data#v1.5.0"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "^2.0.2",
-    "@financial-times/n-handlebars": "^1.19.6",
-    "@financial-times/n-internal-tool": "^2.2.4",
+    "@financial-times/n-gage": "^2.1.2",
+    "@financial-times/n-handlebars": "^1.21.0",
+    "@financial-times/n-internal-tool": "^2.3.1",
     "autoprefixer": "^8.6.3",
     "bower": "^1.8.4",
     "bower-resolve-webpack-plugin": "^1.0.4",
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "cheerio": "^1.0.0-rc.2",
     "mocha": "^5.1.1",
-    "node-sass": "^4.9.0",
+    "node-sass": "^4.9.4",
     "nodemon": "^1.17.5",
     "pa11y-ci": "^2.1.1",
     "postcss-cli": "^5.0.1",
     "proxyquire": "^2.1.0",
-    "sinon": "^6.2.0",
-    "webpack": "^4.12.0",
-    "webpack-cli": "^3.0.4"
+    "sinon": "^6.3.5",
+    "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.2"
   }
 }

--- a/partials/country.html
+++ b/partials/country.html
@@ -8,10 +8,21 @@
 					aria-required="true" required
 					{{#if isDisabled}}disabled{{/if}}>
 		<option value>Please select a country</option>
-		{{#each countries as |country|}}
-		<option value="{{country.code}}" {{#ifEquals country.code ../value }} selected{{/ifEquals}}>{{country.name}}</option>
-		{{/each}}
+		{{#if ncfCountryGroups}}
+			{{#each ncfCountryGroups as |group|}}
+			<optgroup label="{{group.label}}">
+				{{#each group.countries as |country|}}
+					<option value="{{country.code}}" {{#ifEquals country.code ../value }} selected{{/ifEquals}}>{{country.name}}</option>
+				{{/each}}
+			</optgroup>
+			{{/each}}
+		{{else}}
+			{{#each countries as |country|}}
+				<option value="{{country.code}}" {{#ifEquals country.code ../value }} selected{{/ifEquals}}>{{country.name}}</option>
+			{{/each}}
+		{{/if}}
 	</select>
+
 	{{/ncf-countries}}
 
 	<div class="o-forms__errortext">Please select your country</div>

--- a/partials/delivery-country.html
+++ b/partials/delivery-country.html
@@ -9,9 +9,19 @@
 					aria-required="true" required
 					{{#if isDisabled}}disabled{{/if}}>
 		<option value>Please select a country</option>
-		{{#each countries as |country|}}
-		<option value="{{country.code}}" {{#ifEquals country.code ../value }} selected{{/ifEquals}}>{{country.name}}</option>
-		{{/each}}
+		{{#if ncfCountryGroups}}
+			{{#each ncfCountryGroups as |group|}}
+			<optgroup label="{{group.label}}">
+				{{#each group.countries as |country|}}
+					<option value="{{country.code}}" {{#ifEquals country.code ../value }} selected{{/ifEquals}}>{{country.name}}</option>
+				{{/each}}
+			</optgroup>
+			{{/each}}
+		{{else}}
+			{{#each countries as |country|}}
+				<option value="{{country.code}}" {{#ifEquals country.code ../value }} selected{{/ifEquals}}>{{country.name}}</option>
+			{{/each}}
+		{{/if}}
 	</select>
 
 	{{/ncf-countries}}

--- a/tests/helpers/ncf-countries.spec.js
+++ b/tests/helpers/ncf-countries.spec.js
@@ -2,35 +2,82 @@ const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 const { expect } = require('chai');
 
-const mockBillingCountries = [{ code: 'a'}, { code: 'b'}, { code: 'c'}, { code: 'd'}];
-const helper = proxyquire('../../helpers/ncf-countries', {
-	'n-common-static-data': {
-		billingCountries: { countries: mockBillingCountries }
-	}
-});
-
 describe('NCF Countries', () => {
 
+	let helper;
 	let stub;
 
 	beforeEach(() => {
 		stub = sinon.stub();
 	});
 
-	it('sets countries on the context', () => {
+	context('filterList', () => {
 
-		helper({ hash: {}, fn: stub });
-		const context = stub.getCall(0).args[0];
-		expect(context).to.have.property('countries', mockBillingCountries);
+		beforeEach(() => {
+			const mockBillingCountries = generateCountryArray(4, { includeAllFrequent: false });
+			helper = proxyquire('../../helpers/ncf-countries', {
+				'n-common-static-data': {
+					billingCountries: { countries: mockBillingCountries }
+				}
+			});
+		});
+
+		it('filters billingCountries', () => {
+			const filterList = ['C-0', 'C-2'];
+			helper({ hash: { filterList }, fn: stub });
+			const context = stub.getCall(0).args[0];
+			expect(context.countries).to.deep.equal([{ code: 'C-0'}, { code: 'C-2'}]);
+			expect(context.countries).to.not.include([{ code: 'C-1'}, { code: 'C-4'}]);
+		});
+
 	});
 
-	it('filterList filters billingCountries', () => {
-		const filterList = ['b', 'c'];
-		helper({ hash: { filterList }, fn: stub });
-		const context = stub.getCall(0).args[0];
-		expect(context.countries).to.deep.equal([{ code: 'b'}, { code: 'c'}]);
-		expect(context.countries).to.not.include([{ code: 'a'}, { code: 'd'}]);
+	context('when there are more than 50 results', () => {
+		let mockBillingCountries;
+		beforeEach(() => {
+			mockBillingCountries = generateCountryArray(75);
+			helper = proxyquire('../../helpers/ncf-countries', {
+				'n-common-static-data': {
+					billingCountries: { countries: mockBillingCountries }
+				}
+			});
+		});
+
+		it('splits the result set  on the context', () => {
+			helper({ hash: {}, fn: stub });
+			const context = stub.getCall(0).args[0];
+			expect(context).to.have.property('ncfCountryGroups');
+			expect(context.ncfCountryGroups.length).to.equal(2);
+
+			const [frequent, alphabetical ] = context.ncfCountryGroups;
+
+			expect(frequent.label).to.equal('Frequently Used');
+			expect(frequent.countries.map(c => c.code)).to.have.members(['GBR', 'USA', 'FRA', 'CAN', 'JPN']);
+			expect(alphabetical.label).to.equal('Alphabetical');
+			expect(alphabetical.countries).to.deep.equal(mockBillingCountries);
+		});
+
+		it('does not split when a filter means there are less than two frequent countries', () => {
+			// Get all country codes APART from 'CAN','FRA', 'JPN', 'USA' => only GBR would be returned
+			const notWanted = ['CAN','FRA', 'JPN', 'USA'];
+			const filterList = mockBillingCountries.filter(country => !notWanted.includes(country.code)).map(c => c.code);
+
+			helper({ hash: { filterList }, fn: stub });
+			const context = stub.getCall(0).args[0];
+			expect(context).to.not.have.property('ncfCountryGroups');
+			expect(context).to.have.property('countries');
+
+			expect(context.countries.map(c => c.code)).to.not.have.members(notWanted);
+
+		});
 
 	});
 
 });
+
+function generateCountryArray (length, { includeAllFrequent = true } = {}) {
+	return Array.from(Array(length), (item, index) => ({
+		code: `C-${index}`
+	}))
+	.concat(includeAllFrequent ? [{ code: 'GBR' }, { code: 'USA' }, { code: 'FRA' }, { code: 'CAN' }, { code: 'JPN' }] : []);
+}


### PR DESCRIPTION
## Feature Description

When a filterList is not defined - split the countries and arrange the top used first.

## Link to Ticket / Card: https://trello.com/c/MYL6TsCt/389-improve-ux-of-country-selection

## Screenshots:

![screen shot 2018-10-19 at 09 54 42](https://user-images.githubusercontent.com/6599523/47208202-1a4a7b00-d385-11e8-9f62-7076fddd5872.png)

 🐿 v2.10.3