### PR TITLE
Add pattern to password for custom validation

### DIFF
--- a/partials/password.html
+++ b/partials/password.html
@@ -9,6 +9,7 @@
 					data-trackable="field-password"
 					aria-describedby="password-description"
 					aria-required="true" required
+					{{#if pattern}}pattern="{{pattern}}"{{/if}}
 					{{#if isDisabled}}disabled{{/if}}>
 		<span class="o-forms__suffix">
 			<input type="checkbox" id="showPassword" name="showPassword" class="o-forms__checkbox js-show-password__checkbox" data-trackable="field-show-password">

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -168,6 +168,22 @@ const shouldBeRequired = function (context, selector) {
 	});
 };
 
+const shouldAllowPattern = function (context, selector) {
+	it('should not have a pattern by default', () => {
+		const $ = context.template({});
+
+		expect($(selector).attr('pattern')).to.be.undefined;
+	});
+
+	it('should not have a pattern if passed', () => {
+		const $ = context.template({
+			pattern: 'test'
+		});
+
+		expect($(selector).attr('pattern')).to.equal('test');
+	});
+};
+
 const shouldContainPartials = function (context, partials) {
 	it('should contain partials', () => {
 		partials.forEach(({id, partial}) => registerPartial(partial, `<div id="${id}"></div>`));
@@ -207,6 +223,7 @@ module.exports = {
 	shouldBeDisableable,
 	shouldBeHiddable,
 	shouldBeRequired,
+	shouldAllowPattern,
 	shouldContainPartials,
 	shouldError
 };

--- a/tests/partials/password.spec.js
+++ b/tests/partials/password.spec.js
@@ -3,6 +3,7 @@ const {
 	fetchPartial,
 	shouldBeDisableable,
 	shouldBeRequired,
+	shouldAllowPattern,
 	shouldError
 } = require('../helpers');
 
@@ -43,4 +44,6 @@ describe('password template', () => {
 	shouldError(context);
 
 	shouldBeDisableable(context, 'input');
+
+	shouldAllowPattern(context, 'input');
 });


### PR DESCRIPTION
## Feature Description
Saw some error messages in our logs where the Joi validation was firing and our client side wasn't. This will allow us to set patterns to better align our validation with Joi and eventually Membership.