### PR TITLE
Payment utility implementing Apple Pay using Payment Request API

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -5,7 +5,8 @@
 @import 'o-forms/main';
 @import 'o-buttons/main';
 @import 'o-message/main';
-@import "o-icons/main";
+@import 'o-icons/main';
+@import './styles/payment';
 
 @include oFormsBaseFeatures();
 @include oFormsRadioCheckboxFeatures();
@@ -283,6 +284,8 @@
 			margin: 20px 0;
 		}
 	}
+
+	@include ncfPaymentApplePay();
 
 	// Override o-forms padding set at certain screen sizes
 	// This should be removed when Origami remove this from o-forms

--- a/partials/apple-pay.html
+++ b/partials/apple-pay.html
@@ -1,0 +1,3 @@
+<div class="o-forms o-forms--wide">
+	<a href="#" class="apple-pay-button apple-pay-button-black"></a>
+</div>

--- a/partials/apple-pay.html
+++ b/partials/apple-pay.html
@@ -1,3 +1,1 @@
-<div class="o-forms o-forms--wide">
-	<a href="#" class="apple-pay-button apple-pay-button-black"></a>
-</div>
+<a href="#" class="apple-pay-button apple-pay-button-black{{#if isHidden}} o-normalise-visually-hidden{{/if}}"></a>

--- a/styles/payment.scss
+++ b/styles/payment.scss
@@ -1,0 +1,45 @@
+@mixin ncfPaymentApplePay() {
+	@supports (-webkit-appearance: -apple-pay-button) {
+		.apple-pay-button {
+			display: inline-block;
+			-webkit-appearance: -apple-pay-button;
+		}
+		.apple-pay-button-black {
+			-apple-pay-button-style: black;
+		}
+		.apple-pay-button-white {
+			-apple-pay-button-style: white;
+		}
+		.apple-pay-button-white-with-line {
+			-apple-pay-button-style: white-outline;
+		}
+	}
+
+	@supports not (-webkit-appearance: -apple-pay-button) {
+		.apple-pay-button {
+			display: inline-block;
+			background-size: 100% 60%;
+			background-repeat: no-repeat;
+			background-position: 50% 50%;
+			border-radius: 5px;
+			padding: 0px;
+			box-sizing: border-box;
+			min-width: 200px;
+			min-height: 32px;
+			max-height: 64px;
+		}
+		.apple-pay-button-black {
+			background-image: -webkit-named-image(apple-pay-logo-white);
+			background-color: black;
+		}
+		.apple-pay-button-white {
+			background-image: -webkit-named-image(apple-pay-logo-black);
+			background-color: white;
+		}
+		.apple-pay-button-white-with-line {
+			background-image: -webkit-named-image(apple-pay-logo-black);
+			background-color: white;
+			border: .5px solid black;
+		}
+	}
+}

--- a/styles/payment.scss
+++ b/styles/payment.scss
@@ -22,7 +22,7 @@
 			background-repeat: no-repeat;
 			background-position: 50% 50%;
 			border-radius: 5px;
-			padding: 0px;
+			padding: 0;
 			box-sizing: border-box;
 			min-width: 200px;
 			min-height: 32px;
@@ -39,7 +39,7 @@
 		.apple-pay-button-white-with-line {
 			background-image: -webkit-named-image(apple-pay-logo-black);
 			background-color: white;
-			border: .5px solid black;
+			border: 0.5px solid black;
 		}
 	}
 }

--- a/tests/partials/apple-pay.spec.js
+++ b/tests/partials/apple-pay.spec.js
@@ -1,0 +1,26 @@
+const { expect } = require('chai');
+const { fetchPartial } = require('../helpers');
+
+const CLASS_HIDDEN = 'o-normalise-visually-hidden';
+
+let context = {};
+
+describe('apple-pay template', () => {
+	before(async () => {
+		context.template = await fetchPartial('apple-pay.html');
+	});
+
+	it('should be compile', () => {
+		const $ = context.template({});
+
+		expect($('a').length).to.equal(1);
+	});
+
+	it('should hide when told', () => {
+		const $ = context.template({
+			isHidden: true
+		});
+
+		expect($('a').hasClass(CLASS_HIDDEN)).to.be.true;
+	});
+});

