### PR TITLE
Add a11y capability to the Loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,13 @@ The loader is hidden by default on page load.
 
 ```js
 loader.show();
+loader.showAndPreventTabbing();
 loader.hide();
 ```
 
 or
 
-To show loader:
+To show loader on page load/render:
 
 ```handlebars
 {{> n-conversion-forms/partials/loader showLoader=true title="Hooray!" }}
@@ -146,6 +147,7 @@ You can optionally pass in content when showing the loader:
 
 ```js
 loader.show({ title: 'Hello World!' });
+loader.showAndPreventTabbing({ title: 'Hello World!' });
 ```
 
 #### Loading Message

--- a/partials/loader.html
+++ b/partials/loader.html
@@ -1,11 +1,15 @@
-<div class="ncf__loader {{#if showLoader}}is-visible{{else}}n-ui-hide{{/if}}">
+<div class="ncf__loader {{#if showLoader}}is-visible{{else}}n-ui-hide{{/if}}"
+	role="dialog" aria-labelledby="loader-aria-label" aria-describedby="loader-aria-description"
+	aria-modal="true" {{#if showLoader}}tabindex="1"{{/if}}>
 	<div class="ncf__loader__content">
 		{{#if title}}
-			<div class="ncf__loader__content__title">
+			<div class="ncf__loader__content__title" id="loader-aria-label">
 				{{title}}
 			</div>
+		{{else}}
+			<div class="n-ui-hide" id="loader-aria-label">Loading</div>
 		{{/if}}
-		<div class="ncf__loader__content__main">
+		<div class="ncf__loader__content__main" id="loader-aria-description">
 			{{#if @partial-block}}
 				{{> @partial-block }}
 			{{/if}}

--- a/tests/partials/loader.spec.js
+++ b/tests/partials/loader.spec.js
@@ -33,21 +33,54 @@ describe('loader template', () => {
 
 	it('should allow content in the partial', () => {
 		const $ = context.template();
+
 		expect($('.ncf__loader__content__main').html().trim()).to.equal('<div>Foo Bar</div>');
 	});
 
 	it('should show loader when showLoader is set to true', () => {
 		const $ = context.template({ showLoader: true });
 
-		expect($('.is-visible').length).to.equal(1);
-		expect($('.n-ui-hide').length).to.equal(0);
+		expect($('.ncf__loader.is-visible').length).to.equal(1);
+		expect($('.ncf__loader.n-ui-hide').length).to.equal(0);
 	});
 
 	it('should hide loader when showLoader is not set', () => {
 		const $ = context.template();
 
-		expect($('.is-visible').length).to.equal(0);
-		expect($('.n-ui-hide').length).to.equal(1);
+		expect($('.ncf__loader.is-visible').length).to.equal(0);
+		expect($('.ncf__loader.n-ui-hide').length).to.equal(1);
+	});
+
+	describe('a11y', () => {
+		it('should have the appropriate dialog/modal attributes', () => {
+			const $ = context.template();
+			const $container = $('.ncf__loader');
+
+			expect($container.attr('role')).to.equal('dialog');
+			expect($container.attr('aria-modal')).to.equal('true');
+			expect($container.attr('aria-labelledby')).to.equal('loader-aria-label');
+			expect($('#loader-aria-label').length).to.equal(1);
+			expect($container.attr('aria-describedby')).to.equal('loader-aria-description');
+			expect($('#loader-aria-description').length).to.equal(1);
+		});
+
+		it('should use the title as the aria label', () => {
+			const $ = context.template({ title: 'Hooray!' });
+
+			expect($('#loader-aria-label').html().trim()).to.equal('Hooray!');
+		});
+
+		it('should show a fallback aria label if no title is passed in', () => {
+			const $ = context.template();
+
+			expect($('#loader-aria-label').html().trim()).to.equal('Loading');
+		});
+
+		it('should have the correct content in the aria description', () => {
+			const $ = context.template();
+
+			expect($('#loader-aria-description').html().trim()).to.equal('<div>Foo Bar</div>');
+		});
 	});
 
 });

--- a/tests/utils/loader.spec.js
+++ b/tests/utils/loader.spec.js
@@ -7,18 +7,20 @@ describe('Loader', () => {
 	let loader;
 	let documentStub;
 	let elementStub;
-	let addClassStub = sandbox.stub();
-	let removeClassStub = sandbox.stub();
 
 	beforeEach(() => {
 		elementStub = {
 			classList: {
-				add: addClassStub,
-				remove: removeClassStub
-			}
+				add: sandbox.stub(),
+				remove: sandbox.stub()
+			},
+			focus: sandbox.stub(),
+			removeAttribute: sandbox.stub()
 		};
 		documentStub = {
-			querySelector: sandbox.stub()
+			addEventListener: sandbox.stub(),
+			querySelector: sandbox.stub(),
+			removeEventListener: sandbox.stub()
 		};
 	});
 
@@ -69,8 +71,8 @@ describe('Loader', () => {
 		describe('show', () => {
 			it('should show the loader', () => {
 				loader.show();
-				expect(addClassStub.getCall(0).args[0]).to.equal(loader.VISIBLE_CLASS);
-				expect(removeClassStub.getCall(0).args[0]).to.equal(loader.HIDDEN_CLASS);
+				expect(elementStub.classList.add.getCall(0).args[0]).to.equal(loader.VISIBLE_CLASS);
+				expect(elementStub.classList.remove.getCall(0).args[0]).to.equal(loader.HIDDEN_CLASS);
 			});
 			it('should call setContent if content is passed', () => {
 				const content = { title: 'foo' };
@@ -84,8 +86,54 @@ describe('Loader', () => {
 		describe('hide', () => {
 			it('should hide the loader', () => {
 				loader.hide();
-				expect(addClassStub.getCall(0).args[0]).to.equal(loader.VISIBLE_CLASS);
-				expect(removeClassStub.getCall(0).args[0]).to.equal(loader.HIDDEN_CLASS);
+				expect(elementStub.classList.add.getCall(0).args[0]).to.equal(loader.HIDDEN_CLASS);
+				expect(elementStub.classList.remove.getCall(0).args[0]).to.equal(loader.VISIBLE_CLASS);
+			});
+		});
+	});
+
+	context('a11y', () => {
+		beforeEach(() => {
+			documentStub.querySelector.returns(elementStub);
+			loader = new Loader(documentStub);
+		});
+
+		describe('show', () => {
+			it('should give the loader the focus', () => {
+				loader.show();
+
+				expect(elementStub.tabIndex).to.equal(1);
+				expect(elementStub.focus.called).to.be.true;
+			});
+		});
+
+		describe('showAndPreventTabbing', () => {
+			it('should intercept tab keypresses to prevent tabbing to content underneath', () => {
+				loader.showAndPreventTabbing();
+				expect(documentStub.addEventListener.getCall(0).args[0]).to.equal('keydown');
+				expect(documentStub.addEventListener.getCall(0).args[1].name).to.equal('interceptTab');
+			});
+		});
+
+		describe('hide', () => {
+			it('should remove focus from the loader', () => {
+				loader.hide();
+
+				expect(elementStub.removeAttribute.getCall(0).args[0]).to.equal('tabindex');
+			});
+
+			it('should stop intercepting tab keypresses', () => {
+				loader.hide();
+
+				expect(documentStub.removeEventListener.getCall(0).args[0]).to.equal('keydown');
+				expect(documentStub.removeEventListener.getCall(0).args[1].name).to.equal('interceptTab');
+			});
+
+			it('should return focus to a previously focused element', () => {
+				loader.showAndPreventTabbing();
+				loader.hide();
+
+				expect(elementStub.focus.called).to.be.true;
 			});
 		});
 	});

--- a/utils/loader.js
+++ b/utils/loader.js
@@ -59,11 +59,27 @@ class Loader {
 	 * @param {object} content The optional content to set *before* showing the loader.
 	 */
 	show (content) {
+		this._previouslyFocused = document.activeElement;
+
 		if (content) {
 			this.setContent(content);
 		}
 		this.$loader.classList.add(this.VISIBLE_CLASS);
 		this.$loader.classList.remove(this.HIDDEN_CLASS);
+
+		this.$loader.tabIndex = 1;
+		this.$loader.focus();
+	}
+
+	/**
+	 * Show the loader and stop the user from being able to tab away from it or to what's underneath it.
+	 *
+	 * @param {object} content The optional content to set *before* showing the loader.
+	 */
+	showAndPreventTabbing (content) {
+		this.show(content);
+
+		this.element.addEventListener('keydown', this.interceptTab);
 	}
 
 	/**
@@ -72,6 +88,24 @@ class Loader {
 	hide () {
 		this.$loader.classList.add(this.HIDDEN_CLASS);
 		this.$loader.classList.remove(this.VISIBLE_CLASS);
+		this.$loader.removeAttribute('tabindex');
+
+		this.element.removeEventListener('keydown', this.interceptTab);
+
+		if (this._previouslyFocused) {
+			this._previouslyFocused.focus();
+			delete this._previouslyFocused;
+		}
+	}
+
+	/**
+	 * Intercepts Tab key events that normally navigate through the content on the page.
+	 * @param {object} event The event object for the keypress.
+	 */
+	interceptTab (event) {
+		if (event.keyCode === 9) {
+			event.preventDefault();
+		}
 	}
 };
 


### PR DESCRIPTION
 🐿 v2.12.3

## Feature Description

When the loader pops up, screen readers will immediately read the loader message and also prevent tabbing in the background. After the loader is done, any element that had focus previously gets its focus restored.

## Link to Ticket / Card:

https://trello.com/c/ut124coM/1171-accessibility-payment-payment-method-loading-overlay-text-underneath-overlay-is-readable-by-voiceover-confusing

## Screenshots:

![ft-a11y-loader](https://user-images.githubusercontent.com/708296/57536963-358ad100-733d-11e9-932f-b223df9df41b.gif)
