### PR TITLE
Enable and disable payment types from showing

### DIFF
--- a/partials/payment-type.html
+++ b/partials/payment-type.html
@@ -4,16 +4,23 @@
 	<script type="text/javascript" src="https://seal.websecurity.norton.com/getseal?host_name=www.ft.com&amp;size=XS&amp;use_flash=NO&amp;use_transparent=Yes&amp;lang=en"></script> Secure payment details
 </div> -->
 
-<fieldset id="paymentTypeField" class="o-forms o-forms o-forms--wide ncf__field">
-	<legend class="o-forms__label o-normalise-visually-hidden">Payment Type</legend>
+<div id="paymentTypeField" class="o-forms o-forms o-forms--wide ncf__field">
 	<div class="o-forms__group o-forms__group--inline-together">
+		{{#if enableCreditcard }}
 		<input type="radio" name="paymentType" value="creditcard" class="o-forms__radio-button" id="creditcard"{{#ifEquals value "creditcard"}} checked="checked"{{/ifEquals}}>
 		<label for="creditcard" class="o-forms__label">Credit / Debit Card</label>
+		{{/if}}
+		{{#if enablePaypal }}
 		<input type="radio" name="paymentType" value="paypal" class="o-forms__radio-button" id="paypal"{{#ifEquals value "paypal"}} checked="checked"{{/ifEquals}}>
 		<label for="paypal" class="o-forms__label">Paypal</label>
+		{{/if}}
+		{{#if enableDirectdebit }}
 		<input type="radio" name="paymentType" value="directdebit" class="o-forms__radio-button" id="directdebit"{{#ifEquals value "directdebit"}} checked="checked"{{/ifEquals}}>
 		<label for="directdebit" class="o-forms__label">Direct Debit</label>
+		{{/if}}
+		{{#if enableApplepay }}
 		<input type="radio" name="paymentType" value="applepay" class="o-forms__radio-button" id="applepay"{{#ifEquals value "applepay"}} checked="checked"{{/ifEquals}}>
 		<label for="applepay" class="o-forms__label">Apple Pay</label>
+		{{/if}}
 	</div>
-</fieldset>
+</div>

--- a/tests/partials/payment-type.spec.js
+++ b/tests/partials/payment-type.spec.js
@@ -4,47 +4,98 @@ const {
 } = require('../helpers');
 
 let context = {};
+let params;
 
 describe('payment-type', () => {
 	before(async () => {
 		context.template = await fetchPartial('payment-type.html');
+		params = {
+			enableCreditcard: true,
+			enableDirectdebit: true,
+			enablePaypal: true,
+			enableApplepay: true
+		};
 	});
 
 	it('should default to no payment type selected', () => {
-		const $ = context.template({});
-
+		const $ = context.template(params);
 		expect($('input[checked]').length).to.equal(0);
 	});
 
 	it('should default to the given value of creditcard', () => {
-		const value = 'creditcard';
-		const $ = context.template({
-			value
-		});
-		expect($('input[checked]').attr('value')).to.equal(value);
+		params.value = 'creditcard';
+		const $ = context.template(params);
+		expect($('input[checked]').attr('value')).to.equal(params.value);
 	});
 
 	it('should default to the given value of directdebit', () => {
-		const value = 'directdebit';
-		const $ = context.template({
-			value
-		});
-		expect($('input[checked]').attr('value')).to.equal(value);
+		params.value = 'directdebit';
+		const $ = context.template(params);
+		expect($('input[checked]').attr('value')).to.equal(params.value);
 	});
 
 	it('should default to the given value of paypal', () => {
-		const value = 'paypal';
-		const $ = context.template({
-			value
-		});
-		expect($('input[checked]').attr('value')).to.equal(value);
+		params.value = 'paypal';
+		const $ = context.template(params);
+		expect($('input[checked]').attr('value')).to.equal(params.value);
 	});
 
 	it('should default to the given value of applepay', () => {
-		const value = 'applepay';
-		const $ = context.template({
-			value
+		params.value = 'applepay';
+		const $ = context.template(params);
+		expect($('input[checked]').attr('value')).to.equal(params.value);
+	});
+
+	it('should show no payment options by default', () => {
+		expectPaymentType(context);
+	});
+
+	it('should show only creditcard', () => {
+		expectPaymentType(context, { creditcard: true });
+	});
+
+	it('should show only directdebit', () => {
+		expectPaymentType(context, { directdebit: true });
+	});
+
+	it('should show only paypal', () => {
+		expectPaymentType(context, { paypal: true });
+	});
+
+	it('should show only applepay', () => {
+		expectPaymentType(context, { applepay: true });
+	});
+
+	it('should show creditcard and applepay', () => {
+		expectPaymentType(context, {
+			creditcard: true,
+			applepay: true
 		});
-		expect($('input[checked]').attr('value')).to.equal(value);
+	});
+
+	it('should show all payment types', () => {
+		expectPaymentType(context, {
+			creditcard: true,
+			directdebit: true,
+			paypal: true,
+			applepay: true
+		});
 	});
 });
+
+function expectPaymentType (context, { creditcard=false, directdebit=false, paypal=false, applepay=false }={}) {
+	const $ = context.template({
+		enableCreditcard: creditcard,
+		enableDirectdebit: directdebit,
+		enablePaypal: paypal,
+		enableApplepay: applepay
+	});
+	expect($('input[value="creditcard"]').length === 1).to.equal(creditcard);
+	expect($('label[for="creditcard"]').length === 1).to.equal(creditcard);
+	expect($('input[value="directdebit"]').length === 1).to.equal(directdebit);
+	expect($('label[for="directdebit"]').length === 1).to.equal(directdebit);
+	expect($('input[value="paypal"]').length === 1).to.equal(paypal);
+	expect($('label[for="paypal"]').length === 1).to.equal(paypal);
+	expect($('input[value="applepay"]').length === 1).to.equal(applepay);
+	expect($('label[for="applepay"]').length === 1).to.equal(applepay);
+}


### PR DESCRIPTION
## Feature Description
Only show the required payment methods when rendering the page. By default none show, which I'm not sure is the right call but thought it may be safer.
