### PR TITLE
Updated payment type weights to semi bold

### DIFF
--- a/partials/payment-term.html
+++ b/partials/payment-term.html
@@ -2,7 +2,7 @@
 	{{#each options}}
 	<input type="radio" id="{{this.value}}" name="paymentTerm" value="{{this.value}}" class="o-forms__radio o-forms__radio--right ncf__payment-term__input o-forms__radio-button--my-custom-theme" {{#if this.selected}} checked="checked" {{/if}}>
 	<label for="{{this.value}}" class="o-forms__label ncf__payment-term__label">
-		<strong class="ncf__payment-term__label--title">{{this.name}}</strong>
+		<span class="ncf__payment-term__label--title">{{this.name}}</span>
 		<div class="ncf__payment-term__label--description">
 			{{{this.description}}}
 		</div>

--- a/styles/payment-term.scss
+++ b/styles/payment-term.scss
@@ -40,10 +40,6 @@
 			@include oTypographySans($scale: 2);
 		}
 
-		&__price {
-			font-weight: oFontsWeight('semibold');
-		}
-
 		&__label--description {
 			padding-top: 18px;
 		}

--- a/styles/payment-term.scss
+++ b/styles/payment-term.scss
@@ -36,7 +36,12 @@
 		}
 
 		&__label--title {
+			font-weight: oFontsWeight('semibold');
 			@include oTypographySans($scale: 2);
+		}
+
+		&__price {
+			font-weight: oFontsWeight('semibold');
 		}
 
 		&__label--description {


### PR DESCRIPTION
 🐿 v2.12.3

## Feature Description
default price type weight was bold. in ft we use semibolds. I have updated label--title class to use semibold
I have also created new class for ncf-payment-type__price which will be used in next-subscribe to display annual price in semibold as well

## Link to Ticket / Card:
https://trello.com/c/3g3HvElM/1114-1-cost-needs-to-be-bold
## Screenshots:
![Screenshot 2019-05-01 at 15 10 56](https://user-images.githubusercontent.com/26438424/57021592-93743600-6c24-11e9-8e6d-1df01dea4c38.png)
