### PR TITLE
Remove isExtended flag

### DIFF
--- a/partials/accept-terms.html
+++ b/partials/accept-terms.html
@@ -24,7 +24,7 @@
 			{{#if isPrintProduct}}
 		<p class="terms-print">Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).</p>
 		<p class="terms-print">Find out more about your delivery start date in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">Terms &amp; Conditions</a>.</p>
-			{{else if isExtended}}
+			{{else}}
 		<p class="terms-signup">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting customer service or emailing <a class="su-link-external" href="mailto:help@ft.com" target="_blank" rel="noopener">help@ft.com</a>.</p>
 		<p class="terms-signup">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</p>
 		<p class="terms-signup">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">Terms &amp; Conditions</a>.</p>

--- a/tests/partials/accept-terms.spec.js
+++ b/tests/partials/accept-terms.spec.js
@@ -75,8 +75,7 @@ describe('accept-terms template', () => {
 
 	describe('signup', () => {
 		const params = {
-			isSignup: true,
-			isExtended: true, // @todo Remove once extended terms test has been completed
+			isSignup: true
 		};
 
 		it('should use the signup data tracking if the isSignup is true', () => {


### PR DESCRIPTION
## Feature Description
Since the extended terms have been rolled out this flag is no longer needed.

## Link to Ticket / Card:
https://trello.com/c/riRjYe91/682-showextendedterms-clean-up
