### PR TITLE
Add Loader component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 	postcss public/component.css -u autoprefixer -r
 	@$(DONE)
 
-run:
+run: build
 	@DEMO_MODE=true nodemon --ext html,css --watch public --watch views demos/app.js
 
 a11y: build

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ import MyModule from 'n-conversion-forms/utils/my-module';
 * [Country](#country)
 * [Email](#email)
 * [Event Notifier](#event-notifier)
+* [Loader](#loader)
 * [Password](#password)
 * [Payment Term](#payment-term)
 * [Payment Type](#payment-type)
@@ -104,6 +105,50 @@ This utility provides the following:
 ### Event Notifier
 
 TBD
+
+### Loader
+
+```js
+const loader = new Loader(document);
+```
+
+Requirements:
+
++ `{{> n-conversion-forms/partials/loader }}` - The element containing the overlay and loading message/spinner. Place this somewhere near the bottom of your document.
+
+If you want to define some content, this can be done as follows:
+
+```handlebars
+{{#> n-conversion-forms/partials/loader title="Hooray!" }}
+  <p>Main content for the message can be defined in here</p>
+{{/ n-conversion-forms/partials/loader }}
+```
+
+#### Showing/Hiding
+
+The loader is hidden by default on page load.
+
+```js
+loader.show();
+loader.hide();
+```
+
+#### Loading Message
+
+To dynamically set the messsage to be displayed (either of the properties are optional):
+
+```js
+loader.setContent({
+  content: '<p>Main content for the message can be defined in here</p>',
+  title: 'Hooray!'
+});
+```
+
+To clear the message entirely:
+
+```js
+loader.clearContent();
+```
 
 ### Password
 

--- a/bower.json
+++ b/bower.json
@@ -43,7 +43,8 @@
     "o-colors": "^4.7.10",
     "o-icons": "^5.9.0",
     "o-stepped-progress": "^1.0.0",
-    "o-expander": "^4.7.0"
+    "o-expander": "^4.7.0",
+    "o-loading": "^2.3.0"
   },
   "resolutions": {
     "ftdomdelegate": "^3.0.0"

--- a/demos/data.json
+++ b/demos/data.json
@@ -15,6 +15,14 @@
       "fields": "Inline content here."
     }
   },
+  "loader": {
+    "params": {
+      "title": "Hooray!"
+    },
+    "partials": {
+      "@partial-block": "<p>Your content is busy loading! <sup>(not really, this is just a demo)</sup></p>"
+    }
+  },
   "message": {
     "params": {
       "isError": true,

--- a/demos/main.js
+++ b/demos/main.js
@@ -1,0 +1,10 @@
+const Loader = require('../utils/loader');
+
+if (document.querySelector('.ncf__loader')) {
+	const loader = new Loader(document);
+	loader.show();
+}
+
+// Make the textarea display all the rows it's given.
+const $textarea = document.getElementById('example-code');
+$textarea.rows = ($textarea.value.match(/\n/gi).length) + 1;

--- a/demos/main.scss
+++ b/demos/main.scss
@@ -12,3 +12,10 @@ body {
 		height: 100%;
 	}
 }
+
+#demo-page-loader {
+	#example-code {
+		position: relative;
+		z-index: 1001;
+	}
+}

--- a/main.scss
+++ b/main.scss
@@ -10,6 +10,7 @@
 @import './styles/payment';
 @import './styles/payment-term';
 @import './styles/payment-type';
+@import './styles/loader';
 @import './styles/message';
 @import 'o-fonts/main';
 
@@ -211,6 +212,7 @@
 	@include ncfMessage();
 	@include ncfPaymentTerm();
 	@include ncfPaymentType();
+	@include ncfLoader();
 
 	@include ncfPaymentApplePay();
 

--- a/partials/loader.html
+++ b/partials/loader.html
@@ -1,0 +1,14 @@
+<div class="ncf__loader n-ui-hide">
+	<div class="ncf__loader__content">
+		{{#if title}}
+			<div class="ncf__loader__content__title">
+				{{ title }}
+			</div>
+		{{/if}}
+		{{#if @partial-block}}
+		<div class="ncf__loader__content__main">
+			{{> @partial-block }}
+		</div>
+		{{/if}}
+	</div>
+</div>

--- a/styles/loader.scss
+++ b/styles/loader.scss
@@ -1,0 +1,44 @@
+/* stylelint-disable selector-no-qualifying-type */
+@import 'o-loading/main';
+
+@mixin ncfLoader() {
+	&__loader {
+		background-color: rgba(0, 0, 0, 0.75);
+		bottom: 0;
+		height: 100vh;
+		left: 0;
+		position: fixed;
+		right: 0;
+		text-align: center;
+		top: 0;
+		z-index: 1000;
+		align-items: center;
+		justify-content: center;
+
+		&.is-visible {
+			display: flex;
+		}
+
+		&__content {
+			@include oTypographySans();
+			color: oColorsGetPaletteColor('white');
+
+			&::before {
+				@include oLoadingColor('light');
+				@include oLoadingSize('large');
+				@include oLoading();
+
+				content: '';
+				position: relative;
+				top: 50%;
+				transform: translateY(-50%);
+			}
+
+			&__title {
+				@include oTypographySans($scale: 2);
+				// No semi-bold so doing it manually.
+				font-weight: 500;
+			}
+		}
+	}
+}

--- a/tests/partials/loader.spec.js
+++ b/tests/partials/loader.spec.js
@@ -1,0 +1,39 @@
+const { expect } = require('chai');
+const {
+	registerPartial,
+	unregisterPartial,
+	fetchPartial,
+} = require('../helpers');
+
+let context = {};
+
+describe('loader template', () => {
+
+	before(async () => {
+		registerPartial('@partial-block', '<div>Foo Bar</div>');
+		context.template = await fetchPartial('loader.html');
+	});
+
+	after(() => {
+		unregisterPartial('@partial-block');
+	});
+
+	it('should have the loader element', () => {
+		const $ = context.template();
+
+		expect($('.ncf__loader').length).to.equal(1);
+		expect($('.ncf__loader__content').length).to.equal(1);
+	});
+
+	it('should allow a title in the partial', () => {
+		const $ = context.template({ title: 'Hooray!' });
+
+		expect($('.ncf__loader__content__title').html().trim()).to.equal('Hooray!');
+	});
+
+	it('should allow content in the partial', () => {
+		const $ = context.template();
+		expect($('.ncf__loader__content__main').html().trim()).to.equal('<div>Foo Bar</div>');
+	});
+
+});

--- a/tests/utils/loader.spec.js
+++ b/tests/utils/loader.spec.js
@@ -1,0 +1,85 @@
+const Loader = require('../../utils/loader');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+describe('Loader', () => {
+	let loader;
+	let documentStub;
+	let elementStub;
+	let addClassStub = sandbox.stub();
+	let removeClassStub = sandbox.stub();
+
+	beforeEach(() => {
+		elementStub = {
+			classList: {
+				add: addClassStub,
+				remove: removeClassStub
+			}
+		};
+		documentStub = {
+			querySelector: sandbox.stub()
+		};
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	describe('constructor', () => {
+		it('should throw an error if nothing passed', () => {
+			expect(() => {
+				new Loader();
+			}).to.throw();
+		});
+
+		it('should throw an error if loader not present', () => {
+			expect(() => {
+				documentStub.querySelector.returns(false);
+				new Loader(documentStub);
+			}).to.throw();
+		});
+	});
+
+	context('constructed', () => {
+		beforeEach(() => {
+			documentStub.querySelector.returns(elementStub);
+			loader = new Loader(documentStub);
+		});
+
+		describe('clearContent', () => {
+			it('should clear the content of the partial', () => {
+				loader.setContent('<div>Baz</div>');
+				loader.clearContent();
+				expect(elementStub.innerHTML).to.equal('');
+			});
+		});
+
+		describe('setContent', () => {
+			it('should set the title of the partial', () => {
+				loader.setContent({ title: 'Hooray!'});
+				expect(elementStub.innerHTML).to.equal('Hooray!');
+			});
+			it('should set the content of the partial', () => {
+				loader.setContent({ content: '<div>Baz</div>'});
+				expect(elementStub.innerHTML).to.equal('<div>Baz</div>');
+			});
+		});
+
+		describe('show', () => {
+			it('should show the loader', () => {
+				loader.show();
+				expect(addClassStub.getCall(0).args[0]).to.equal(loader.VISIBLE_CLASS);
+				expect(removeClassStub.getCall(0).args[0]).to.equal(loader.HIDDEN_CLASS);
+			});
+		});
+
+		describe('hide', () => {
+			it('should hide the loader', () => {
+				loader.hide();
+				expect(addClassStub.getCall(0).args[0]).to.equal(loader.VISIBLE_CLASS);
+				expect(removeClassStub.getCall(0).args[0]).to.equal(loader.HIDDEN_CLASS);
+			});
+		});
+	});
+});

--- a/utils/loader.js
+++ b/utils/loader.js
@@ -1,0 +1,73 @@
+/**
+ * Utility for the `n-conversion-forms/partial/loader.html` partial
+ * @example
+ * const loader = new Loader(document);
+ *
+ * loader.show();
+ */
+class Loader {
+	/**
+	 * Initalise the Loader utility
+	 * @param {Element} element Usually the window.document
+	 * @throws If the document not passed
+	 * @throws When the loader element not found
+	 */
+	constructor (element) {
+		if (!element) {
+			throw new Error('Please supply a DOM element');
+		}
+
+		this.VISIBLE_CLASS = 'is-visible';
+		this.HIDDEN_CLASS = 'n-ui-hide';
+
+		this.element = element;
+		this.$loader = element.querySelector('.ncf__loader');
+		this.$loaderContent = element.querySelector('.ncf__loader__content');
+		this.$loaderContentTitle = element.querySelector('.ncf__loader__content__title');
+		this.$loaderContentMain = element.querySelector('.ncf__loader__content__main');
+
+		if (!this.$loader) {
+			throw new Error('Please include the loader partial on the page');
+		}
+	}
+
+	/**
+	 * Clear the content.
+	 */
+	clearContent () {
+		this.$loaderContent.innerHTML = '';
+	}
+
+	/**
+	 * Set the html content.
+	 *
+	 * @param {string} title The HTML markup/string containing the title of the message.
+	 * @param {string} content The HTML markup/string containing the main content of the message.
+	 */
+	setContent ({ title, content}) {
+		if (title) {
+			this.$loaderContentTitle.innerHTML = title;
+		}
+		if (content) {
+			this.$loaderContentMain.innerHTML = content;
+		}
+	}
+
+	/**
+	 * Show the loader
+	 */
+	show () {
+		this.$loader.classList.add(this.VISIBLE_CLASS);
+		this.$loader.classList.remove(this.HIDDEN_CLASS);
+	}
+
+	/**
+	 * Hide the loader
+	 */
+	hide () {
+		this.$loader.classList.add(this.HIDDEN_CLASS);
+		this.$loader.classList.remove(this.VISIBLE_CLASS);
+	}
+};
+
+module.exports = Loader;


### PR DESCRIPTION
🐿 v2.12.3

## Feature Description

Loader component for use in all of our forms. Includes JS util for controlling it.

Note: I've had to do a fair bit of hacking around in the demos/test code to make it so that I could use `@partial-block` because I felt that defining named inline partials wasn't as neat. At least now we have the ability to do so going forward 😄

## Link to Ticket / Card:

https://trello.com/c/0xuGAx9L/1074-5-loaders-on-all-the-pages

## Screenshots:

Note: the example where data is passed in is incorrect here (`title=title`). I've fixed it since making the gif.

![](https://user-images.githubusercontent.com/708296/56742152-1c462a00-676c-11e9-9515-58dcb813ad80.gif)