### PR TITLE
Add DD Guarantee

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -42,6 +42,7 @@
     "o-message": "^2.4.1",
     "o-colors": "^4.7.10",
     "o-icons": "^5.9.0",
-    "o-stepped-progress": "^1.0.0"
+    "o-stepped-progress": "^1.0.0",
+    "o-expander": "^4.6.1"
   }
 }

--- a/partials/payment-type.html
+++ b/partials/payment-type.html
@@ -30,3 +30,25 @@
 
 	<div class="o-forms__errortext">Please enter a valid payment type</div>
 </div>
+
+{{#if enableDirectdebit }}
+	<div id="dd-guarantee" class="n-ui-hide" data-o-component="o-expander" data-o-expander-shrink-to="hidden" data-o-expander-expanded-toggle-text="guarantee" data-o-expander-collapsed-toggle-text="guarantee" role="tabpanel">
+		<p>Direct Debit is only supported in the UK</p>
+		<p>Your payments are protected by the Direct Debit
+			<button type="button" class="dd-guarantee__toggle">guarantee</button>
+		</p>
+		<ul class="dd-guarantee__list">
+			<li class="dd-guarantee__list-item">This Guarantee is offered by all banks and building societies that accept instructions to pay Direct Debits.</li>
+			<li class="dd-guarantee__list-item">If there are any changes to the amount, date or frequency of your Direct Debit GoCardless re: The Financial Times will
+				notify you 3 working days in advance of your account being debited or as otherwise agreed. If you request GoCardless
+				Ltd re: The Financial Times to collect a payment, confirmation of the amount and date will be given to you at the time
+				of the request.</li>
+			<li class="dd-guarantee__list-item">If an error is made in the payment of your Direct Debit, by GoCardless Ltd re: The Financial Times or your bank or building
+				society, you are entitled to a full and immediate refund of the amount paid from your bank or building society.</li>
+			<li class="dd-guarantee__list-item">If you receive a refund you are not entitled to, you must pay it back when GoCardless Ltd re: The Financial Times asks
+				you to.</li>
+			<li class="dd-guarantee__list-item">You can cancel a Direct Debit at any time by simply contacting your bank or building society. Written confirmation may
+				be required. Please also notify us.</li>
+		</ul>
+	</div>
+{{/if}}

--- a/styles/payment.scss
+++ b/styles/payment.scss
@@ -1,3 +1,5 @@
+@import "o-expander/main";
+
 @mixin ncfPaymentApplePay() {
 	@supports (-webkit-appearance: -apple-pay-button) {
 		.apple-pay-button {
@@ -55,5 +57,23 @@
 
 	.ncf__payment-type__pp[aria-selected=true] img {
 		filter: grayscale(0);
+	}
+}
+
+#dd-guarantee {
+	@include oTypographySans($scale: -1);
+
+	text-align: center;
+}
+.dd-guarantee {
+	&__list {
+		@include oExpanderContent;
+
+		text-align: left;
+	}
+	&__toggle {
+		@include oExpanderToggle;
+
+		color: oColorsGetPaletteColor('teal');
 	}
 }

--- a/tests/utils/direct-debit-guarantee.spec.js
+++ b/tests/utils/direct-debit-guarantee.spec.js
@@ -1,0 +1,44 @@
+const expect = require('chai').expect;
+const proxyquire = require('proxyquire').noCallThru();
+const sinon = require('sinon');
+
+let expanderInstance = 'expanderInstance';
+let initStub = sinon.stub().returns(expanderInstance);
+let OExpanderStub = {
+	init: initStub
+};
+let FormElementStub = sinon.stub();
+
+const DirectDebitGuarantee = proxyquire('../../utils/direct-debit-guarantee', {
+	'./form-element': FormElementStub,
+	'o-expander': OExpanderStub
+});
+
+describe('DirectDebitGuarantee', () => {
+	let document = 'document';
+	let directDebitGuarantee;
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox();
+		directDebitGuarantee = new DirectDebitGuarantee(document);
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	describe('constructor', () => {
+		it('should call FormElement parent class', () => {
+			expect(FormElementStub.calledWithNew()).to.be.true;
+		});
+
+		it('should call initialise the expander', () => {
+			expect(initStub.called).to.be.true;
+		});
+
+		it('should have an expander property exposing the expander element', () => {
+			expect(directDebitGuarantee.expander).to.deep.eq(expanderInstance);
+		});
+	});
+
+});

--- a/tests/utils/form-element.spec.js
+++ b/tests/utils/form-element.spec.js
@@ -1,0 +1,66 @@
+const FormElement = require('../../utils/form-element');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+describe('FormElement', () => {
+  let formElement;
+  let document;
+  let sandbox;
+  let addStub;
+  let removeStub;
+
+  beforeEach(() => {
+    $formElement = { type: '' };
+    checkboxElement = { addEventListener: () => { }, checked: false };
+    addStub = sinon.stub();
+    removeStub = sinon.stub();
+    document = {
+      querySelector: (selector) => {
+        return {
+          classList: {
+            add: addStub,
+            remove: removeStub
+          }
+        };
+      }
+    };
+    formElement = new FormElement(document);
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('constructor', () => {
+    it('should throw an error if document element isn\'t passed in.', () => {
+      expect(() => {
+        new FormElement();
+      }).to.throw();
+    });
+
+    it('should throw an error if form element does not exist on the page', () => {
+      expect(() => {
+        document.querySelector = () => { };
+        new FormElement(document);
+      }).to.throw();
+    });
+  });
+
+  describe('hide', () => {
+    it('should add the n-ui-hide class', () => {
+      formElement.hide();
+
+      expect(addStub.getCall(0).args[0]).to.equal('n-ui-hide');
+    });
+  });
+
+  describe('show', () => {
+    it('should remove the n-ui-hide class', () => {
+      formElement.show();
+
+      expect(removeStub.getCall(0).args[0]).to.equal('n-ui-hide');
+    });
+  });
+
+});

--- a/utils/direct-debit-guarantee.js
+++ b/utils/direct-debit-guarantee.js
@@ -1,0 +1,27 @@
+const expander = require('o-expander');
+const FormElement = require('./form-element');
+
+/**
+ * Direct Debit utils.
+ * @example
+ * new DirectDebitGuarantee();
+ *
+ */
+class DirectDebitGuarantee extends FormElement {
+
+	/**
+	 * Constructor for the DirectDebitGuarantee component.
+	 * @param {object} document The global document object
+	 */
+	constructor (document) {
+		super(document, '#dd-guarantee');
+
+		this.expander = expander.init(this.$el, {
+			contentClassName: 'dd-guarantee__list',
+			toggleSelector: '.dd-guarantee__toggle'
+		});
+	}
+
+}
+
+module.exports = DirectDebitGuarantee;

--- a/utils/form-element.js
+++ b/utils/form-element.js
@@ -1,0 +1,45 @@
+/**
+ * Form element helper.
+ * @example
+ * new FormElement();
+ *
+ */
+class FormElement {
+
+  /**
+   * Constructor for the FormElement.
+   * @param {object} document The global document object
+   * @param {string} querySelector The selector for the main element used by this component.
+   */
+  constructor (document, querySelector) {
+    this.$document = document;
+
+    if (!this.$document) {
+      throw new Error('Please supply the document element');
+    }
+    
+    this.$el = this.$document.querySelector(querySelector);
+
+    if (!this.$el) {
+      throw new Error('Please include the DOM element for this component on the page');
+    }
+  }
+
+  /**
+   * Hides the form element.
+   */
+  hide () {
+    this.$el.classList.add('n-ui-hide');
+  }
+
+
+  /**
+   * Shows the form element.
+   */
+  show () {
+    this.$el.classList.remove('n-ui-hide');
+  }
+
+}
+
+module.exports = FormElement;


### PR DESCRIPTION
 🐿 v2.12.1

## Feature Description

Add DD Guarantee copy below payment type selector.

## Link to Ticket / Card:

https://trello.com/c/ggg5CVC9/939-3-direct-debit-guarantee

## Screenshots:

![ft-dd-guarantee](https://user-images.githubusercontent.com/708296/54376121-463f0380-467a-11e9-8041-855dffbcd230.gif)

