### PR TITLE
White background styles for messages

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -10,6 +10,7 @@
 @import './styles/payment';
 @import './styles/payment-term';
 @import './styles/payment-type';
+@import './styles/message';
 @import 'o-fonts/main';
 
 @include oFonts();
@@ -194,12 +195,7 @@
 		}
 	}
 
-	&__message {
-		p + p {
-			margin-top: 0;
-		}
-	}
-
+	@include ncfMessage();
 	@include ncfPaymentTerm();
 	@include ncfPaymentType();
 

--- a/partials/message.html
+++ b/partials/message.html
@@ -3,8 +3,8 @@
 		<div class="o-message__container">
 			<div class="o-message__content">
 				<p class="o-message__content-main">
-					{{#if messageTitle}}
-						<span class="o-message__content-highlight">{{messageTitle}}</span>
+					{{#if title}}
+						<span class="o-message__content-highlight">{{title}}</span>
 					{{/if}}
 					<span class="o-message__content-detail">{{{message}}}</span>
 				</p>

--- a/styles/message.scss
+++ b/styles/message.scss
@@ -1,0 +1,23 @@
+@mixin ncfMessage() {
+	&__message {
+		p + p {
+			margin-top: 0;
+		}
+	}
+
+	// Change the colour of messages inside the wrapper
+	// to look better with a white background
+	.ncf__wrapper & &__message {
+		.o-message--error {
+			color: oColorsGetPaletteColor(crimson);
+			background-color: oColorsMix(crimson, white, 10);
+
+			.o-message__actions__primary {
+				background-color: oColorsMix(crimson, white, 10);
+				&:hover {
+					background-color: oColorsMix(crimson, white, 20);
+				}
+			}
+		}
+	}
+}

--- a/tests/partials/message.spec.js
+++ b/tests/partials/message.spec.js
@@ -102,7 +102,7 @@ describe('message template', () => {
 	});
 
 	it('should display a title if specified', () => {
-		const $ = context.template({ messageTitle: 'Foo' });
+		const $ = context.template({ title: 'Foo' });
 		const $title = $(SELECTOR_TITLE);
 
 		expect($title.length).to.equal(1);


### PR DESCRIPTION
## Feature Description
Error messages on a white background did not look nice, this is because the red being used was based on them showing on the paper background color.

## Link to Ticket / Card:
https://trello.com/c/xVc7RwxM/843-5-buy-flow-error-message-review

## Screenshots:

| Before | After |
| --- | --- |
| <img width="473" alt="Screenshot 2019-04-15 at 15 13 55" src="https://user-images.githubusercontent.com/1721150/56139591-1c3a7300-5f91-11e9-9063-fda20fd1e5c9.png"> | <img width="475" alt="Screenshot 2019-04-15 at 15 12 54" src="https://user-images.githubusercontent.com/1721150/56139551-0d53c080-5f91-11e9-8c2e-b03ed397dd80.png"> |
