### PR TITLE
Fix spacing above payment term description

### DIFF
--- a/styles/payment-term.scss
+++ b/styles/payment-term.scss
@@ -41,7 +41,7 @@
 		}
 
 		&__label--description {
-			padding-top: 18px;
+			padding-top: 14px;
 		}
 
 		&__legal {


### PR DESCRIPTION
## Feature Description

Made the padding match the spacing of the form fields for consistency.

## Link to Ticket / Card:

https://trello.com/c/7I9Rwnhx/1106-1-awkward-looking-radio-button

## Screenshots:

|Before|After|
|-|-|
|<img src="https://user-images.githubusercontent.com/708296/57298030-184dcc80-70c9-11e9-9307-ad3f96e5c48f.png">|<img src="https://user-images.githubusercontent.com/708296/57298044-20a60780-70c9-11e9-9087-1c636b178012.png">|

