### PR TITLE
Reduce the wrappers margins on small screens

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -44,7 +44,8 @@
     "o-icons": "^5.9.0",
     "o-stepped-progress": "^1.0.0",
     "o-expander": "^4.7.0",
-    "o-loading": "^2.3.0"
+    "o-loading": "^2.3.0",
+    "o-grid": "^4.5.2"
   },
   "resolutions": {
     "ftdomdelegate": "^3.0.0"

--- a/main.scss
+++ b/main.scss
@@ -31,7 +31,11 @@
 
 	&__wrapper {
 		background: oColorsGetPaletteColor('white');
-		padding: 50px;
+		padding: 20px;
+
+		@include oGridRespondTo($from: S) {
+			padding: 50px;
+		}
 	}
 
 	&__stepped-progress {


### PR DESCRIPTION
## Feature Description
50px margin on a small screen is not good

## Screenshots:
| Before | After |
| --- | --- |
| ![screencapture-ft-buy-offer-683995bf-ed3f-2fd6-d589-1628ebad1629-registered-2019-05-07-14_31_20](https://user-images.githubusercontent.com/1721150/57303274-e0e51d00-70d4-11e9-9b0b-7dcc6ea8a75c.png) | ![screencapture-local-ft-5050-buy-offer-683995bf-ed3f-2fd6-d589-1628ebad1629-registered-2019-05-07-14_30_49](https://user-images.githubusercontent.com/1721150/57303279-e3477700-70d4-11e9-8ce3-b23c360577bb.png) |
