### PR TITLE
Update payment options copy

### DIFF
--- a/partials/payment-term.html
+++ b/partials/payment-term.html
@@ -9,9 +9,14 @@
 	</label>
 	{{/each}}
 	<div class="ncf__payment-term__legal">
-		With all subscription types, we will automatically renew your subscription using the payment method provided unless you
-		cancel before your renewal date. We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next
-		renewal. Find out more about our cancellation policy in our
-		<a href="https://help.ft.com/help/legal-privacy/terms-conditions/" title="FT Legal Terms and Conditions help page">Terms &amp; Conditions</a>.
+		<p>
+			With all subscription types, we will automatically renew your subscription using the payment
+			method provided unless you cancel before your renewal date.
+		</p>
+		<p>
+			We will notify you at least 14 days in advance of any changes to the price in your subscription
+			that would apply upon next renewal. Find out more about our cancellation policy in our
+			<a href="https://help.ft.com/help/legal-privacy/terms-conditions/" title="FT Legal Terms and Conditions help page">Terms &amp; Conditions</a>.
+		</p>
 	</div>
 </div>

--- a/partials/payment-term.html
+++ b/partials/payment-term.html
@@ -16,7 +16,7 @@
 		<p>
 			We will notify you at least 14 days in advance of any changes to the price in your subscription
 			that would apply upon next renewal. Find out more about our cancellation policy in our
-			<a href="https://help.ft.com/help/legal-privacy/terms-conditions/" title="FT Legal Terms and Conditions help page">Terms &amp; Conditions</a>.
+			<a class="ncf__link--external" href="https://help.ft.com/help/legal-privacy/terms-conditions/" title="FT Legal Terms and Conditions help page" target="_blank" rel="noopener">Terms &amp; Conditions</a>.
 		</p>
 	</div>
 </div>


### PR DESCRIPTION
 🐿 v2.12.3

## Feature Description

Adds a paragraph break in the copy underneath the payment options.

## Link to Ticket / Card:

https://trello.com/c/c0giULyF/1131-1-add-paragraph-break-in-large-amount-of-text

## Screenshots:

|Before|After|
|-|-|
|<img src="https://user-images.githubusercontent.com/708296/57023656-82c6be80-6c2a-11e9-9175-01761b59dfab.png">|<img src="https://user-images.githubusercontent.com/708296/57023671-8a866300-6c2a-11e9-9326-f88ec5b1d9b7.png">|