### PR TITLE
Add error message and util helper for payment type

### DIFF
--- a/partials/payment-type.html
+++ b/partials/payment-type.html
@@ -23,4 +23,6 @@
 		<label for="applepay" class="o-forms__label">Apple Pay</label>
 		{{/if}}
 	</div>
+
+	<div class="o-forms__errortext">Please enter a valid payment type</div>
 </div>

--- a/tests/utils/payment-type.spec.js
+++ b/tests/utils/payment-type.spec.js
@@ -14,7 +14,11 @@ describe('PaymentType', () => {
 			cloneNode: sandbox.stub(),
 			setAttribute: sandbox.stub(),
 			getAttribute: sandbox.stub(),
-			querySelector: sandbox.stub()
+			querySelector: sandbox.stub(),
+			classList: {
+				add: sandbox.stub(),
+				remove: sandbox.stub()
+			}
 		};
 		documentStub = {
 			querySelector: sandbox.stub()
@@ -93,6 +97,20 @@ describe('PaymentType', () => {
 			it('should fail silently if the element doesn\'t exist', () => {
 				elementStub.querySelector.returns(null);
 				expect(() => { paymentType.hide(PaymentType.PAYPAL); }).not.to.throw();
+			});
+		});
+
+		describe('displayError', () => {
+			it('should add a class to the paymentType element', () => {
+				paymentType.displayError();
+				expect(elementStub.classList.add.called).to.be.true;
+			});
+		});
+
+		describe('removeError', () => {
+			it('should remove a class to the paymentType element', () => {
+				paymentType.removeError();
+				expect(elementStub.classList.remove.called).to.be.true;
 			});
 		});
 

--- a/utils/payment-type.js
+++ b/utils/payment-type.js
@@ -68,6 +68,20 @@ class PaymentType {
 	}
 
 	/**
+	 * Display an error message on the paymentType
+	 */
+	displayError () {
+		this.$paymentType.classList.add('o-forms--error');
+	}
+
+	/**
+	 * Remove an error from display
+	 */
+	removeError () {
+		this.$paymentType.classList.remove('o-forms--error');
+	}
+
+	/**
 	 * Returns the value of the currently selected item
 	 * @return {String}
 	 * @throws If nothing has been selected


### PR DESCRIPTION
When a payment type is not recognised we should error and display an
error to the user. Message has been added to the template and the
utility will help with displaying it client side

