### PR TITLE
Add hidden and name parameters to message partial

### DIFF
--- a/partials/message.html
+++ b/partials/message.html
@@ -1,4 +1,4 @@
-<div class="ncf__message o-forms o-forms--wide">
+<div class="ncf__message o-forms o-forms--wide{{#if isHidden}} n-ui-hide{{/if}}"{{#if name}} data-message-name="{{name}}"{{/if}}>
 	<div class="o-message {{#if isNotice}}o-message--notice-inner{{else}}o-message--alert-inner{{/if}}{{#if isError}} o-message--error{{else if isSuccess}} o-message--success{{else if isInform}} o-message--inform{{else}} o-message--neutral{{/if}}" data-o-component="o-message">
 		<div class="o-message__container">
 			<div class="o-message__content">

--- a/tests/partials/message.spec.js
+++ b/tests/partials/message.spec.js
@@ -14,7 +14,9 @@ const SELECTOR_ADDITIONAL = '.o-message__content--additional';
 const SELECTOR_MESSAGE = '.o-message__content-main';
 const SELECTOR_MESSAGE_CONTENT = '.o-message__content-detail';
 const SELECTOR_CONTAINER = '.o-message';
+const SELECTOR_MESSAGE_CONTAINER = '.ncf__message';
 const SELECTOR_TITLE = '.o-message__content-highlight';
+const HIDDEN_CLASS = 'n-ui-hide';
 
 let context = {};
 
@@ -163,5 +165,25 @@ describe('message template', () => {
 		const $ = context.template({ actions: [{ link: '#', text: 'Foo', isSecondary: true }] });
 
 		expect($(`${SELECTOR_ACTIONS} a`).attr('class')).to.contain(CLASS_ACTIONS_SECONDARY);
+	});
+
+	it('should have no name by default', () => {
+		const $ = context.template({ message: 'Foo' });
+		expect($(SELECTOR_MESSAGE_CONTAINER).attr('data-message-name')).to.be.undefined;
+	});
+
+	it('should have a message-name if passed', () => {
+		const $ = context.template({ message: 'Foo', name: 'Test' });
+		expect($(SELECTOR_MESSAGE_CONTAINER).attr('data-message-name')).to.equal('Test');
+	});
+
+	it('should be shown by default', () => {
+		const $ = context.template({ message: 'Foo' });
+		expect($(SELECTOR_MESSAGE_CONTAINER).attr('class')).to.not.contain(HIDDEN_CLASS);
+	});
+
+	it('should apply a hidden class if marked hidden', () => {
+		const $ = context.template({ message: 'Foo', isHidden: true });
+		expect($(SELECTOR_MESSAGE_CONTAINER).attr('class')).to.contain(HIDDEN_CLASS);
 	});
 });


### PR DESCRIPTION
## Feature Description
These new features will be used in subscribe to allow us to pin point messages within client side code showing and hiding them as appropriate.

## Link to Ticket / Card:
https://trello.com/c/xVc7RwxM/843-5-buy-flow-error-message-review
