### PR TITLE
Show loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ loader.show();
 loader.hide();
 ```
 
+or
+
+To show loader:
+
+```handlebars
+{{> n-conversion-forms/partials/loader showLoader=true title="Hooray!" }}
+```
+
 You can optionally pass in content when showing the loader:
 
 ```js

--- a/partials/loader.html
+++ b/partials/loader.html
@@ -1,8 +1,8 @@
-<div class="ncf__loader n-ui-hide">
+<div class="ncf__loader {{#if showLoader}}is-visible{{else}}n-ui-hide{{/if}}">
 	<div class="ncf__loader__content">
 		{{#if title}}
 			<div class="ncf__loader__content__title">
-				{{ title }}
+				{{title}}
 			</div>
 		{{/if}}
 		<div class="ncf__loader__content__main">

--- a/tests/partials/loader.spec.js
+++ b/tests/partials/loader.spec.js
@@ -36,4 +36,18 @@ describe('loader template', () => {
 		expect($('.ncf__loader__content__main').html().trim()).to.equal('<div>Foo Bar</div>');
 	});
 
+	it('should show loader when showLoader is set to true', () => {
+		const $ = context.template({ showLoader: true });
+
+		expect($('.is-visible').length).to.equal(1);
+		expect($('.n-ui-hide').length).to.equal(0);
+	});
+
+	it('should hide loader when showLoader is not set', () => {
+		const $ = context.template();
+
+		expect($('.is-visible').length).to.equal(0);
+		expect($('.n-ui-hide').length).to.equal(1);
+	});
+
 });


### PR DESCRIPTION
 🐿 v2.12.3

### Description
Provides the option to set the variable `showLoader` in the HTML in order to show loader without javascript. 