### PR TITLE
Show light versions of paypal/direct debit icons when selected.

### DIFF
--- a/partials/payment-type.html
+++ b/partials/payment-type.html
@@ -10,17 +10,15 @@
 			<input type="radio" name="paymentType" value="creditcard" class="o-forms__radio-button" id="creditcard"{{#ifEquals value "creditcard"}} checked="checked"{{/ifEquals}}>
 			<label for="creditcard" class="o-forms__label">Credit / Debit Card</label>
 		</div>
+
 		<div class="ncf__payment-type ncf__payment-type--paypal{{#unless enablePaypal }} n-ui-hide{{/unless}}">
 			<input type="radio" name="paymentType" value="paypal" class="o-forms__radio-button" id="paypal"{{#ifEquals value "paypal"}} checked="checked"{{/ifEquals}}>
-			<label for="paypal" class="o-forms__label" aria-label="Pay using Paypal">
-				<img src="https://www.ft.com/__assets/creatives/third-party/pp-logo-100px.png" alt="paypal">
-			</label>
+			<label for="paypal" class="o-forms__label">PayPal</label>
 		</div>
+
 		<div class="ncf__payment-type ncf__payment-type--directdebit{{#unless enableDirectdebit }} n-ui-hide{{/unless}}">
 			<input type="radio" name="paymentType" value="directdebit" class="o-forms__radio-button" id="directdebit"{{#ifEquals value "directdebit"}} checked="checked"{{/ifEquals}}>
-			<label for="directdebit" class="o-forms__label" aria-label="Pay using Direct Debit">
-				<img src="https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fthird-party%2Fdirect-debit-transparent.png?width=300&amp;source=next&amp;fit=scale-down" alt="Direct Debit">
-			</label>
+			<label for="directdebit" class="o-forms__label">Direct Debit</label>
 		</div>
 		<div class="ncf__payment-type ncf__payment-type--applepay{{#unless enableApplepay }} n-ui-hide{{/unless}}">
 			<input type="radio" name="paymentType" value="applepay" class="o-forms__radio-button" id="applepay"{{#ifEquals value "applepay"}} checked="checked"{{/ifEquals}}>

--- a/styles/payment-type.scss
+++ b/styles/payment-type.scss
@@ -1,3 +1,10 @@
+@mixin buttonImageOverriding() {
+	color: transparent;
+	background-repeat: no-repeat;
+	background-position: center;
+	background-size: 60px;
+}
+
 @mixin ncfPaymentType() {
 	&__payment-type {
 		grid-row: 1;
@@ -15,6 +22,30 @@
 		&-selector {
 			display: inline-block;
 			width: 100%;
+		}
+
+		&--paypal {
+			.o-forms__label {
+				background-image: url(https://www.ft.com/__assets/creatives/third-party/pp-logo-100px.png);
+				@include buttonImageOverriding();
+			}
+
+			.o-forms__radio-button:checked+.o-forms__label {
+				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fthird-party%2Fdirect-debit-transparent.png?width=300&source=next&fit=scale-down);
+				@include buttonImageOverriding();
+			}
+		}
+
+		&--directdebit {
+			.o-forms__label {
+				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fthird-party%2Fdirect-debit-transparent.png?width=300&source=next&fit=scale-down);
+				@include buttonImageOverriding();
+			}
+
+			.o-forms__radio-button:checked+.o-forms__label {
+				background-image: url(https://www.ft.com/__assets/creatives/third-party/pp-logo-100px.png);
+				@include buttonImageOverriding();
+			}
 		}
 	}
 
@@ -51,3 +82,4 @@
 		}
 	}
 }
+

--- a/styles/payment-type.scss
+++ b/styles/payment-type.scss
@@ -30,7 +30,7 @@
 				@include buttonImageOverriding();
 			}
 
-			.o-forms__radio-button:checked+.o-forms__label {
+			.o-forms__radio-button:checked + .o-forms__label {
 				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fthird-party%2Fdirect-debit-transparent.png?width=300&source=next&fit=scale-down);
 				@include buttonImageOverriding();
 			}
@@ -42,7 +42,7 @@
 				@include buttonImageOverriding();
 			}
 
-			.o-forms__radio-button:checked+.o-forms__label {
+			.o-forms__radio-button:checked + .o-forms__label {
 				background-image: url(https://www.ft.com/__assets/creatives/third-party/pp-logo-100px.png);
 				@include buttonImageOverriding();
 			}
@@ -82,4 +82,3 @@
 		}
 	}
 }
-

--- a/styles/payment-type.scss
+++ b/styles/payment-type.scss
@@ -26,25 +26,25 @@
 
 		&--paypal {
 			.o-forms__label {
-				background-image: url(https://www.ft.com/__assets/creatives/third-party/pp-logo-100px.png);
 				@include buttonImageOverriding();
+				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2Fassets%2Fthird-party%2Fpp-logo-100px.png?width=300&source=next&fit=scale-down);
 			}
 
 			.o-forms__radio-button:checked + .o-forms__label {
-				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fthird-party%2Fdirect-debit-transparent.png?width=300&source=next&fit=scale-down);
 				@include buttonImageOverriding();
+				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2Fassets%2Fthird-party%2Fpp-logo-white.png?width=300&source=next&fit=scale-down);
 			}
 		}
 
 		&--directdebit {
 			.o-forms__label {
-				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fthird-party%2Fdirect-debit-transparent.png?width=300&source=next&fit=scale-down);
 				@include buttonImageOverriding();
+				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2Fassets%2Fthird-party%2Fdirect_debit.png?width=300&source=next&fit=scale-down);
 			}
 
 			.o-forms__radio-button:checked + .o-forms__label {
-				background-image: url(https://www.ft.com/__assets/creatives/third-party/pp-logo-100px.png);
 				@include buttonImageOverriding();
+				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2Fassets%2Fthird-party%2Fdirect_debit-white.png?width=300&source=next&fit=scale-down);
 			}
 		}
 	}


### PR DESCRIPTION
## Feature Description

Previously, the icons were remaining the same colour and were therefore barely visible.

## Link to Ticket / Card:

This is a twofer: https://trello.com/c/Und1hTOS/1115-1-paypal-button and https://trello.com/c/OoF1bLJP/1116-1-direct-debit-button

## Screenshots:

<img src="https://user-images.githubusercontent.com/708296/57133365-76617380-6d9a-11e9-9c54-0a52bf0a5770.png">
<img src="https://user-images.githubusercontent.com/708296/57133367-7a8d9100-6d9a-11e9-97b5-7a08cadef89f.png">