### PR TITLE
Remove empty values from tracking data

### DIFF
--- a/tests/utils/tracking.spec.js
+++ b/tests/utils/tracking.spec.js
@@ -81,6 +81,41 @@ describe('Tracking', () => {
 				expect(tracking.dispatchCustomEvent.getCall(0).args[0]).to.not.include({ action: 'bad', category: 'bad' });
 			});
 		});
+
+		describe('empty properties', () => {
+			const data = {
+				testUndefined: undefined,
+				testNull: null,
+				testEmptyString: '',
+				testZero: 0,
+				testFalse: false
+			};
+
+			it('should not send undefined properties', () => {
+				tracking.dispatch('test', 'test', data);
+				expect(tracking.dispatchCustomEvent.getCall(0).args[0]).to.not.include({ testUndefined: undefined });
+			});
+
+			it('should not send null properties', () => {
+				tracking.dispatch('test', 'test', data);
+				expect(tracking.dispatchCustomEvent.getCall(0).args[0]).to.not.include({ testNull: null });
+			});
+
+			it('should not send empty string properties', () => {
+				tracking.dispatch('test', 'test', data);
+				expect(tracking.dispatchCustomEvent.getCall(0).args[0]).to.not.include({ testEmptyString: '' });
+			});
+
+			it('should send zero properties', () => {
+				tracking.dispatch('test', 'test', data);
+				expect(tracking.dispatchCustomEvent.getCall(0).args[0]).to.include({ testZero: 0 });
+			});
+
+			it('should send false properties', () => {
+				tracking.dispatch('test', 'test', data);
+				expect(tracking.dispatchCustomEvent.getCall(0).args[0]).to.include({ testFalse: false });
+			});
+		});
 	});
 
 	describe('dispatchCustomEvent', () => {

--- a/utils/tracking.js
+++ b/utils/tracking.js
@@ -36,6 +36,15 @@ class Tracking {
 
 		const eventData = Object.assign({}, data, { action, category });
 
+		// Clean eventData of empty properties
+		for (const property in eventData) {
+			if (eventData[property] === undefined ||
+				eventData[property] === null ||
+				eventData[property] === '') {
+				delete eventData[property];
+			}
+		}
+
 		try {
 			return this.dispatchCustomEvent(eventData);
 		} catch (e) {


### PR DESCRIPTION
## Feature Description
Analytics has asked us to remove empty values from tracking data as it makes their extraction tables messy.

## Link to Ticket / Card:
https://trello.com/c/Oyrn3QMM/1203-1-analytics-remove-empty-values

