### PR TITLE
Make sure Zuora errors get the correct prototype

### DIFF
--- a/utils/zuora.js
+++ b/utils/zuora.js
@@ -151,8 +151,23 @@ class Zuora {
 /**
  * Error classes
  */
-class ZuoraErrorValidation extends Error {};
-class ZuoraErrorMandateCancel extends Error {};
-class ZuoraErrorInvalidPaymentType extends Error {};
+class ZuoraErrorValidation extends Error {
+	constructor (message) {
+		super(message);
+		Object.setPrototypeOf(this, ZuoraErrorValidation.prototype);
+	}
+};
+class ZuoraErrorMandateCancel extends Error {
+	constructor (message) {
+		super(message);
+		Object.setPrototypeOf(this, ZuoraErrorMandateCancel.prototype);
+	}
+};
+class ZuoraErrorInvalidPaymentType extends Error {
+	constructor (message) {
+		super(message);
+		Object.setPrototypeOf(this, ZuoraErrorInvalidPaymentType.prototype);
+	}
+};
 
 module.exports = Zuora;


### PR DESCRIPTION
## Feature Description
Seems babel in next-subscribe does not fix the prototypes like typescript/node does, this is needed to fix them so we can do `instanceof` tests.

## Link to Ticket / Card:
https://trello.com/c/ZH273Wxn/1092-5-analytics-add-event-which-fires-when-we-show-the-user-a-message

