### PR TITLE
1097 5 update mainscss to not output double styling

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -41,8 +41,7 @@
 			padding: 0;
 		}
 
-		&--reduced-padding-custom-margin {
-			padding: 0;
+		&--subscription-confirmation {
 			margin: oTypographySpacingSize(4) 0 oTypographySpacingSize(2);
 		}
 	}
@@ -78,19 +77,26 @@
 		}
 	}
 
-	&__header2 {
-		&--reduced-size {
+	&__headed-paragraph {
+		.ncf__header {
+			@include oTypographySize(2);
 			padding: 0;
-			margin: 0 0 oTypographySpacingSize(2);
+			margin: 0 0 oTypographySpacingSize(1);
 		}
 
+		.ncf__paragraph {
+			padding: 0;
+		}
+	}
+
+	&__header2 {
 		&--afterline {
 			@include oTypographySize(1);
 			&:after {
 				@include oTypographyPadding($top: 3, $bottom: 0);
 				content: '';
 				display: block;
-				width: 110px;
+				width: 90px;
 				border-bottom: oTypographySpacingSize(1) solid oColorsGetPaletteColor('black');
 			}
 		}

--- a/main.scss
+++ b/main.scss
@@ -38,11 +38,11 @@
 		margin: 0;
 
 		&--reduced-padding {
-			padding: 0 0;
+			padding: 0;
 		}
 
 		&--reduced-padding-custom-margin {
-			padding: 0 0;
+			padding: 0;
 			margin: oTypographySpacingSize(4) 0 oTypographySpacingSize(2);
 		}
 	}
@@ -80,7 +80,7 @@
 
 	&__header2 {
 		&--reduced-size {
-			padding: 0 0;
+			padding: 0;
 			margin: 0 0 oTypographySpacingSize(2);
 		}
 

--- a/main.scss
+++ b/main.scss
@@ -34,13 +34,16 @@
 	}
 
 	&__paragraph {
-		@include oTypographySans(1);
 		padding: oTypographySpacingSize(4) 0;
 		margin: 0;
 
 		&--reduced-padding {
-			@include oTypographySans(1);
-			padding: oTypographySpacingSize(0) 0;
+			padding: 0 0;
+		}
+
+		&--reduced-padding-custom-margin {
+			padding: 0 0;
+			margin: oTypographySpacingSize(4) 0 oTypographySpacingSize(2);
 		}
 	}
 
@@ -71,20 +74,18 @@
 		@include oTypographyProductHeadingLevel5;
 
 		&--confirmation {
-			@include oTypographySerif($scale: 4);
-			margin-top: -8px;
+			@include oTypographySerif($scale: 3);
 		}
 	}
 
 	&__header2 {
 		&--reduced-size {
-			@include oTypographySerif($scale: 0);
-			padding: oTypographySpacingSize(0) 0;
-			margin: 22px 0 -10px;
+			padding: 0 0;
+			margin: 0 0 oTypographySpacingSize(2);
 		}
 
 		&--afterline {
-			@include oTypographySerif($scale: 1);
+			@include oTypographySize(1);
 			&:after {
 				@include oTypographyPadding($top: 3, $bottom: 0);
 				content: '';
@@ -179,6 +180,12 @@
 			width: 40px;
 			height: 40px;
 		}
+	}
+
+	&__icon-download {
+		@include oIconsGetIcon('download', oColorsGetPaletteColor('cold-1'), 32);
+		border: 0;
+		vertical-align: middle;
 	}
 
 	&__list {

--- a/partials/confirmation.html
+++ b/partials/confirmation.html
@@ -1,7 +1,7 @@
 <div class="ncf ncf__wrapper">
 	<div class="ncf__center">
 		<div class="ncf__icon ncf__icon--tick ncf__icon--large"></div>
-		<p class="ncf__paragraph--reduced-padding-custom-margin">You are now subscribed to:</p>
+		<p class="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">You are now subscribed to:</p>
 		<h1 class="ncf__header ncf__header--confirmation">{{offer}}</h1>
 	</div>
 
@@ -28,11 +28,13 @@
 		</div>
 	{{/if}}
 
-	<h3 class="ncf__header2--reduced-size">Something not right?</h3>
-	<p class="ncf__paragraph--reduced-padding">
-		Go to your <a class="ncf__link" href="https://myaccount.ft.com/details/core/view" target="_blank" rel="noopener" data-trackable="yourAccount">account settings</a> to view or edit
-		your account. If you need to get in touch call us on <a href="tel:+442077556248" class="ncf__link--external">+44 (0) 207 755 6248</a>. Or contact us for additional support.
-	</p>
+	<div class="ncf__headed-paragraph">
+		<h3 class="ncf__header">Something not right?</h3>
+		<p class="ncf__paragraph">
+			Go to your <a class="ncf__link" href="https://myaccount.ft.com/details/core/view" target="_blank" rel="noopener" data-trackable="yourAccount">account settings</a> to view or edit
+			your account. If you need to get in touch call us on <a href="tel:+442077556248" class="ncf__link--external">+44 (0) 207 755 6248</a>. Or contact us for additional support.
+		</p>
+	</div>
 	<p class="ncf__center">
 		<a href="/signup/newsletters" class="ncf__button ncf__button--submit">Start exploring</a>
 	</p>

--- a/partials/confirmation.html
+++ b/partials/confirmation.html
@@ -1,11 +1,11 @@
-<div class="ncf__wrapper">
+<div class="ncf ncf__wrapper">
 	<div class="ncf__center">
 		<div class="ncf__icon ncf__icon--tick ncf__icon--large"></div>
-		<p class="ncf__paragraph--reduced-padding">You are now subscribed to:</p>
+		<p class="ncf__paragraph--reduced-padding-custom-margin">You are now subscribed to:</p>
 		<h1 class="ncf__header ncf__header--confirmation">{{offer}}</h1>
 	</div>
 
-	<p class="ncf__paragraph--reduced-padding">
+	<p class="ncf__paragraph">
 		We've sent confirmation of your new subscription to {{#if email}}{{email}}{{else}}your email{{/if}}.
 		Here's a summary of your {{offer}} subscription:
 	</p>
@@ -24,7 +24,7 @@
 
 	{{#if directDebitMandateUrl}}
 		<div>
-			<p class="ncf__paragraph--reduced-padding">Download your <a href={{directDebitMandateUrl}} data-trackable="dd-mandate-link" id="encryptedMandateLink">direct debit mandate</a>.</p>
+			<p class="ncf__paragraph--reduced-padding">Download your <a href={{directDebitMandateUrl}} data-trackable="dd-mandate-link" id="encryptedMandateLink">direct debit mandate</a><i class="ncf__icon-download"></i></p>
 		</div>
 	{{/if}}
 


### PR DESCRIPTION
## Feature Description
We were not using origami styles as they should be used. This PR fixes our usage by minimising component duplication in final css. I was able to reduce oTypographySans and oTypographySerif usage

## Link to Ticket / Card:
https://trello.com/c/G1HP59O2/1097-5-update-mainscss-to-not-output-double-styling
## Screenshots:
![Screenshot 2019-04-25 at 15 29 32](https://user-images.githubusercontent.com/26438424/56744437-70eba400-6770-11e9-9b0c-cab9c0dfa76c.png)

