### PR TITLE
Port across validation & email utilities from next-subscribe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ make run # build and start documentation app at http://local.ft.com:5005/
 
 * [Requirements](#requirements)
 * [Usage](#usage)
+* [Utilities](#utilities)
 * [Contributing](#contributing)
 
 ## Requirements
@@ -45,11 +46,65 @@ The styles can be used by including the `main.scss` file within your own SASS fi
 
 ### JS
 
-The utils can be used by including the individual file from within your own JS files.
+The utils can be used by including the individual file from within your own JS files. For more information see the [Utilities](#utilities) section below.
 
 ```js
 import MyModule from 'n-conversion-forms/utils/my-module';
 ```
+
+## Utilities
+
+### Email
+
+```js
+const email = new Email(document);
+```
+
+This utility provides the following:
+
++ If a confirm email field is present will validate to ensure the email addresses match and present the user with an error if not.
++ Registering an email exists lookup as follows:
+
+    ```js
+    email.registerEmailExistsCheck(backendServiceUrl, onFoundCallback, onNotFoundCallback);
+    ```
+  
+  **NB** It's recommended you have a hidden `#csrf-token` input element that you validate the request with in your backend service to prevent having your service abused.
+
+  The backend service will be sent the following as the body of a `POST` request: `{ email, csrfToken }`.
+
+### Event Notifier
+
+TBD
+
+### Password
+
+```js
+const password = new Password(document);
+```
+
+This utility's sole purpose (currently) is to enable the functionality behind the `Show password` checkbox that toggles whether the password is masked or not.
+
+### Tracking
+
+```js
+const tracking = new Tracking(window, document.body);
+```
+
+TBD
+
+### Validation
+
+```js
+const validation = new Validation();
+validation.init();
+```
+
+This utility will set up the form for client side validation using [`o-forms`](https://github.com/Financial-Times/o-forms#javascript).
+
+**NB:** By default, using this utility will prompt the user with a dialog before leaving the page if there have been changes on the form. It can be disabled as follows: `new Validation({mutePromptBeforeLeaving: true})`
+
+One useful property made available is the main form DOM element via `validation.$form`. Use this for scoping `querySelector` calls to find elements within your form.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This utility provides the following:
     email.registerEmailExistsCheck(backendServiceUrl, onFoundCallback, onNotFoundCallback);
     ```
   
-  **NB** It's recommended you have a hidden `#csrf-token` input element that you validate the request with in your backend service to prevent having your service abused.
+  **NB** It's recommended you have a hidden `#csrfToken` input element that you validate the request with in your backend service to prevent having your service abused.
 
   The backend service will be sent the following as the body of a `POST` request: `{ email, csrfToken }`.
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-conversion-forms#readme",
   "dependencies": {
+    "fetchres": "^1.7.2",
     "lodash.get": "^4.4.2",
     "n-common-static-data": "financial-times/n-common-static-data#v1.5.0"
   },
@@ -32,6 +33,7 @@
     "bower-resolve-webpack-plugin": "^1.0.4",
     "chai": "^4.2.0",
     "cheerio": "^1.0.0-rc.2",
+    "fetch-mock": "^7.2.0",
     "mocha": "^5.1.1",
     "node-sass": "^4.9.4",
     "nodemon": "^1.17.5",

--- a/tests/utils/email.spec.js
+++ b/tests/utils/email.spec.js
@@ -1,5 +1,6 @@
 const Email = require('../../utils/email');
 const expect = require('chai').expect;
+const fetchMock = require('fetch-mock');
 const sinon = require('sinon');
 
 describe('Email', () => {
@@ -7,12 +8,14 @@ describe('Email', () => {
 	let emailElement;
 	let emailConfirmElement;
 	let emailConfirmFieldElement;
+	let csrfFieldElement;
 	let sandbox;
 
 	beforeEach(() => {
 		emailElement = { addEventListener: ()=>{} };
 		emailConfirmElement = { addEventListener: ()=>{} };
 		emailConfirmFieldElement = { classList: { add: ()=>{}, remove: ()=>{} } };
+		csrfFieldElement = { value: '1234567890' };
 
 		document = {
 			querySelector: (selector) => {
@@ -20,6 +23,8 @@ describe('Email', () => {
 					return emailConfirmFieldElement;
 				} else if (selector.indexOf('#emailConfirm') !== -1) {
 					return emailConfirmElement;
+				} else if (selector.indexOf('#csrf-token') !== -1) {
+					return csrfFieldElement;
 				} else {
 					return emailElement;
 				}
@@ -33,6 +38,7 @@ describe('Email', () => {
 	});
 
 	afterEach(() => {
+		fetchMock.restore();
 		sandbox.restore();
 	});
 
@@ -104,4 +110,80 @@ describe('Email', () => {
 			expect(emailConfirmFieldElement.classList.remove.calledOnce).to.be.false;
 		});
 	});
+
+	describe('Email Exists', () => {
+		const url = '/foo';
+		let email;
+		let onFound;
+		let onNotFound;
+
+		beforeEach(() => {
+			onFound = sinon.stub();
+			onNotFound = sinon.stub();
+
+			email = new Email(document);
+		});
+
+		it('should add an additional event listener to the email field', () => {
+			email.registerEmailExistsCheck(url, onFound, onNotFound);
+			// Check it's called twice since by default we bind a change listener in the constructor.
+			expect(emailElement.addEventListener.calledTwice).to.be.true;
+		});
+
+		it('should call the onNotFound callback if the email field has no value.', () => {
+			email.handleEmailExistsChange(url, onFound, onNotFound);
+			expect(onFound.called).to.be.false;
+			expect(onNotFound.called).to.be.true;
+		});
+
+		it('should call the specified url with the correct params if the email field has a value', () => {
+			fetchMock.mock(url, 200);
+
+			emailElement.value = 'test@example.com';
+			email.handleEmailExistsChange(url, onFound, onNotFound);
+
+			expect(fetchMock.called(url)).to.be.true;
+			expect(fetchMock.lastOptions(url)).to.deep.equal({
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({
+					email: 'test@example.com',
+					csrfToken: '1234567890'
+				})
+			});
+		});
+
+		it('should call the onNotFound callback if the call to the url fails', async () => {
+			fetchMock.mock(url, 500);
+
+			emailElement.value = 'test@example.com';
+			await email.handleEmailExistsChange(url, onFound, onNotFound);
+
+			expect(onFound.called).to.be.false;
+			expect(onNotFound.called).to.be.true;
+		});
+
+		it('should call the onFound callback if the user exists', async () => {
+			fetchMock.mock(url, { userExists: true });
+
+			emailElement.value = 'test@example.com';
+			await email.handleEmailExistsChange(url, onFound, onNotFound);
+
+			expect(onFound.called).to.be.true;
+			expect(onNotFound.called).to.be.false;
+		});
+
+		it('should call the onNotFound callback if the user doesn\'t exist', async () => {
+			fetchMock.mock(url, { userExists: false });
+
+			emailElement.value = 'test@example.com';
+			await email.handleEmailExistsChange(url, onFound, onNotFound);
+
+			expect(onFound.called).to.be.false;
+			expect(onNotFound.called).to.be.true;
+		});
+	});
+
 });

--- a/tests/utils/email.spec.js
+++ b/tests/utils/email.spec.js
@@ -23,7 +23,7 @@ describe('Email', () => {
 					return emailConfirmFieldElement;
 				} else if (selector.indexOf('#emailConfirm') !== -1) {
 					return emailConfirmElement;
-				} else if (selector.indexOf('#csrf-token') !== -1) {
+				} else if (selector.indexOf('#csrfToken') !== -1) {
 					return csrfFieldElement;
 				} else {
 					return emailElement;
@@ -128,6 +128,12 @@ describe('Email', () => {
 			email.registerEmailExistsCheck(url, onFound, onNotFound);
 			// Check it's called twice since by default we bind a change listener in the constructor.
 			expect(emailElement.addEventListener.calledTwice).to.be.true;
+		});
+
+		it('should return the handler function so it can potentially be unregistered', () => {
+			let handler = email.registerEmailExistsCheck(url, onFound, onNotFound);
+
+			expect(typeof handler).to.equal('function');
 		});
 
 		it('should call the onNotFound callback if the email field has no value.', () => {

--- a/tests/utils/validation.spec.js
+++ b/tests/utils/validation.spec.js
@@ -1,0 +1,124 @@
+const expect = require('chai').expect;
+const proxyquire = require('proxyquire').noCallThru();
+const sinon = require('sinon');
+
+let findInputsStub = sinon.stub();
+let OFormsStub = sinon.stub().returns({
+	findInputs: findInputsStub
+});
+
+const Validation = proxyquire('../../utils/validation', {
+	'o-forms': OFormsStub
+});
+
+global.document = {};
+global.window = {};
+
+describe('Validation', () => {
+	let document;
+	let formElement;
+	let requiredElListener;
+	let submitElement;
+	let sandbox;
+	let checkValidityStub;
+	let validation;
+
+	beforeEach(() => {
+		submitElement = {};
+		formElement = {
+			length: 1,
+			addEventListener: () => {},
+			querySelector: () => submitElement
+		};
+		global.document.querySelector = () => formElement;
+		requiredElListener = sinon.stub();
+		checkValidityStub = sinon.stub();
+		sandbox = sinon.createSandbox();
+		sandbox.spy(formElement, 'addEventListener');
+		sandbox.spy(OFormsStub, 'constructor');
+		findInputsStub.returns([
+			{ name: 'foo', type: 'hidden' },
+			{ name: 'bar' },
+			{ name: 'baz', required: true, addEventListener: requiredElListener, checkValidity: checkValidityStub },
+			{ name: 'qoo', required: true, addEventListener: requiredElListener, checkValidity: checkValidityStub }
+		]);
+
+		validation = new Validation(document);
+		validation.init();
+	});
+
+	afterEach(() => {
+		delete global.window.onbeforeunload;
+		sandbox.restore();
+	});
+
+	describe('constructor', () => {
+		it('should call oForms to setup client side validation', () => {
+			expect(OFormsStub.calledWithNew()).to.be.true;
+		});
+
+		it('should have a $form property exposing the form element', () => {
+			expect(validation.$form).to.deep.eq(formElement);
+		});
+	});
+
+	describe('init', () => {
+		it('should disable the submit button', () => {
+			expect(validation.$submit.disabled).to.be.true;
+		});
+
+		it('should add an event listener to all required elements', () => {
+			expect(requiredElListener.calledTwice).to.be.true;
+		});
+
+		it('should bind to onbeforeunload by default', () => {
+			expect(global.window.onbeforeunload).to.exist;
+			expect(typeof global.window.onbeforeunload).to.equal('function');
+		});
+
+		it('should not bind to onbeforeunload if mutePromptBeforeLeaving = true', () => {
+			delete global.window.onbeforeunload;
+			const validation2 = new Validation({ mutePromptBeforeLeaving: true });
+			validation2.init();
+
+			expect(global.window.onbeforeunload).to.be.undefined;
+		});
+	});
+
+	describe('onbeforeunload', () => {
+		it('should return null by default', () => {
+			expect(global.window.onbeforeunload()).to.be.null;
+		});
+
+		it('should return true if the form has changed', () => {
+			validation.formChanged = true;
+
+			expect(global.window.onbeforeunload()).to.be.true;
+		});
+	});
+
+	describe('checkFormValidity', () => {
+		it('should disable the submit button and set the form as invalid if there are invalid elements.', () => {
+			validation.formValid = true;
+			validation.$submit.disabled = false;
+
+			checkValidityStub.returns(false);
+			validation.checkFormValidity();
+
+			expect(validation.formValid).to.be.false;
+			expect(validation.$submit.disabled).to.be.true;
+		});
+
+		it('should enable the submit button and set the form as valid if there are invalid elements.', () => {
+			validation.formValid = false;
+			validation.$submit.disabled = true;
+
+			checkValidityStub.returns(true);
+			validation.checkFormValidity();
+
+			expect(validation.formValid).to.be.true;
+			expect(validation.$submit.disabled).to.be.false;
+		});
+	});
+
+});

--- a/utils/email.js
+++ b/utils/email.js
@@ -12,7 +12,7 @@ class Email {
 		this.$email = document.querySelector('.ncf #email');
 		this.$emailConfirm = document.querySelector('.ncf #emailConfirm');
 		this.$emailConfirmField = document.querySelector('.ncf #emailConfirmField');
-		this.$csrfToken = document.querySelector('.ncf #csrf-token');
+		this.$csrfToken = document.querySelector('.ncf #csrfToken');
 
 		if (!this.$email) {
 			throw new Error('Please include the email partial on the page.');
@@ -39,16 +39,21 @@ class Email {
 
 	/**
 	 * Register the email exists call.
-	 * **NB** It's recommended you have a hidden #csrf-token input element that you validate the request with in your backend service.
+	 * **NB** It's recommended you have a hidden #csrfToken input element that you validate the request with in your backend service.
 	 *
 	 * @param {string} url URL to the email exists endpoint.
 	 * @param {function} onFound Callback function to run if email does exist
 	 * @param {function} onNotFound Callback function to run if email does *not* exist.
+	 * @returns {function} The handler function so the caller can unregister it if they need.
 	 */
 	registerEmailExistsCheck (url, onFound, onNotFound) {
-		this.$email.addEventListener('change', () => {
+		const handler = () => {
 			this.handleEmailExistsChange(url, onFound, onNotFound);
-		});
+		};
+
+		this.$email.addEventListener('change', handler);
+
+		return handler;
 	}
 
 	handleEmailExistsChange (url, onFound, onNotFound) {

--- a/utils/email.js
+++ b/utils/email.js
@@ -1,3 +1,5 @@
+const fetchres = require('fetchres');
+
 class Email {
 	/**
 	 * Initalise the Email utility
@@ -10,6 +12,7 @@ class Email {
 		this.$email = document.querySelector('.ncf #email');
 		this.$emailConfirm = document.querySelector('.ncf #emailConfirm');
 		this.$emailConfirmField = document.querySelector('.ncf #emailConfirmField');
+		this.$csrfToken = document.querySelector('.ncf #csrf-token');
 
 		if (!this.$email) {
 			throw new Error('Please include the email partial on the page.');
@@ -33,6 +36,47 @@ class Email {
 			}
 		}
 	}
+
+	/**
+	 * Register the email exists call.
+	 * **NB** It's recommended you have a hidden #csrf-token input element that you validate the request with in your backend service.
+	 *
+	 * @param {string} url URL to the email exists endpoint.
+	 * @param {function} onFound Callback function to run if email does exist
+	 * @param {function} onNotFound Callback function to run if email does *not* exist.
+	 */
+	registerEmailExistsCheck (url, onFound, onNotFound) {
+		this.$email.addEventListener('change', () => {
+			this.handleEmailExistsChange(url, onFound, onNotFound);
+		});
+	}
+
+	handleEmailExistsChange (url, onFound, onNotFound) {
+		if (this.$email.value) {
+			return fetch(url, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({
+					email: this.$email.value,
+					csrfToken: this.$csrfToken && this.$csrfToken.value
+				})
+			})
+				.then(fetchres.json)
+				.then(response => {
+					if (response.userExists) {
+						onFound();
+					} else {
+						onNotFound();
+					}
+				})
+				.catch(onNotFound);
+		} else {
+			onNotFound();
+		}
+	};
+
 };
 
 module.exports = Email;

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -61,6 +61,7 @@ class Validation {
 
 	/**
 	 * Return the invalid fields on the form.
+	 * @returns {DOMElements} The array-like containing the invalid form elements.
 	 */
 	getInvalidEls () {
 		return this.$requiredEls.filter($el => !$el.checkValidity());

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -1,0 +1,71 @@
+const OForms = require('o-forms');
+
+class Validation {
+
+	/**
+	 * Set up the Validation utility
+	 * @param {boolean} mutePromptBeforeLeaving (default: false) Whether to prompt the user before leaving if there have been changes in any of the fields.
+	 */
+	constructor ({ mutePromptBeforeLeaving } = {}) {
+		this.$form = document.querySelector('form.ncf');
+		this.$submit = this.$form.querySelector('[type="submit"]');
+		this.oForms = new OForms(this.$form);
+		this.$formFields = this.oForms.findInputs().filter($el => $el.type !== 'hidden');
+		this.$requiredEls = this.$formFields.filter($el => $el.required);
+		this.formValid = false;
+		this.formChanged = false;
+		this.formSubmit = false;
+		this.mutePromptBeforeLeaving = mutePromptBeforeLeaving || false;
+	}
+
+	/**
+	 * Initalise
+	 */
+	init () {
+		if (!this.$form.length) return;
+
+		this.$submit.disabled = true;
+
+		for (const $el of this.$requiredEls) {
+			$el.addEventListener('blur', this.checkFormValidity.bind(this), false);
+		}
+
+		this.$form.addEventListener('change', () => {
+			this.formChanged = true;
+		});
+
+		this.$form.addEventListener('submit', () => {
+			this.formSubmit = true;
+		});
+
+		if (!this.mutePromptBeforeLeaving) {
+			window.onbeforeunload = () => {
+				// Prompt the user about leaving in case they have changes they might lose.
+				return this.formChanged && !this.formSubmit || null;
+			};
+		}
+	}
+
+	/**
+	 * Update the state of the form to reflect form validity.
+	 */
+	checkFormValidity () {
+		if (this.getInvalidEls().length === 0) {
+			this.formValid = true;
+			this.$submit.disabled = false;
+		} else {
+			this.formValid = false;
+			this.$submit.disabled = true;
+		}
+	}
+
+	/**
+	 * Return the invalid fields on the form.
+	 */
+	getInvalidEls () {
+		return this.$requiredEls.filter($el => !$el.checkValidity());
+	}
+
+}
+
+module.exports = Validation;


### PR DESCRIPTION
Also added a utilities section to the readme with more details for how to use each of the JS utils.

I left the `event-notifier` and `tracking` as TBD as they can be better described by someone who knows more about them/understands them better.