### PR TITLE
Make checkboxes validate on click

### DIFF
--- a/utils/validation.js
+++ b/utils/validation.js
@@ -24,7 +24,11 @@ class Validation {
 		if (!this.$form.length) return;
 
 		for (const $el of this.$requiredEls) {
-			$el.addEventListener('blur', this.checkFormValidity.bind(this), false);
+			if (/(checkbox)/gi.test($el.type)) {
+				$el.addEventListener('change', this.checkElementValidity.bind(this, $el), false);
+			} else {
+				$el.addEventListener('blur', this.checkFormValidity.bind(this), false);
+			}
 		}
 
 		this.$form.addEventListener('change', () => {
@@ -51,6 +55,14 @@ class Validation {
 	 */
 	validateForm (event) {
 		this.oForms.validateForm(event);
+	}
+
+	/**
+	 * Checks a single elements validity.
+	 */
+	checkElementValidity ($el) {
+		// Make sure the input element has been updated (for example if this is from a label click for a checkbox).
+		this.oForms.validateInput($el);
 	}
 
 	/**


### PR DESCRIPTION
 🐿 v2.12.3

## Feature Description

Checkboxes were only updating on blur which led to some odd behaviour (see before gif below)

## Link to Ticket / Card:

https://trello.com/c/aiopoOpg/1129-1-tc-strange-behaviour

## Screenshots:

|Before|After|
|-|-|
|![ft-checkbox-validation-before](https://user-images.githubusercontent.com/708296/57020164-66258900-6c20-11e9-8090-08d03d7e18f8.gif)|![ft-checkbox-validation-after](https://user-images.githubusercontent.com/708296/57020175-6c1b6a00-6c20-11e9-835e-50f826587f80.gif)|