### PR TITLE
Correct scope for value

### DIFF
--- a/partials/country.html
+++ b/partials/country.html
@@ -12,7 +12,7 @@
 			{{#each ncfCountryGroups as |group|}}
 			<optgroup label="{{group.label}}">
 				{{#each group.countries as |country|}}
-					<option value="{{country.code}}" {{#ifEquals country.code ../value }} selected{{/ifEquals}}>{{country.name}}</option>
+					<option value="{{country.code}}" {{#ifEquals country.code ../../value }} selected{{/ifEquals}}>{{country.name}}</option>
 				{{/each}}
 			</optgroup>
 			{{/each}}

--- a/partials/delivery-country.html
+++ b/partials/delivery-country.html
@@ -13,7 +13,7 @@
 			{{#each ncfCountryGroups as |group|}}
 			<optgroup label="{{group.label}}">
 				{{#each group.countries as |country|}}
-					<option value="{{country.code}}" {{#ifEquals country.code ../value }} selected{{/ifEquals}}>{{country.name}}</option>
+					<option value="{{country.code}}" {{#ifEquals country.code ../../value }} selected{{/ifEquals}}>{{country.name}}</option>
 				{{/each}}
 			</optgroup>
 			{{/each}}


### PR DESCRIPTION
## Feature Description

As there is an extra level of nesting for the optgroup work, the value lookup needs to be updated to reflect that.

 🐿 v2.10.3
