### PR TITLE
Add question about Design/UX to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,14 @@
 
 ## Link to Ticket / Card:
 
+
 ## Screenshots:
+
+
+## Has the necessary documentation been created / updated?
+- [ ] Yes
+- [ ] Not required for this ticket
+
+## Has this been given a review by Design/UX?
+- [ ] Yes
+- [ ] Not required for this ticket


### PR DESCRIPTION
🐿 v2.12.3

## Feature Description
As discussed in the last Retro session... this should help us (mostly me 😅) remember to run stuff past Design/UX.

## Link to Ticket / Card:

https://trello.com/c/V0Skk59N/175-add-checkbox-to-pr-template-for-design-review