### PR TITLE
Remove package change form

### DIFF
--- a/partials/package-change.html
+++ b/partials/package-change.html
@@ -3,10 +3,7 @@
 		<div class="o-message__content">
 			<p class="o-message__content-main">You have chosen <strong>{{currentPackage}}</strong></p>
 			<div class="o-message__actions">
-				<form action="{{changePackageUrl}}" method="POST">
-					{{#each formData}}<input type="hidden" name="{{name}}" value="{{value}}" />{{/each}}
-					<button class="ncf__button ncf__button--mono" data-trackable="change" type="submit">Change</button>
-				</form>
+				<a href="{{changePackageUrl}}" class="ncf__button ncf__button--mono" data-trackable="change">Change</a>
 			</div>
 		</div>
 	</div>

--- a/tests/partials/package-change.spec.js
+++ b/tests/partials/package-change.spec.js
@@ -10,32 +10,17 @@ describe('package-change template', () => {
 		context.template = await fetchPartial('package-change.html');
 	});
 
-	it('should set the form up correctly', () => {
+	it('should set the link correctly', () => {
 		const data = { changePackageUrl: '/foo' };
 		const $ = context.template(data);
 
-		expect($('form').attr('action')).to.equal('/foo');
-		expect($('form [type=submit]').length).to.equal(1);
+		expect($('a').attr('href')).to.equal('/foo');
 	});
 
 	it('should display package name and price when passed', () => {
-		const data = {
-			currentPackage: 'Digital'
-		};
+		const data = { currentPackage: 'Digital' };
 		const $ = context.template(data);
 
 		expect($('.ncf__center').text()).to.contain(data.currentPackage);
-	});
-
-	it('should display package name and price when passed', () => {
-		const data = {
-			formData: [{
-				name: 'foo',
-				value: 'bar'
-			}]
-		};
-		const $ = context.template(data);
-
-		expect($('form input[name="foo"][value="bar"]').length).to.equal(1);
 	});
 });


### PR DESCRIPTION
Now pages are accessed just via GET requests there is no longer a
need for this to be a form