### PR TITLE
Only remove payment type if already present.

### DIFF
--- a/tests/utils/payment-type.spec.js
+++ b/tests/utils/payment-type.spec.js
@@ -89,6 +89,11 @@ describe('PaymentType', () => {
 				paymentType.hide(PaymentType.PAYPAL);
 				expect(elementStub.querySelector.calledWithMatch(PaymentType.PAYPAL)).to.be.true;
 			});
+
+			it('should fail silently if the element doesn\'t exist', () => {
+				elementStub.querySelector.returns(null);
+				expect(() => { paymentType.hide(PaymentType.PAYPAL); }).not.to.throw();
+			});
 		});
 
 		describe('getSelected', () => {

--- a/utils/payment-type.js
+++ b/utils/payment-type.js
@@ -37,8 +37,12 @@ class PaymentType {
 		const input = this.$paymentType.querySelector(`#${type}`);
 		const label = this.$paymentType.querySelector(`label[for=${type}]`);
 
-		input.remove();
-		label.remove();
+		if (input) {
+			input.remove();
+		}
+		if (label) {
+			label.remove();
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Feature Description

Just ran into this error on `next-subscribe`.

## Screenshots:

<img width="430" alt="1549892424" src="https://user-images.githubusercontent.com/708296/52566844-b3087900-2e02-11e9-92ce-8ec75b887b09.png">

![1549892405](https://user-images.githubusercontent.com/708296/52566791-93715080-2e02-11e9-8ff7-23a6671d50f3.png)
