### PR TITLE
doc: add Snyk badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Contains HTML and CSS that's used within the conversion forms
 
 [![CircleCI](https://circleci.com/gh/Financial-Times/n-conversion-forms.svg?style=svg)](https://circleci.com/gh/Financial-Times/n-conversion-forms)
+[![Known Vulnerabilities](https://snyk.io/test/github/Financial-Times/n-conversion-forms/badge.svg?targetFile=package.json)](https://snyk.io/test/github/Financial-Times/n-conversion-forms?targetFile=package.json)
 
 ```bash
 make install # install all dependencies


### PR DESCRIPTION
## Feature Description
Add Snyk Badge to readme.

## Link to Ticket / Card:
This is a proposal nothing related to the current Backlog.

*Why I think we should do that (when we have time as tech debts)?*
Because it immediately communicates to developers that are reading the README that we use Snyk and the repo is tracked and (hopefully) in a good state by the security perspective.

Additionally, it just take 2 minutes to open a PR.

## Screenshots:
This is how the readme will look like for this repo

<img width="456" alt="Screenshot 2019-04-15 at 09 15 56" src="https://user-images.githubusercontent.com/752680/56117572-49226200-5f60-11e9-9445-464499072aca.png">

