### PR TITLE
Stop people emailing customer services

### DIFF
--- a/partials/accept-terms.html
+++ b/partials/accept-terms.html
@@ -25,7 +25,7 @@
 		<p class="terms-print">Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).</p>
 		<p class="terms-print">Find out more about your delivery start date in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">Terms &amp; Conditions</a>.</p>
 			{{else}}
-		<p class="terms-signup">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting customer service or emailing <a class="su-link-external" href="mailto:help@ft.com" target="_blank" rel="noopener">help@ft.com</a>.</p>
+		<p class="terms-signup">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">customer service through chat, phone or email</a>.</p>
 		<p class="terms-signup">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</p>
 		<p class="terms-signup">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">Terms &amp; Conditions</a>.</p>
 			{{/if}}


### PR DESCRIPTION
## Feature Description
Remove the mailto and link them out to the contact us page

## Link to Ticket / Card:
https://trello.com/c/hIUKTV6G/747-buy-flow-tcs-sentence-update-for-people-to-chat-or-call-cs-as-opposed-to-email-them

