### PR TITLE
Add zuora iframe to zuora util

### DIFF
--- a/tests/utils/zuora.spec.js
+++ b/tests/utils/zuora.spec.js
@@ -42,9 +42,14 @@ describe('Zuora', () => {
 	});
 
 	context('constructor', () => {
-		it('Sets up global listeners', () => {
+		it('sets up global listeners', () => {
 			expect(window.Z.setEventHandler.getCall(0).args[0]).to.equal('blur_mode_enabled');
 			expect(window.Z.setEventHandler.getCall(1).args[0]).to.equal('blur_mode_disabled');
+		});
+
+		it('sets up dom elements', () => {
+			expect(zuora.iframe).to.exist;
+			expect(zuora.overlay).to.exist;
 		});
 
 		it('gets Z from window and adds to class scope', () => {

--- a/utils/zuora.js
+++ b/utils/zuora.js
@@ -22,8 +22,9 @@ class Zuora {
 	constructor (window) {
 		this.Z = window.Z;
 
-		// `blur_mode_(enabled|disabled)` are for the DD confirmation dialog.
+		this.iframe = new FormElement(window.document, '.ncf__zuora-payment');
 		this.overlay = new FormElement(window.document, '.ncf__zuora-payment-overlay');
+		// `blur_mode_(enabled|disabled)` are for the DD confirmation dialog.
 		this.Z.setEventHandler('blur_mode_enabled', () => { this.overlay.show(); });
 		this.Z.setEventHandler('blur_mode_disabled', () => { this.overlay.hide(); });
 	}


### PR DESCRIPTION
 🐿 v2.12.3

## Feature Description

This is so we can show/hide the iframe if there's a problem fetching the config.

## Link to Ticket / Card:

https://trello.com/c/tDfDnNrM/1119-1-large-gap-between-error-and-payment-method
