### PR TITLE
Adjust the margins in the fieldset

### DIFF
--- a/demos/data.json
+++ b/demos/data.json
@@ -6,8 +6,11 @@
     }
   },
   "fieldset": {
+    "legend": "The legend is great",
+    "isHeader": true,
+    "descriptor": "The descriptor is also here",
     "partials": {
-      "fields": "Inline content here."
+      "fields": "<div class=o-forms__group>Testing</div>"
     }
   },
   "form": {

--- a/main.scss
+++ b/main.scss
@@ -52,6 +52,14 @@
 		margin: 0 0 20px;
 		min-inline-size: auto;
 		padding: 0;
+
+		.ncf__header {
+			margin: 0;
+		}
+	}
+
+	&__fieldset-descriptor {
+		margin: 0;
 	}
 
 	&__field {

--- a/main.scss
+++ b/main.scss
@@ -60,6 +60,7 @@
 
 	&__fieldset-descriptor {
 		margin: 0;
+		@include oTypographySize(-1);
 	}
 
 	&__field {

--- a/partials/fieldset.html
+++ b/partials/fieldset.html
@@ -4,7 +4,7 @@
 	<legend class="o-forms__label{{#if isHeader}} ncf__header{{/if}}{{#if hideLegend}} o-normalise-visually-hidden{{/if}}">{{legend}}</legend>
 	{{/if}}
 	{{#if descriptor}}
-	<p class="ncf__fieldset--descriptor">{{descriptor}}</p>
+	<p class="ncf__fieldset-descriptor">{{descriptor}}</p>
 	{{/if}}
 
 	<div class="o-forms__group">


### PR DESCRIPTION
## Feature Description
Design review changes to adjust the margins of the fieldset header and descriptor

## Link to Ticket / Card:
https://trello.com/c/tRS4iLrq/1108-1-gap-between-details-first-field-too-large
https://trello.com/c/NwZgjVfg/1110-1-gap-between-payment-title-and-field-too-large-missing-blurb

## Screenshots:
| Before | After |
| --- | --- |
| <img width="418" alt="Screenshot 2019-04-29 at 18 08 46" src="https://user-images.githubusercontent.com/1721150/56913567-e5448100-6aa9-11e9-98cb-df8e40534297.png"> | <img width="391" alt="Screenshot 2019-04-29 at 18 08 18" src="https://user-images.githubusercontent.com/1721150/56913572-e8d80800-6aa9-11e9-8d6f-3d3204513fa5.png"> |
| <img width="416" alt="Screenshot 2019-04-29 at 18 09 00" src="https://user-images.githubusercontent.com/1721150/56913582-ef667f80-6aa9-11e9-95fb-3ce2707221dc.png"> | <img width="391" alt="Screenshot 2019-04-29 at 18 07 45" src="https://user-images.githubusercontent.com/1721150/56913589-f3929d00-6aa9-11e9-8c3c-bb9693700196.png"> |



