### PR TITLE
Adjust margins on the progress indicator

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -34,6 +34,14 @@
 		padding: 50px;
 	}
 
+	&__stepped-progress {
+		margin: 0 20px;
+
+		@include oGridRespondTo($from: S) {
+			margin: 0;
+		}
+	}
+
 	&__paragraph {
 		padding: oTypographySpacingSize(4) 0;
 		margin: 0;

--- a/partials/progress-indicator.html
+++ b/partials/progress-indicator.html
@@ -1,4 +1,4 @@
-<div class="o-stepped-progress" data-o-component="o-stepped-progress">
+<div class="ncf__stepped-progress o-stepped-progress" data-o-component="o-stepped-progress">
 	<ol class="o-stepped-progress__steps">
 		{{#each items}}
 		<li>


### PR DESCRIPTION
## Feature Description
This is to line our progress indicator up correctly to margins

## Screenshots:
| Small | Large |
| --- | --- |
| <img width="473" alt="Screenshot 2019-05-07 at 15 03 32" src="https://user-images.githubusercontent.com/1721150/57305947-ceb9ad80-70d9-11e9-9142-415102783ace.png"> | <img width="562" alt="Screenshot 2019-05-07 at 15 03 16" src="https://user-images.githubusercontent.com/1721150/57305951-d2e5cb00-70d9-11e9-8d7e-1c7a9c664f4b.png"> |

