### PR TITLE
Fix min/max length attributes

### DIFF
--- a/partials/phone.html
+++ b/partials/phone.html
@@ -13,8 +13,8 @@
 
 	<input type="tel" id="primaryTelephone" name="primaryTelephone" value="{{value}}" placeholder="Enter your phone number"
 				class="o-forms__text js-field__input js-item__value"
-				data-min="5"
-				data-max="15"
+				minLength="5"
+				maxLength="15"
 				data-trackable="field-phone"
 				aria-describedby="phone-description"
 				aria-required="true" required


### PR DESCRIPTION
 🐿 v2.12.3

## Feature Description
The minimum and maximum validity attributes were set wrong. This led to a customer entering too short a phone number. The form submitted OK and the user was informed that they had been successful.
Meanwhile, a POST to the _Marketo_ platform happened in the background, and failed, even though the success page had already appeared. So the customer thought they were successful but marketing couldn't find their details in Marketo.

## Link to Ticket / Card:
https://trello.com/c/zIrJT8AH/864-lead-creation-bug

## Screenshots:
Before:
![image](https://user-images.githubusercontent.com/8417658/57779935-0f8b7500-771f-11e9-9406-3722e66b7dfb.png)

After:
![image](https://user-images.githubusercontent.com/8417658/57779895-fbe00e80-771e-11e9-8fbc-22a03ccde908.png)

