### PR TITLE
Update payment term options

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,25 @@ const password = new Password(document);
 
 This utility's sole purpose (currently) is to enable the functionality behind the `Show password` checkbox that toggles whether the password is masked or not.
 
+### PaymentTerm
+
+```js
+const paymentTerm = new PaymentTerm(document);
+
+// Return the currently selected payment term
+paymentTerm.getSelected();
+
+// Update the payment term options displayed
+const options = [{
+  name: 'Name of term',
+  value: 'Value to send',
+  description: 'Can contain <strong>HTML</strong>'
+}];
+paymentTerm.updateOptions(options);
+```
+
+Update and get the currently selected payment term on the form
+
 ### PaymentType
 
 ```js

--- a/tests/utils/payment-term.spec.js
+++ b/tests/utils/payment-term.spec.js
@@ -10,7 +10,13 @@ describe('PaymentTerm', () => {
 	beforeEach(() => {
 		elementStub = {
 			querySelector: sandbox.stub(),
-			getAttribute: sandbox.stub()
+			querySelectorAll: sandbox.stub(),
+			getAttribute: sandbox.stub(),
+			setAttribute: sandbox.stub(),
+			cloneNode: sandbox.stub(),
+			remove: sandbox.stub(),
+			insertBefore: sandbox.stub(),
+			parentElement: elementStub
 		};
 		documentStub = {
 			querySelector: sandbox.stub()
@@ -54,6 +60,58 @@ describe('PaymentTerm', () => {
 				elementStub.querySelector.returns(elementStub);
 				paymentTerm.getSelected();
 				expect(elementStub.getAttribute.calledWith('value')).to.be.true;
+			});
+		});
+
+		describe('updateOptions', () => {
+			beforeEach(() => {
+				paymentTerm.getSelected = sandbox.stub().returns(true);
+				elementStub.querySelector.returns(elementStub);
+				elementStub.cloneNode.returns(elementStub);
+				elementStub.querySelectorAll.returns([elementStub]);
+			});
+
+			it('should throw if no options given', () => {
+				expect(() => {
+					paymentTerm.updateOptions();
+				}).to.throw();
+			});
+
+			it('should throw if options not array', () => {
+				expect(() => {
+					paymentTerm.updateOptions('test');
+				}).to.throw();
+			});
+
+			it('should clone two nodes for each option', () => {
+				const options = [{}, {}];
+				paymentTerm.updateOptions(options);
+
+				expect(elementStub.cloneNode.callCount).to.equal(options.length * 2);
+			});
+
+			it('should set the value for each input', () => {
+				const options = [{ value: 1 }, { value: 2 }];
+				paymentTerm.updateOptions(options);
+
+				expect(elementStub.setAttribute.calledWith('value', options[0].value)).to.be.true;
+				expect(elementStub.setAttribute.calledWith('value', options[1].value)).to.be.true;
+			});
+
+			it('should set the id for each input', () => {
+				const options = [{ value: 1 }, { value: 2 }];
+				paymentTerm.updateOptions(options);
+
+				expect(elementStub.setAttribute.calledWith('id', options[0].value)).to.be.true;
+				expect(elementStub.setAttribute.calledWith('id', options[1].value)).to.be.true;
+			});
+
+			it('should set the for for each label', () => {
+				const options = [{ value: 1 }, { value: 2 }];
+				paymentTerm.updateOptions(options);
+
+				expect(elementStub.setAttribute.calledWith('for', options[0].value)).to.be.true;
+				expect(elementStub.setAttribute.calledWith('for', options[1].value)).to.be.true;
 			});
 		});
 	});

--- a/utils/payment-term.js
+++ b/utils/payment-term.js
@@ -3,11 +3,16 @@
  * @example
  * const paymentTerm = new PaymentTerm(document);
  *
- * // Show payment type
- * paymentType.show(PaymentType.APPLEPAY);
+ * // Return the currently selected payment term
+ * paymentTerm.getSelected();
  *
- * // Hide payment type
- * paymentType.hide(PaymentType.CREDITCARD);
+ * // Update the payment term options displayed
+ * const options = [{
+ * 	name: 'Name of term',
+ * 	value: 'Value to send',
+ * 	description: 'Can contain <strong>HTML</strong>'
+ * }];
+ * paymentTerm.updateOptions(options);
  */
 
 const LABEL_TITLE_CLASS = '.ncf__payment-term__label--title';

--- a/utils/payment-term.js
+++ b/utils/payment-term.js
@@ -35,7 +35,7 @@ class PaymentTerm {
 	 * @throws If nothing has been selected
 	 */
 	getSelected () {
-		const checked = this.$paymentTerm.querySelector('input[checked]');
+		const checked = this.$paymentTerm.querySelector('input:checked');
 		if (!checked) {
 			throw new Error('No payment term has been selected');
 		}

--- a/utils/payment-term.js
+++ b/utils/payment-term.js
@@ -9,6 +9,10 @@
  * // Hide payment type
  * paymentType.hide(PaymentType.CREDITCARD);
  */
+
+const LABEL_TITLE_CLASS = '.ncf__payment-term__label--title';
+const LABEL_DESCRIPTION_CLASS = '.ncf__payment-term__label--description';
+
 class PaymentTerm {
 	/**
 	 * Initalise the PaymentTerm utility
@@ -40,6 +44,41 @@ class PaymentTerm {
 			throw new Error('No payment term has been selected');
 		}
 		return checked.getAttribute('value');
+	}
+
+	/**
+	 * Update the payment term options
+	 * @param {Array} options Array of objects contain terms information
+	 */
+	updateOptions (options) {
+		const selected = this.getSelected();
+		const inputToCopy = this.$paymentTerm.querySelector('input');
+		const labelToCopy = this.$paymentTerm.querySelector('label');
+		const container = inputToCopy.parentElement;
+
+		// Reduce to create an array of new input and label elements
+		const newElements = options.reduce((acc, option) => {
+			const input = inputToCopy.cloneNode();
+			input.setAttribute('id', option.value);
+			input.setAttribute('value', option.value);
+			input.checked = option.value === selected;
+
+			const label = labelToCopy.cloneNode(true);
+			label.setAttribute('for', option.value);
+			label.querySelector(LABEL_TITLE_CLASS).innerText = option.name;
+			label.querySelector(LABEL_DESCRIPTION_CLASS).innerHTML = option.description;
+
+			return acc.concat([input, label]);
+		}, []);
+
+		// Remove existing
+		this.$paymentTerm
+			.querySelectorAll('input,label')
+			.forEach(element => element.remove());
+
+		// Add new elements
+		newElements
+			.forEach(element => container.insertBefore(element, container.lastElementChild));
 	}
 }
 

--- a/utils/payment-type.js
+++ b/utils/payment-type.js
@@ -73,7 +73,7 @@ class PaymentType {
 	 * @throws If nothing has been selected
 	 */
 	getSelected () {
-		const checked = this.$paymentType.querySelector('input[checked]');
+		const checked = this.$paymentType.querySelector('input:checked');
 		if (!checked) {
 			throw new Error('No payment type has been selected');
 		}


### PR DESCRIPTION
## Feature Description

When a user changes their billing address the Payment Terms will update. The `updateOptions` will build the new options from existing ones an eventually remove the old ones.

Fixed a but that meant the first input with a checked attribute was being classed as the input's value rather than the actual selected input.