### PR TITLE
Add validation on init

### DIFF
--- a/tests/utils/validation.spec.js
+++ b/tests/utils/validation.spec.js
@@ -44,9 +44,6 @@ describe('Validation', () => {
 		]);
 
 		validation = new Validation(document);
-
-		sandbox.spy(validation, 'validateOnInit');
-		sandbox.spy(validation, 'checkFormValidity');
 		validation.init();
 	});
 
@@ -65,7 +62,7 @@ describe('Validation', () => {
 		});
 
 		it('should check validation status on init', () => {
-			expect(validation.validateOnInit.called).to.be.true;
+			expect(checkValidityStub.called).to.be.true;
 		});
 	});
 
@@ -125,16 +122,6 @@ describe('Validation', () => {
 
 			expect(validation.formValid).to.be.true;
 			expect(validation.$submit.disabled).to.be.false;
-		});
-	});
-
-	describe('validateOnInit', () => {
-		it('checks the validity of the form elements', () => {
-			expect(checkValidityStub.called).to.be.true;
-		});
-
-		it('calls checkFormValidity to enable/disable submit button as appropriate', () => {
-			expect(validation.checkFormValidity.called).to.be.true;
 		});
 	});
 

--- a/tests/utils/validation.spec.js
+++ b/tests/utils/validation.spec.js
@@ -44,6 +44,9 @@ describe('Validation', () => {
 		]);
 
 		validation = new Validation(document);
+
+		sandbox.spy(validation, 'validateOnInit');
+		sandbox.spy(validation, 'checkFormValidity');
 		validation.init();
 	});
 
@@ -59,6 +62,10 @@ describe('Validation', () => {
 
 		it('should have a $form property exposing the form element', () => {
 			expect(validation.$form).to.deep.eq(formElement);
+		});
+
+		it('should check validation status on init', () => {
+			expect(validation.validateOnInit.called).to.be.true;
 		});
 	});
 
@@ -118,6 +125,16 @@ describe('Validation', () => {
 
 			expect(validation.formValid).to.be.true;
 			expect(validation.$submit.disabled).to.be.false;
+		});
+	});
+
+	describe('validateOnInit', () => {
+		it('checks the validity of the form elements', () => {
+			expect(checkValidityStub.called).to.be.true;
+		});
+
+		it('calls checkFormValidity to enable/disable submit button as appropriate', () => {
+			expect(validation.checkFormValidity.called).to.be.true;
 		});
 	});
 

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -45,7 +45,7 @@ class Validation {
 			};
 		}
 
-		this.validateOnInit();
+		this.checkFormValidity();
 	}
 
 	/**
@@ -59,17 +59,6 @@ class Validation {
 			this.formValid = false;
 			this.$submit.disabled = true;
 		}
-	}
-
-	/**
-	 * Check for validity on init.
-	 */
-	validateOnInit () {
-		this.$requiredEls.map($el => {
-			$el.checkValidity();
-		});
-
-		this.checkFormValidity();
 	}
 
 	/**

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -44,6 +44,8 @@ class Validation {
 				return this.formChanged && !this.formSubmit || null;
 			};
 		}
+
+		this.validateOnInit();
 	}
 
 	/**
@@ -57,6 +59,17 @@ class Validation {
 			this.formValid = false;
 			this.$submit.disabled = true;
 		}
+	}
+
+	/**
+	 * Check for validity on init.
+	 */
+	validateOnInit () {
+		this.$requiredEls.map($el => {
+			$el.checkValidity();
+		});
+
+		this.checkFormValidity();
 	}
 
 	/**


### PR DESCRIPTION
 🐿 v2.10.3

## Feature Description

Validates the form when initialised so that forms that are pre-filled on page load can have the submit button re-enabled.

## Link to Ticket / Card:

https://trello.com/c/4enpx6cF/743-next-subscribe-fix-button-on-all-pages