### PR TITLE
Add renderCallback to zuora util

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ const zuora = new Zuora(window);
 
 // Will render the 3rd party Zuora iframe with client side validation and custom error messages.
 // Returns a Promise that resolves ONLY once the form has loaded.
-zuora.render({ params, prePopulatedFields, hostedPaymentPageCallback });
+zuora.render({ params, prePopulatedFields, renderCallback });
 
 // Will attempt to submit the 3rd party Zuora iframe form and reject if there are client side
 // validation errors or if the user refuses the Direct Debit mandate confirmation.

--- a/partials/loader.html
+++ b/partials/loader.html
@@ -5,10 +5,10 @@
 				{{ title }}
 			</div>
 		{{/if}}
-		{{#if @partial-block}}
 		<div class="ncf__loader__content__main">
-			{{> @partial-block }}
+			{{#if @partial-block}}
+				{{> @partial-block }}
+			{{/if}}
 		</div>
-		{{/if}}
 	</div>
 </div>

--- a/tests/utils/zuora.spec.js
+++ b/tests/utils/zuora.spec.js
@@ -25,6 +25,7 @@ describe('Zuora', () => {
 		window = {
 			Z: {
 				prepopulate: sinon.stub(),
+				runAfterRender: sinon.stub(),
 				renderWithErrorHandler: sinon.stub(),
 				sendErrorMessageToHpm: sinon.stub(),
 				setEventHandler: sinon.stub(),
@@ -54,16 +55,16 @@ describe('Zuora', () => {
 	context('render', () => {
 		const params = { foo: 'bar' };
 		const prepopulatedFields = { firstName: 'John' };
-		const hostedPaymentPageCallback = () => { };
+		const renderCallback = () => { };
 
 		it('calls relevant Zuora functions', async () => {
-			await zuora.render({ params, prepopulatedFields, hostedPaymentPageCallback });
+			await zuora.render({ params, prepopulatedFields, renderCallback });
 
 			expect(window.Z.renderWithErrorHandler.called).to.be.true;
 		});
 
 		it('sets up error handler that calls sendErrorMessageToHpm', async () => {
-			await zuora.render({ params, prepopulatedFields, hostedPaymentPageCallback });
+			await zuora.render({ params, prepopulatedFields, renderCallback });
 			const handler = window.Z.renderWithErrorHandler.getCall(0).args[3];
 
 			handler();
@@ -71,11 +72,17 @@ describe('Zuora', () => {
 		});
 
 		it('sets up error handler that calls sendErrorMessageToHpm with correct error', async () => {
-			await zuora.render({ params, prepopulatedFields, hostedPaymentPageCallback });
+			await zuora.render({ params, prepopulatedFields, renderCallback });
 			const handler = window.Z.renderWithErrorHandler.getCall(0).args[3];
 
 			handler(fixtures.render.key, fixtures.render.code, fixtures.render.message);
 			expect(window.Z.sendErrorMessageToHpm.getCall(0).args).to.deep.equal(['firstName', 'First Name is invalid']);
+		});
+
+		it('binds the renderCallback to Zuora\'s runAfterRender function', async () => {
+			await zuora.render({ params, prepopulatedFields, renderCallback });
+
+			expect(window.Z.runAfterRender.called).to.be.true;
 		});
 	});
 

--- a/utils/zuora.js
+++ b/utils/zuora.js
@@ -33,20 +33,23 @@ class Zuora {
 	 * error messages.
 	 * @param {Object} params Parameters for customizing this Payment Pages 2.0 form
 	 * @param {Object} prePopulatedFields Parameters with field ids and values to be pre-populated on the form
-	 * @param {Function} hostedPaymentPageCallback Handles only the error responses in Payment Page request from the Z.renderWithErrorHandler function
+	 * @param {Function} renderCallback A function that gets called after the form is rendered.
 	 */
-	render ({ params, prePopulatedFields={}, hostedPaymentPageCallback=()=>{} }) {
+	render ({ params, prePopulatedFields = {}, renderCallback=()=>{} }) {
+		// This will be called from within the iframe after it has been rendered. For some reason, this seemingly
+		//  breaks their normal convention of using post message.
+		this.Z.runAfterRender(renderCallback.bind(this));
 		/**
 		 * Z.renderWithErrorHandler - Zuora 3rd party method
 		 * @param {Object}    params - see parent function
 		 * @param {Object}    prePopulatedFields - see parent function
-		 * @param {Function}  hostedPaymentPageCallback - see parent function
-		 * @param {Function}  anonymous - Zuora Custom Error Message Callback
+		 * @param {Function}  anonymous - Meant to run after init, but it doesn't seem to work ¯\_(ツ)_/¯
+		 * @param {Function}  anonymous - Handles only the error responses in Payment Page request from the Z.renderWithErrorHandler function.
 		 */
 		this.Z.renderWithErrorHandler(
 			params,
 			prePopulatedFields,
-			hostedPaymentPageCallback,
+			()=>{},
 			(key, code, message) => {
 				// Generate our custom error messages and send them to the HPM
 				const errorMessage = customiseZuoraError.generateCustomErrorMessage(key, code, message);


### PR DESCRIPTION
🐿 v2.12.3

Also sneaking in a cheeky loader fix 😬

## Feature Description

The hostedPaymentPageCallback wasn't working and I found out about the `runAfterRender` function. I figure it's a more useful event to be binding to anyway.