### PR TITLE
Message changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ make run # build and start documentation app at http://local.ft.com:5005/
 * [Usage](#usage)
 * [Utilities](#utilities)
 * [Contributing](#contributing)
+* [Partials](docs/PARTIALS)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ make run # build and start documentation app at http://local.ft.com:5005/
 * [Usage](#usage)
 * [Utilities](#utilities)
 * [Contributing](#contributing)
-* [Partials](docs/PARTIALS)
+* [Partials](docs/PARTIALS.md)
 
 ## Requirements
 

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -25,7 +25,7 @@ i.e `{{> n-conversion-forms/partials/message isError=true message=flash.message 
 
 ### Title:
 
-* messageTitle: string - messageTitle='The title of the message'. Optional.
+* messageTitle: string - messageTitle="The title of the message". Optional.
 
 ### Message:
 

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -1,0 +1,49 @@
+# Partials
+
+## Content
+
+* [Message](#message)
+
+## Message
+
+Displays a message on the page using [o-message](https://registry.origami.ft.com/components/o-message@3.0.1).
+
+i.e `{{> n-conversion-forms/partials/message isError=true message=flash.message }}`
+
+### Options
+
+#### Type:
+
+* Notice: boolean - isNotice=true
+* Alert: default
+
+### Status:
+
+* Error: boolean - isError=true
+* Success: boolean - isSuccess=true
+* Inform: boolean - isInform=true - default
+
+### Title:
+
+* messageTitle: string - messageTitle='The title of the message'. Optional.
+
+### Message:
+
+* message: string - message. Required.
+
+### Additional message:
+
+`{ additional: ['Allows an additional message'] }`
+
+* additional: array of strings - additional=additional. Optional.
+
+### Actions
+
+Allows for a links to be added to the message
+
+* actions: array. Optional
+
+Required if you have actions.
+* link: url=https://ft.com.
+* text: string=FT.com.
+* isSecondary: boolean. If there is more than one action.

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -27,7 +27,7 @@ i.e `{{> n-conversion-forms/partials/message isError=true message=flash.message 
 
 * messageTitle: string - messageTitle="The title of the message". Optional.
 
-### Message:
+### Message:
 
 * message: string - message. Required.
 

--- a/partials/message.html
+++ b/partials/message.html
@@ -3,8 +3,8 @@
 		<div class="o-message__container">
 			<div class="o-message__content">
 				<p class="o-message__content-main">
-					{{#if title}}
-						<span class="o-message__content-highlight">{{title}}</span>
+					{{#if messageTitle}}
+						<span class="o-message__content-highlight">{{messageTitle}}</span>
 					{{/if}}
 					<span class="o-message__content-detail">{{{message}}}</span>
 				</p>

--- a/tests/partials/message.spec.js
+++ b/tests/partials/message.spec.js
@@ -102,7 +102,7 @@ describe('message template', () => {
 	});
 
 	it('should display a title if specified', () => {
-		const $ = context.template({ title: 'Foo' });
+		const $ = context.template({ messageTitle: 'Foo' });
 		const $title = $(SELECTOR_TITLE);
 
 		expect($title.length).to.equal(1);


### PR DESCRIPTION
## Feature Description

I needed to change the `title` variable on the message html because many repos will have set a title but do not necessarily want the title to be displayed on the error message. The user will now have to set the messageTitle in order for a bolded title to be shown on the message.

I also updated the readme to include a `partial docs` which should hopefully make n-conversion-forms easier to use. 

## Link to Ticket / Card:

Connected to the changes that had to be made to this card: https://trello.com/c/9Y35jKJN/772-add-n-membership-sdk-to-next-profile
