### PR TITLE
Remove disabled submit button

### DIFF
--- a/tests/utils/validation.spec.js
+++ b/tests/utils/validation.spec.js
@@ -18,17 +18,14 @@ describe('Validation', () => {
 	let document;
 	let formElement;
 	let requiredElListener;
-	let submitElement;
 	let sandbox;
 	let checkValidityStub;
 	let validation;
 
 	beforeEach(() => {
-		submitElement = {};
 		formElement = {
 			length: 1,
-			addEventListener: () => {},
-			querySelector: () => submitElement
+			addEventListener: () => {}
 		};
 		global.document.querySelector = () => formElement;
 		requiredElListener = sinon.stub();
@@ -67,9 +64,6 @@ describe('Validation', () => {
 	});
 
 	describe('init', () => {
-		it('should disable the submit button', () => {
-			expect(validation.$submit.disabled).to.be.true;
-		});
 
 		it('should add an event listener to all required elements', () => {
 			expect(requiredElListener.calledTwice).to.be.true;
@@ -102,26 +96,22 @@ describe('Validation', () => {
 	});
 
 	describe('checkFormValidity', () => {
-		it('should disable the submit button and set the form as invalid if there are invalid elements.', () => {
+		it('should set the form as invalid if there are invalid elements.', () => {
 			validation.formValid = true;
-			validation.$submit.disabled = false;
 
 			checkValidityStub.returns(false);
 			validation.checkFormValidity();
 
 			expect(validation.formValid).to.be.false;
-			expect(validation.$submit.disabled).to.be.true;
 		});
 
-		it('should enable the submit button and set the form as valid if there are invalid elements.', () => {
+		it('should set the form as valid if there are invalid elements.', () => {
 			validation.formValid = false;
-			validation.$submit.disabled = true;
 
 			checkValidityStub.returns(true);
 			validation.checkFormValidity();
 
 			expect(validation.formValid).to.be.true;
-			expect(validation.$submit.disabled).to.be.false;
 		});
 	});
 

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -8,7 +8,6 @@ class Validation {
 	 */
 	constructor ({ mutePromptBeforeLeaving } = {}) {
 		this.$form = document.querySelector('form.ncf');
-		this.$submit = this.$form.querySelector('[type="submit"]');
 		this.oForms = new OForms(this.$form);
 		this.$formFields = this.oForms.findInputs().filter($el => $el.type !== 'hidden');
 		this.$requiredEls = this.$formFields.filter($el => $el.required);
@@ -23,8 +22,6 @@ class Validation {
 	 */
 	init () {
 		if (!this.$form.length) return;
-
-		this.$submit.disabled = true;
 
 		for (const $el of this.$requiredEls) {
 			$el.addEventListener('blur', this.checkFormValidity.bind(this), false);
@@ -49,15 +46,21 @@ class Validation {
 	}
 
 	/**
+	 * Proxy method for oForms validateForm
+	 * @param {Event} event DOM event
+	 */
+	validateForm (event) {
+		this.oForms.validateForm(event);
+	}
+
+	/**
 	 * Update the state of the form to reflect form validity.
 	 */
 	checkFormValidity () {
 		if (this.getInvalidEls().length === 0) {
 			this.formValid = true;
-			this.$submit.disabled = false;
 		} else {
 			this.formValid = false;
-			this.$submit.disabled = true;
 		}
 	}
 


### PR DESCRIPTION
## Feature Description
After talking to Origami it seems disabling the submit button is not a great user experience. This stops the disabling of the submit button and exposes the validateForm method from oForms so that next-subscribe can do it's magic...

## Link to Ticket / Card:
https://trello.com/c/tUrGMboj/1128-1-payment-page-apple-pay-become-a-subscriber-cta-never-enabled

