### PR TITLE
Enable passing in content for the loader when calling the show method

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ loader.show();
 loader.hide();
 ```
 
+You can optionally pass in content when showing the loader:
+
+```js
+loader.show({ title: 'Hello World!' });
+```
+
 #### Loading Message
 
 To dynamically set the messsage to be displayed (either of the properties are optional):

--- a/tests/utils/loader.spec.js
+++ b/tests/utils/loader.spec.js
@@ -72,6 +72,13 @@ describe('Loader', () => {
 				expect(addClassStub.getCall(0).args[0]).to.equal(loader.VISIBLE_CLASS);
 				expect(removeClassStub.getCall(0).args[0]).to.equal(loader.HIDDEN_CLASS);
 			});
+			it('should call setContent if content is passed', () => {
+				const content = { title: 'foo' };
+				sandbox.stub(loader, 'setContent');
+
+				loader.show(content);
+				expect(loader.setContent.getCall(0).args[0]).to.equal(content);
+			});
 		});
 
 		describe('hide', () => {

--- a/utils/loader.js
+++ b/utils/loader.js
@@ -55,8 +55,13 @@ class Loader {
 
 	/**
 	 * Show the loader
+	 *
+	 * @param {object} content The optional content to set *before* showing the loader.
 	 */
-	show () {
+	show (content) {
+		if (content) {
+			this.setContent(content);
+		}
 		this.$loader.classList.add(this.VISIBLE_CLASS);
 		this.$loader.classList.remove(this.HIDDEN_CLASS);
 	}


### PR DESCRIPTION
🐿 v2.12.3

## Link to Ticket / Card:

https://trello.com/c/0xuGAx9L/1074-5-loaders-on-all-the-pages