### PR TITLE
Updated confirmation page style

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -31,6 +31,17 @@
 		padding: 50px;
 	}
 
+  &__paragraph {
+	@include oTypographySans(1);
+	padding: oTypographySpacingSize(5) 0;
+	margin: 0;
+
+	&--reduced-padding {
+	  @include oTypographySans(1);
+	  padding: oTypographySpacingSize(-2) 0;
+	}
+  }
+
 	&__fieldset {
 		border: 0;
 		margin: 0 0 20px;
@@ -61,6 +72,18 @@
 			@include oTypographySerif($scale: 4);
 		}
 	}
+
+  &__header2--afterline {
+	@include oTypographyProductHeadingLevel5;
+
+	&:after {
+	  @include oTypographyPadding($top: 3, $bottom: 0);
+	  content: '';
+	  display: block;
+	  width: 110px;
+	  border-bottom: oTypographySpacingSize(1) solid oColorsGetPaletteColor('black');
+	}
+  }
 
 	&__link--external {
 		@include oTypographyLinkExternal;
@@ -149,7 +172,7 @@
 	}
 
 	&__list {
-
+	  @include oTypographySans($scale: 0);
 		&-title,
 		&-data {
 			width: calc(50% - 10px);

--- a/partials/confirmation.html
+++ b/partials/confirmation.html
@@ -1,16 +1,18 @@
 <div class="ncf__wrapper">
 	<div class="ncf__center">
 		<div class="ncf__icon ncf__icon--tick ncf__icon--large"></div>
-		<p>You are now subscribed to:</p>
+		<p class="ncf__paragraph">You are now subscribed to:</p>
 		<h1 class="ncf__header ncf__header--confirmation">{{offer}}</h1>
 	</div>
 
-	<p>
-		We've sent confirmation of your new subscription to {{email}}.
+	<p class="ncf__paragraph">
+		We've sent confirmation of your new subscription to {{#if email}}{{email}}{{else}}your email{{/if}}.
 		Here's a summary of your {{offer}} subscription:
 	</p>
 
-	<h2>Your billing details</h2>
+
+	{{#if details}}
+	<h2 class="ncf__header2--afterline">Your billing details</h2>
 	<dl class="ncf__list">
 		{{#each details as |detail|}}
 		<dt class="ncf__list-title">{{detail.title}}</dt>
@@ -18,8 +20,15 @@
 		{{/each}}
 	</dl>
 
-	<h3>Something not right?</h3>
-	<p>
+	{{else}}
+	<p class="ncf__paragraph">You can view details on <a class="ncf__link--external"
+														 href="https://myaccount.ft.com/details/core/view"
+														 target="_blank" rel="noopener" data-trackable="yourAccount">your
+		account</a> page</p>
+	{{/if}}
+
+	<h2>Something not right?</h2>
+	<p class="ncf__paragraph--reduced-padding">
 		Go to your account settings to edit your account.
 		If you need to get in touch call us on <a href="tel:+442077556248" class="ncf__link--external">+44 (0) 207 755 6248</a>.
 		Or contact us for additional support.

--- a/tests/partials/confirmation.spec.js
+++ b/tests/partials/confirmation.spec.js
@@ -46,6 +46,6 @@ describe('confirmation template', () => {
 		});
 
 		expect($('dl dt').length).to.equal(0);
-		expect(Array.from($('a')).filter(elem => elem.attribs.href.includes('https://myaccount.ft.com/details/core/view')).length).to.equal(1);
+		expect(Array.from($('a')).filter(elem => elem.attribs['data-trackable'] && elem.attribs['data-trackable'].includes('yourAccount')).length).to.equal(1);
 	});
 });

--- a/tests/partials/confirmation.spec.js
+++ b/tests/partials/confirmation.spec.js
@@ -37,4 +37,15 @@ describe('confirmation template', () => {
 
 		expect($('dl dt').length).to.equal(2);
 	});
+
+
+	it('should display redirect to MMA', () => {
+		const details = [];
+		const $ = context.template({
+			details
+		});
+
+		expect($('dl dt').length).to.equal(0);
+		expect($.text()).to.contain('You can view details on your account page');
+	});
 });

--- a/tests/partials/confirmation.spec.js
+++ b/tests/partials/confirmation.spec.js
@@ -46,6 +46,6 @@ describe('confirmation template', () => {
 		});
 
 		expect($('dl dt').length).to.equal(0);
-		expect($.text()).to.contain('You can view details on your account page');
+		expect($.text()).to.contain('You can view details on your');
 	});
 });

--- a/tests/partials/confirmation.spec.js
+++ b/tests/partials/confirmation.spec.js
@@ -46,6 +46,6 @@ describe('confirmation template', () => {
 		});
 
 		expect($('dl dt').length).to.equal(0);
-		expect($.text()).to.contain('You can view details on your');
+		expect(Array.from($('a')).filter(elem => elem.attribs.href.includes('https://myaccount.ft.com/details/core/view')).length).to.equal(1);
 	});
 });


### PR DESCRIPTION
 🐿 v2.12.0

## Feature Description
Updated confirmation page styling. 
Added different data displaying capabilities if some of the data is missing {email / confirmation_details}

## Link to Ticket / Card:
https://trello.com/c/RBa9tkWU/819-8-buy-flow-confirmation-page
## Screenshots:
With full details:
<img width="383" alt="Screenshot 2019-03-15 at 14 46 56" src="https://user-images.githubusercontent.com/26438424/54441601-01c46e00-4735-11e9-9ed8-79d6f9e49b08.png">
when confirmation data is missing:
<img width="517" alt="Screenshot 2019-03-15 at 14 47 16" src="https://user-images.githubusercontent.com/26438424/54441620-0be66c80-4735-11e9-896e-d58eb8d476b9.png">

