### PR TITLE
Fix content size for fieldset

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -179,8 +179,8 @@
 			}
 
 			&::after {
-				top: 49px;
-				right: 20px;
+				top: 43px;
+				right: 14px;
 			}
 		}
 

--- a/main.scss
+++ b/main.scss
@@ -29,9 +29,10 @@
 	}
 
 	&__fieldset {
-		padding: 0;
-		margin: 0 0 20px;
 		border: 0;
+		margin: 0 0 20px;
+		min-inline-size: auto;
+		padding: 0;
 	}
 
 	&__field {


### PR DESCRIPTION
## Feature Description

Fixes a content size issue when using fieldsests. Also fixes offset radio button problem.

## Screenshots:

| Before  | After  |
|---------|--------|
|![beforeFieldset]|![afterFieldset]|
|![beforeRadio]|![afterRadio]|

[beforeFieldset]: https://user-images.githubusercontent.com/708296/52403088-d4ddc500-2abd-11e9-956c-408b889a003b.png
[afterFieldset]: https://user-images.githubusercontent.com/708296/52403095-d7d8b580-2abd-11e9-809c-2924c0c196c8.png
[beforeRadio]: https://user-images.githubusercontent.com/708296/52403509-ccd25500-2abe-11e9-891f-4041edc03b54.png
[afterRadio]: https://user-images.githubusercontent.com/708296/52403512-cfcd4580-2abe-11e9-9239-542ff3f52bab.png
