### PR TITLE
Added DD mandate link

### DIFF
--- a/partials/confirmation.html
+++ b/partials/confirmation.html
@@ -21,6 +21,13 @@
 	</dl>
 	{{/if}}
 
+
+	{{#if ddMandateUrl}}
+		<div>
+			<p class="ncf__paragraph--reduced-padding">Download your <a href={{ddMandateUrl}} data-trackable="dd-mandate-link" id="encryptedMandateLink">direct debit mandate</a>.</p>
+		</div>
+	{{/if}}
+
 	<h3 class="ncf__header2--reduced-size">Something not right?</h3>
 	<p class="ncf__paragraph--reduced-padding">
 		Go to your <a class="ncf__link"

--- a/tests/partials/confirmation.spec.js
+++ b/tests/partials/confirmation.spec.js
@@ -38,6 +38,23 @@ describe('confirmation template', () => {
 		expect($('dl dt').length).to.equal(2);
 	});
 
+	it('should display dd mandate link', () => {
+		const ddMandateUrl = 'www.ft.com';
+		const $ = context.template({
+			ddMandateUrl
+		});
+
+		expect($('dl dt').length).to.equal(0);
+		expect(Array.from($('a')).filter(elem => elem.attribs['data-trackable'] && elem.attribs['data-trackable'].includes('dd-mandate-link')).length).to.equal(1);
+	});
+
+	it('should NOT display dd mandate link if link is not present', () => {
+		const $ = context.template({});
+
+		expect($('dl dt').length).to.equal(0);
+		expect(Array.from($('a')).filter(elem => elem.attribs['data-trackable'] && elem.attribs['data-trackable'].includes('dd-mandate-link')).length).to.equal(0);
+	});
+
 
 	it('should display redirect to MMA', () => {
 		const details = [];


### PR DESCRIPTION
Added DD mandate link

 🐿 v2.12.3

## Feature Description
Currently there is a button, which will be visible if ddMandateLink is generated.
This PR does not include the styles yet. Will have to wait for Lucinda to come back from holidays to design this link

## Link to Ticket / Card:
https://trello.com/c/qb963YhC/880-3-buy-flow-add-direct-debit-mandate-to-confirmation-page
## Screenshots:
![Screenshot 2019-03-25 at 16 34 43](https://user-images.githubusercontent.com/26438424/54937406-419d0980-4f1c-11e9-8e91-7044118c9471.png)
