### PR TITLE
Unpin @financial-times/n-gage

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "n-common-static-data": "financial-times/n-common-static-data#v1.6.1"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "3.5.0",
+    "@financial-times/n-gage": "^3.6.0",
     "@financial-times/n-handlebars": "^1.21.0",
     "@financial-times/n-internal-tool": "^2.3.1",
     "autoprefixer": "^8.6.3",


### PR DESCRIPTION
This pull requests unpins the @financial-times/n-gage dependency. As a general rule we should not be pinning any of our devDependencies.