### PR TITLE
Using origami component for progress

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,14 +33,15 @@
     "main.scss"
   ],
   "devDependencies": {
-    "o-techdocs": "^7.0.8"
+    "o-techdocs": "^7.0.9"
   },
   "dependencies": {
-    "o-forms": "^5.8.3",
+    "o-forms": "^5.11.0",
     "n-ui-foundations": "^3.0.1",
-    "o-buttons": "^5.12.0",
-    "o-message": "^2.4.0",
-    "o-colors": "^4.7.2",
-    "o-icons": "^5.7.1"
+    "o-buttons": "^5.15.1",
+    "o-message": "^3.0.1",
+    "o-colors": "^4.7.10",
+    "o-icons": "^5.9.0",
+    "o-stepped-progress": "^1.0.0"
   }
 }

--- a/main.scss
+++ b/main.scss
@@ -6,6 +6,7 @@
 @import 'o-buttons/main';
 @import 'o-message/main';
 @import 'o-icons/main';
+@import 'o-stepped-progress/main';
 @import './styles/payment';
 
 @include oFormsBaseFeatures();
@@ -15,6 +16,7 @@
 @include oFormsWideFeature();
 @include oMessage();
 @include oFormsRadioCheckboxRightModifier();
+@include oSteppedProgress();
 
 // Custom styles
 .ncf {
@@ -149,90 +151,6 @@
 	&__message {
 		p + p {
 			margin-top: 0;
-		}
-	}
-
-	// NOTE: This is going to mostly get replaced with the official origami version when it's ready.
-	&__progress {
-		display: flex;
-		justify-content: space-between;
-		margin-bottom: 20px;
-		margin-top: 20px;
-		position: relative;
-
-		&::before {
-			background: oColorsGetPaletteColor('black-40');
-			content: '';
-			display: block;
-			height: 2px;
-			left: 28px;
-			position: absolute;
-			top: 11px;
-			width: calc(100% - 60px);
-		}
-
-		&__icon {
-			background: oColorsGetPaletteColor('paper');
-			border: 2px solid oColorsGetPaletteColor('black-40');
-			border-radius: 9999px;
-			display: block;
-			height: 20px;
-			margin: 0 auto;
-			width: 20px;
-		}
-
-		&__label {
-			@include oTypographySans($scale: -1);
-
-			display: inline-block;
-			margin-top: 10px;
-		}
-
-		&__item {
-			position: relative;
-			color: oColorsGetPaletteColor('black');
-			border-bottom: initial;
-
-			&:hover {
-				color: oColorsGetPaletteColor('black');
-			}
-
-			&--current {
-				.ncf__progress__icon {
-					border-color: oColorsGetPaletteColor('black');
-					&::before {
-						background: oColorsGetPaletteColor('black');
-						border-radius: 9999px;
-						content: '';
-						display: block;
-						width: 14px;
-						height: 14px;
-						margin: 3px 0 0 3px;
-					}
-				}
-			}
-			&--complete {
-				.ncf__progress__icon {
-					background: oColorsGetPaletteColor('black');
-					border-color: oColorsGetPaletteColor('black');
-					&::before {
-						@include oIconsGetIcon('tick', oColorsGetPaletteColor('paper'), 20);
-						content: '';
-						color: oColorsGetPaletteColor('paper');
-					}
-				}
-				.ncf__progress__label {
-					position: relative;
-					text-decoration: underline;
-
-					&::after {
-						@include oIconsGetIcon('edit', oColorsGetPaletteColor('black'), 20);
-						content: '';
-						position: absolute;
-						top: -2px;
-					}
-				}
-			}
 		}
 	}
 

--- a/main.scss
+++ b/main.scss
@@ -124,6 +124,12 @@
 		}
 	}
 
