### PR TITLE
Adjust the vertical align of the change package button

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -143,6 +143,10 @@
 			margin: 0 0 10px;
 		}
 
+		&--baseline {
+			vertical-align: baseline;
+		}
+
 		&--google {
 			@include oButtonsTheme('secondary');
 			background-color: oColorsGetPaletteColor('white');

--- a/partials/package-change.html
+++ b/partials/package-change.html
@@ -3,7 +3,7 @@
 		<div class="o-message__content">
 			<p class="o-message__content-main">You have chosen <span class="ncf__strong">{{currentPackage}}</span></p>
 			<div class="o-message__actions">
-				<a href="{{changePackageUrl}}" class="ncf__button ncf__button--mono" data-trackable="change">Change</a>
+				<a href="{{changePackageUrl}}" class="ncf__button ncf__button--mono ncf__button--baseline" data-trackable="change">Change</a>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Feature Description
Adjust how the change package button is vertically aligned

## Link to Ticket / Card:
https://trello.com/c/Q3Sw71Ul/1146-1-make-change-button-more-vertically-centered

## Screenshots:
| Before | After |
| --- | --- |
| <img width="536" alt="Screenshot 2019-05-07 at 12 54 42" src="https://user-images.githubusercontent.com/1721150/57297592-dec89180-70c7-11e9-812f-e31435715829.png"> | <img width="536" alt="Screenshot 2019-05-07 at 12 54 26" src="https://user-images.githubusercontent.com/1721150/57297597-e425dc00-70c7-11e9-8489-0abc894d8871.png"> | 

