### PR TITLE
Fieldset accessibility improvements

### DIFF
--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -2,7 +2,68 @@
 
 ## Content
 
+* [Fieldset](#fieldset)
+* [Loader](#loader)
 * [Message](#message)
+
+## Fieldset
+
+Renders a fieldset.
+
+### Options
+
++ `descriptor`: string - Text used to describe this set of fields.
++ `legend`: string - Text to display in the `fieldset`'s `legend` element. Not passing this in won't render this element.
++ `hideLegend`: boolean - Whether to visibly show the `legend` or not.
++ `headingLevel`: string - The heading level to use when the `header` inline partial (see below) is used.
++ `name`: string - The value for the `fieldset`'s `name` attribute.
+
+### Inline Partials
+
+#### fields
+
+The form fields to be displayed in this fieldset.
+
+```handlebars
+{{#> n-conversion-forms/partials/fieldset }}
+  {{#*inline "fields"}}
+    {{> n-conversion-forms/partials/email value='test@example.com' }}
+  {{/inline}}
+{{/ n-conversion-forms/partials/fieldset }}
+```
+
+#### header
+
+This is useful for cases where you'd want to pass in markup to use within the header element. For example, you may want to specify a more accessibility friendly header as follows:
+
+```handlebars
+{{#> n-conversion-forms/partials/fieldset headingLevel="h1" legend="Details" hideLegend="true" }}
+  {{#*inline "header"}}
+    <span class="o-normalise-visually-hidden"></span>Details<span class="o-normalise-visually-hidden"> (page 1 of 3)</span>
+  {{/inline}}
+{{/ n-conversion-forms/partials/fieldset }}
+```
+
+*NB*: The `headingLevel` option is required in order for this to work.
+
+## Loader
+
+A full screen loading overlay.
+
+### Options
+
++ `showLoader`: boolean - Whether to show the loader by default/on page load.
++ `title`: string - The title of the message shown underneath the loading spinner.
+
+### Inline Partials
+
+You can pass in HTML (additional to the `title`) using [partial block syntax](https://handlebarsjs.com/partials.html#partial-block) as follows:
+
+```handlebars
+{{> n-conversion-forms/partials/loader}}
+  <p>Some additional content<p>
+{{/ n-conversion-forms/partials/loader}}
+```
 
 ## Message
 
@@ -12,41 +73,17 @@ i.e `{{> n-conversion-forms/partials/message isError=true message=flash.message 
 
 ### Options
 
-#### Type:
++ `isHidden`: boolean - Whether the message is hidden by default/on page load.
++ `name`: string - The name for this message that gets added to the `data-message-name` attribute.
++ `isError`: boolean - Use the `Error` origami styles for this message.
++ `isInform`: boolean - Use the `Success` origami styles for this message.
++ `isNotice`: boolean - Use the `Notice` origami styles for this message.
++ `isSuccess`: boolean - Use the `Success` origami styles for this message.
++ `title`: string - The title for this message.
++ `message`: string - The main content for this message.
++ `additional`: Array - An array of strings containing additional information.
++ `actions`: Array - An array containing the below config for the action buttons:
+  + `link`: string - The link to go to when clicking the button.
+  + `isSecondary`: boolean - Whether to render this button using secondary styling from [o-buttons](https://registry.origami.ft.com/components/o-buttons).
+  + `text`: string - The text the user will see on the button.
 
-* Notice: boolean - isNotice=true
-* Alert: default
-
-### Status:
-
-* Error: boolean - isError=true
-* Success: boolean - isSuccess=true
-* Inform: boolean - isInform=true - default
-
-### Title:
-
-* messageTitle: string - messageTitle="The title of the message". Optional.
-
-### Message:
-
-* message: string - message. Required.
-
-### Additional message:
-
-`{ additional: ['Allows an additional message'] }`
-
-* additional: array of strings - additional=additional. Optional.
-
-### Actions
-
-Allows for two types of styles:
-
-* button-style: o-message__actions__primary
-* link-style: o-message__actions__secondary
-
-* actions: Optional. Array of objects containing the following properties:
-
-Required if you have actions.
-* link: url=https://ft.com.
-* text: string=FT.com.
-* isSecondary: boolean.

--- a/partials/fieldset.html
+++ b/partials/fieldset.html
@@ -1,7 +1,12 @@
 <fieldset {{#if name}}name="{{name}}" {{/if}}class="ncf__fieldset">
 
 	{{#if legend}}
-	<legend class="o-forms__label{{#if isHeader}} ncf__header{{/if}}{{#if hideLegend}} o-normalise-visually-hidden{{/if}}">{{legend}}</legend>
+	<legend class="o-forms__label{{#if hideLegend}} o-normalise-visually-hidden{{/if}}">{{legend}}</legend>
+	{{/if}}
+	{{#if headingLevel}}
+		<{{headingLevel}} class="ncf__header">
+			{{> header }}
+		</{{headingLevel}}>
 	{{/if}}
 	{{#if descriptor}}
 	<p class="ncf__fieldset-descriptor">{{descriptor}}</p>

--- a/tests/partials/fieldset.spec.js
+++ b/tests/partials/fieldset.spec.js
@@ -11,12 +11,14 @@ const SELECTOR_LEGEND = 'legend';
 const SELECTOR_FIELDSET = 'fieldset';
 const TEST_LEGEND = 'testing';
 const TEST_FIELDS_ID = 'testing';
+const TEST_HEADER_ID = 'header_test';
 
 let context = {};
 
 describe('fieldset template', () => {
 	before(async () => {
 		context.template = await fetchPartial('fieldset.html');
+		registerPartial('header', `<div id="${TEST_HEADER_ID}"></div>`);
 		registerPartial('fields', `<div id="${TEST_FIELDS_ID}"></div>`);
 	});
 
@@ -72,16 +74,22 @@ describe('fieldset template', () => {
 		expect($(SELECTOR_LEGEND).attr('class')).to.not.contain(CLASS_HEADER);
 	});
 
-	it('should add heaing class when "isHeader" is passed', () => {
+	it('should add a header when a headingLevel is passed', () => {
 		const $ = context.template({
 			legend: TEST_LEGEND,
-			isHeader: true
+			headingLevel: 'h1'
 		});
 
-		expect($(SELECTOR_LEGEND).attr('class')).to.contain(CLASS_HEADER);
+		expect($('h1').attr('class')).to.contain(CLASS_HEADER);
 	});
 
-	it('should have feilds inner partial', () => {
+	it('should have a header inner partial', () => {
+		const $ = context.template({ headingLevel: 'h1' });
+
+		expect($(`#${TEST_HEADER_ID}`).length).to.equal(1);
+	});
+
+	it('should have a fields inner partial', () => {
 		const $ = context.template({});
 
 		expect($(`#${TEST_FIELDS_ID}`).length).to.equal(1);


### PR DESCRIPTION
## Feature Description

I need to be able to pass in the heading text for a `fieldset` containing accessibility related markup.

While I was there I noticed that the partials documentation was sorely lacking so I refactored what was there and added the documentation for the `fieldset` and `loader` partials. The rest will need to be added later as there are still 25+ missing partials from this file.

For clarity, this is what the implementation would look like:

```handlebars
{{#> n-conversion-forms/partials/fieldset name="details" headingLevel="h1" }}
  {{#*inline "header"}}
    <span class="o-normalise-visually-hidden">Personal </span>Details<span class="o-normalise-visually-hidden"> (page 1 of 3)</span>
  {{/inline}}
{{/ n-conversion-forms/partials/fieldset }}
```

## Link to Ticket / Card:

https://trello.com/c/LqaflqYj/1196-accessibility-details-page-heading