+	&__icon--inline-edit {
+		@include oIconsGetIcon('edit', oColorsGetPaletteColor('black'), 20);
+		border: none;
+		vertical-align: middle;
+	}
+
 	&__icon--large {
 		width: 40px;
 		height: 40px;

--- a/main.scss
+++ b/main.scss
@@ -126,7 +126,7 @@
 
 	&__icon--inline-edit {
 		@include oIconsGetIcon('edit', oColorsGetPaletteColor('black'), 20);
-		border: none;
+		border: 0;
 		vertical-align: middle;
 	}
 

--- a/partials/progress-indicator.html
+++ b/partials/progress-indicator.html
@@ -5,7 +5,7 @@
 			{{#if isComplete}}
 			<a href="{{this.url}}" class="o-stepped-progress__step o-stepped-progress__step--complete" data-trackable="change-progress">
 				<span class="o-stepped-progress__label">
-					{{this.name}} <span class="o-stepped-progress__status">(completed)</span>
+					{{this.name}} <i class="ncf__icon ncf__icon--inline-edit"></i> <span class="o-stepped-progress__status">(completed)</span>
 				</span>
 			</a>
 			{{else}}

--- a/partials/progress-indicator.html
+++ b/partials/progress-indicator.html
@@ -5,7 +5,7 @@
 			{{#if isComplete}}
 			<a href="{{this.url}}" class="o-stepped-progress__step o-stepped-progress__step--complete" data-trackable="change-progress">
 				<span class="o-stepped-progress__label">
-					{{this.name}} <i class="ncf__icon ncf__icon--inline-edit"></i> <span class="o-stepped-progress__status">(completed)</span>
+					{{this.name}}<i class="ncf__icon ncf__icon--inline-edit"></i> <span class="o-stepped-progress__status">(completed)</span>
 				</span>
 			</a>
 			{{else}}

--- a/partials/progress-indicator.html
+++ b/partials/progress-indicator.html
@@ -1,15 +1,21 @@
-<div class="ncf__progress">
-	{{#each items}}
-	{{#if isComplete}}
-	<a class="ncf__progress__item ncf__progress__item--complete" href="{{this.url}}" data-trackable="change-progress">
-		<i class="ncf__progress__icon"></i>
-		<span class="ncf__progress__label">{{this.name}}</span>
-	</a>
-	{{else}}
-	<div class="ncf__progress__item{{#if isCurrent}} ncf__progress__item--current{{/if}}">
-		<i class="ncf__progress__icon"></i>
-		<span class="ncf__progress__label">{{this.name}}</span>
-	</div>
-	{{/if}}
-	{{/each}}
+<div class="o-stepped-progress" data-o-component="o-stepped-progress">
+	<ol class="o-stepped-progress__steps">
+		{{#each items}}
+		<li>
+			{{#if isComplete}}
+			<a href="{{this.url}}" class="o-stepped-progress__step o-stepped-progress__step--complete" data-trackable="change-progress">
+				<span class="o-stepped-progress__label">
+					{{this.name}} <span class="o-stepped-progress__status">(completed)</span>
+				</span>
+			</a>
+			{{else}}
+			<div class="o-stepped-progress__step{{#if isCurrent}} o-stepped-progress__step--current{{/if}}">
+				<span class="o-stepped-progress__label">
+					{{this.name}} {{#if isCurrent}}<span class="o-stepped-progress__status">(current step)</span>{{/if}}
+				</span>
+			</div>
+			{{/if}}
+		</li>
+		{{/each}}
+	</ol>
 </div>

--- a/tests/partials/progress-indicator.spec.js
+++ b/tests/partials/progress-indicator.spec.js
@@ -1,9 +1,9 @@
 const { expect } = require('chai');
 const { fetchPartial } = require('../helpers');
 
-const CLASS_COMPLETE = 'ncf__progress__item--complete';
-const CLASS_CURRENT = 'ncf__progress__item--current';
-const CLASS_PROGRESS_ITEM = 'ncf__progress__item';
+const CLASS_COMPLETE = 'o-stepped-progress__step--complete';
+const CLASS_CURRENT = 'o-stepped-progress__step--current';
+const CLASS_PROGRESS_ITEM = 'o-stepped-progress__step';
 
 let context = {};
 


### PR DESCRIPTION
## Feature Description
As trailblazers we created a component that was then implemented by Origami. This PR removes our original work so that we can replace it with the component.

## Link to Ticket / Card:
https://trello.com/c/wUinlgf5/834-use-o-stepped-progress-instead-of-our-home-brew-progress-styles

## Screenshots:

| Before | After |
| --- | --- |
| <img width="525" alt="screenshot 2019-01-31 at 15 48 51" src="https://user-images.githubusercontent.com/1721150/52066083-bf254880-256f-11e9-9d4c-29e0db9dcd77.png"> | <img width="511" alt="screenshot 2019-01-31 at 16 39 53" src="https://user-images.githubusercontent.com/1721150/52069579-e29fc180-2576-11e9-87de-00cfa40c0e31.png"> | 