### PR TITLE
Fix payment term show bug which checked by default

### DIFF
--- a/tests/utils/payment-type.spec.js
+++ b/tests/utils/payment-type.spec.js
@@ -13,6 +13,7 @@ describe('PaymentType', () => {
 			append: sandbox.stub(),
 			cloneNode: sandbox.stub(),
 			setAttribute: sandbox.stub(),
+			removeAttribute: sandbox.stub(),
 			getAttribute: sandbox.stub(),
 			querySelector: sandbox.stub(),
 			classList: {
@@ -70,6 +71,11 @@ describe('PaymentType', () => {
 			it('should set the correct value', () => {
 				paymentType.show(PaymentType.CREDITCARD);
 				expect(elementStub.setAttribute.calledWith('value', PaymentType.CREDITCARD)).to.be.true;
+			});
+
+			it('should not be selected by default', () => {
+				paymentType.show(PaymentType.CREDITCARD);
+				expect(elementStub.removeAttribute.calledWith('checked')).to.be.true;
 			});
 
 			it('should set the correct for', () => {

--- a/utils/payment-type.js
+++ b/utils/payment-type.js
@@ -59,6 +59,7 @@ class PaymentType {
 
 		input.setAttribute('id', type);
 		input.setAttribute('value', type);
+		input.removeAttribute('checked');
 
 		label.setAttribute('for', type);
 		label.innerText = PaymentType.LABELS[type];


### PR DESCRIPTION
If the shown payment term was copied from the current selected
term then it would mark the new one as checked when shown.