--- a/tests/utils/payment.spec.js
+++ b/tests/utils/payment.spec.js
@@ -1,0 +1,147 @@
+const Payment = require('../../utils/payment');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+describe('Payment', () => {
+	let window;
+	let sandbox;
+	let payment;
+	let product;
+	let request;
+	let button;
+
+	beforeEach(() => {
+		request = {};
+		button = { classList: { add: () => true, remove: () => true }, addEventListener: () => {} };
+		window = { PaymentRequest: function () { return request; }, document: { querySelector: () => button } };
+		product = {value: 1.00, currency: 'GBP', label: 'Testing'};
+
+		sandbox = sinon.createSandbox();
+		sandbox.spy(button.classList, 'add');
+		sandbox.spy(button.classList, 'remove');
+		sandbox.spy(button, 'addEventListener');
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	describe('Other payment methods', () => {
+		it('should throw an error', () => {
+			expect(() => {
+				new Payment(window, 'other', product);
+			}).to.throw();
+		});
+	});
+
+	describe('Apple Pay payment method', () => {
+
+		describe('constructor', () => {
+			it('should not setup the request if PaymentRequest not available', () => {
+				window.PaymentRequest = null;
+				payment = new Payment(window, 'apple', product);
+				expect(payment.request).to.be.undefined;
+			});
+
+			it('should throw an error if the button not available', () => {
+				window.document.querySelector = () => false;
+				expect(() => {
+					new Payment(window, 'apple', product);
+				}).to.throw();
+			});
+
+			it('should register a onMerchantValidation handler', () => {
+				payment = new Payment(window, 'apple', product);
+				expect(payment.request.onMerchantValidation).to.equal(payment.onMerchantValidation);
+			});
+		});
+
+		describe('showPaymentButton', () => {
+			beforeEach(() => {
+				payment = new Payment(window, 'apple', product);
+			});
+
+			it('should return false if browser can not make payment', async () => {
+				request.canMakePayment = () => Promise.resolve(false);
+				expect(await payment.showPaymentButton()).to.be.false;
+			});
+
+			it('should hide the payment button if browser can not make payment', async () => {
+				request.canMakePayment = () => Promise.resolve(false);
+				await payment.showPaymentButton();
+				expect(button.classList.add.called).to.be.true;
+			});
+
+			it('should return true if browser can make payment', async () => {
+				request.canMakePayment = () => Promise.resolve(true);
+				expect(await payment.showPaymentButton()).to.be.true;
+			});
+
+			it('should show the payment button if can make payment', async () => {
+				request.canMakePayment = () => Promise.resolve(true);
+				await payment.showPaymentButton();
+				expect(button.classList.remove.called).to.be.true;
+			});
+
+			it('should add a click handler if can make payment', async () => {
+				request.canMakePayment = () => Promise.resolve(true);
+				await payment.showPaymentButton();
+				expect(button.addEventListener.called).to.be.true;
+			});
+		});
+
+		describe('show', () => {
+			it('@todo after membership integration');
+		});
+
+		describe('onMerchantValidation', () => {
+			it('@todo after membership integration');
+		});
+	});
+
+	describe('Static helpers', () => {
+		describe('getButtonSelector', () => {
+			it('should throw if method is not apple', () => {
+				expect(() => {
+					Payment.getButtonSelector('other');
+				}).to.throw();
+			});
+
+			it('should return apple button selector', () => {
+				expect(Payment.getButtonSelector('apple')).to.be.string;
+			});
+		});
+
+		describe('getPaymentMethod', () => {
+			it('should throw if method is not apple', () => {
+				expect(() => {
+					Payment.getPaymentMethod('other');
+				}).to.throw();
+			});
+
+			it('should return apple payment method', () => {
+				expect(Payment.getPaymentMethod('apple')).to.have.property('supportedMethods');
+			});
+		});
+
+		describe('getPaymentDetails', () => {
+			it('should format given values in payment details object', () => {
+				const label = 'test';
+				const value = 1.01;
+				const currency = 'GBP';
+				const details = Payment.getPaymentDetails(value, currency, label);
+
+				expect(details.total.label).to.equal(label);
+				expect(Object.values(details.total.amount)).to.deep.include(value);
+				expect(details.displayItems[0].label).to.equal(label);
+				expect(Object.values(details.displayItems[0].amount)).to.deep.include(currency);
+			});
+		});
+
+		describe('getPaymentOptions', () => {
+			it('should return payment options', () => {
+				expect(Payment.getPaymentOptions()).to.be.a('object');
+			});
+		});
+	});
+});

--- a/tests/utils/payment.spec.js
+++ b/tests/utils/payment.spec.js
@@ -39,8 +39,9 @@ describe('Payment', () => {
 		describe('constructor', () => {
 			it('should not setup the request if PaymentRequest not available', () => {
 				window.PaymentRequest = null;
-				payment = new Payment(window, 'apple', product);
-				expect(payment.request).to.be.undefined;
+				expect(() => {
+					new Payment(window, 'apple', product);
+				}).to.throw();
 			});
 
 			it('should throw an error if the button not available', () => {

--- a/utils/payment.js
+++ b/utils/payment.js
@@ -1,0 +1,188 @@
+const FAILURE = 'failure';
+const SUCCESS = 'success';
+const METHOD_APPLE_PAY = 'apple';
+const SELECTOR_APPLE_PAY = '.apple-pay-button';
+const CLASS_HIDDEN = 'o-normalise-visually-hidden';
+
+/**
+ * Validate ourselves with Apple through Membership and get a payment session token
+ * @param {string} url Merchant validation URL
+ * @return {promise<string>} session token
+ */
+async function fetchPaymentSession (url) {
+	// Call Membership with the URL so they can validate session
+	const sessionToken = await fetch('membership', url);
+	return sessionToken;
+}
+
+/**
+ * Process the response from Apple Pay with Membership
+ * @param {object} response Apple Pay response
+ * @return {promise<string>} `success` or `failure`
+ */
+async function processResponse (response) {
+	// Call Membership with the response so they can return a status
+	try {
+		const status = await fetch('membership', response);
+		return status ? SUCCESS : FAILURE;
+	} catch (e) {
+		return FAILURE;
+	}
+}
+
+/**
+ * Payment wrapper for Payment Request API interaction
+ * @example
+ * // Create a payment instance
+ * const payment = new Payment(window, Payment.METHOD_APPLE_PAY, {value: 1.00, currency: 'GBP', label: 'Standard FT'});
+ * const shown = await payment.showPaymentButton();
+ * if (!shown) {
+ *     // Browser doesn't support the payment method
+ * }
+ */
+class Payment {
+	/**
+	 * Check the Payment Request API is available and the methods button is available
+	 * @param {Window} window
+	 * @param {string} method
+	 * @param {number} value Decimal price
+	 * @param {string} currency ISO 3 digit currency code
+	 * @param {string} label Name for what's being sold
+	 * @throws If the payment button is not found
+	 */
+	constructor (window, method, {value, currency, label}) {
+		if (!window.PaymentRequest) {
+			// For method='apple' fallback to using Apple Pay JS instead?
+			return;
+		}
+
+		// Create the payment request
+		this.request = new window.PaymentRequest(
+			Payment.getPaymentMethod(method),
+			Payment.getPaymentDetails(value, currency, label),
+			Payment.getPaymentOptions()
+		);
+
+		// Setup payment button
+		this.paymentButton = window.document.querySelector(Payment.getButtonSelector(method));
+		if (!this.paymentButton) {
+			throw new Error('Payment button not within HTML');
+		}
+
+		// Add merchant validation listener (needed for ApplePay)
+		this.request.onMerchantValidation = this.onMerchantValidation;
+	}
+
+	/**
+	 * Display the payment button and attach click handler
+	 * @return {promise<boolean>} Whether successful
+	 */
+	async showPaymentButton () {
+		const canMakePayment = await this.request.canMakePayment();
+		if (!canMakePayment) {
+			this.paymentButton.classList.add(CLASS_HIDDEN);
+			return false;
+		}
+		this.paymentButton.classList.remove(CLASS_HIDDEN);
+		this.paymentButton.addEventListener('click', () => {
+			this.show();
+		});
+		return true;
+	}
+
+	/**
+	 * Call the show method on the request and process the response
+	 */
+	async show () {
+		const response = await this.request.show();
+		try {
+			const status = await processResponse(response);
+			response.complete(status);
+		} catch (e) {
+			// Handle errors
+			response.complete(FAILURE);
+		}
+	}
+
+	/**
+	 * Handle merchant validation
+	 * @param {object} event
+	 */
+	onMerchantValidation (event) {
+		const sessionPromise = fetchPaymentSession(event.validationURL);
+		event.complete(sessionPromise);
+	}
+
+	/**
+	 * Apple Pay payment method
+	 */
+	static get METHOD_APPLE_PAY () {
+		return METHOD_APPLE_PAY;
+	}
+
+	/**
+	 * Return the DOM selector for the payment button
+	 * @param {string} name `apple` is only supported currently
+	 */
+	static getButtonSelector (name) {
+		if (name !== METHOD_APPLE_PAY) {
+			throw new Error('Only Apple Pay is supported currently');
+		}
+		return SELECTOR_APPLE_PAY;
+	}
+
+	/**
+	 * Return the requested payment method
+	 * @param {string} name `apple` is only supported currently
+	 */
+	static getPaymentMethod (name) {
+		if (name !== METHOD_APPLE_PAY) {
+			throw new Error('Only Apple Pay is supported currently');
+		}
+		return {
+			supportedMethods: 'https://apple.com/apple-pay',
+			data: {
+				version: 3,
+				merchantIdentifier: 'merchant.com.example',
+				merchantCapabilities: ['supports3DS', 'supportsCredit', 'supportsDebit'],
+				supportedNetworks: ['amex', 'discover', 'masterCard', 'visa'],
+				countryCode: 'US',
+			}
+		};
+	}
+
+	/**
+	 * Generate the payment details object
+	 * @param {number} value Decimal price
+	 * @param {string} currency ISO 3 digit currency code
+	 * @param {string} label Name for what's being sold
+	 * @return {object}
+	 */
+	static getPaymentDetails (value, currency, label) {
+		return {
+			total: {
+				label: label,
+				amount: { value, currency },
+			},
+			displayItems: [{
+				label: label,
+				amount: { value, currency},
+			}]
+		};
+	}
+
+	/**
+	 * Return the default payment options
+	 * @return {object}
+	 */
+	static getPaymentOptions () {
+		return {
+			requestPayerName: false,
+			requestPayerEmail: false,
+			requestPayerPhone: false,
+			requestShipping: false
+		};
+	}
+}
+
+module.exports = Payment;

--- a/utils/payment.js
+++ b/utils/payment.js
@@ -34,10 +34,15 @@ async function processResponse (response) {
  * Payment wrapper for Payment Request API interaction
  * @example
  * // Create a payment instance
- * const payment = new Payment(window, Payment.METHOD_APPLE_PAY, {value: 1.00, currency: 'GBP', label: 'Standard FT'});
- * const shown = await payment.showPaymentButton();
- * if (!shown) {
- *     // Browser doesn't support the payment method
+ * try {
+ *     const product = {value: 1.00, currency: 'GBP', label: 'Standard FT'};
+ *     const payment = new Payment(window, Payment.METHOD_APPLE_PAY, product);
+ *     const shown = await payment.showPaymentButton();
+ *     if (!shown) {
+ *         // User can't make a payment for example no card on account
+ *     }
+ * } catch (e) {
+ *     // Payment Request API not supported or payment button not found
  * }
  */
 class Payment {
@@ -52,8 +57,8 @@ class Payment {
 	 */
 	constructor (window, method, {value, currency, label}) {
 		if (!window.PaymentRequest) {
-			// For method='apple' fallback to using Apple Pay JS instead?
-			return;
+			// @todo for method='apple' fallback to using Apple Pay JS instead?
+			throw new Error('Browser does not support Payment Request API');
 		}
 
 		// Create the payment request
@@ -84,7 +89,8 @@ class Payment {
 			return false;
 		}
 		this.paymentButton.classList.remove(CLASS_HIDDEN);
-		this.paymentButton.addEventListener('click', () => {
+		this.paymentButton.addEventListener('click', e => {
+			e.preventDefault();
 			this.show();
 		});
 		return true;


### PR DESCRIPTION
## Feature Description
The PR you've all been waiting for, the first stab at Apple Pay using the Payment Request API.

Example usage -

Include the Handlebars template
```
{{> n-conversion-forms/partials/apple-pay isHidden=true }}
```

Initalise the Javascript
```javascript
const product = {value: 1.00, currency: 'GBP', label: 'Standard FT'};
const payment = new Payment(window, Payment.METHOD_APPLE_PAY, product);
const shown = await payment.showPaymentButton();
if (!shown) {
   // Browser doesn't support the payment method
}
```

## Link to Ticket / Card:
https://trello.com/c/lBW3ZJwU/653-apple-pay-as-new-payment-method

## Screenshots:
![takemymoney](https://user-images.githubusercontent.com/1721150/48073118-ede08c80-e1d5-11e8-9590-369b942f5608.gif)

