### PR TITLE
Add custom validation capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,22 @@ This utility will set up the form for client side validation using [`o-forms`](h
 
 One useful property made available is the main form DOM element via `validation.$form`. Use this for scoping `querySelector` calls to find elements within your form.
 
+#### Custom Validation
+
+You can add some custom validation functionality as follows:
+
+```js
+validation.addCustomValidation({
+  errorMessage: 'Custom error message here.',
+  field: domElementToValidate,
+  validator: () => {
+    // Custom validation code here. *Must* return truthy or falsey.
+  }
+});
+```
+
+If the validation fails, the field will look like it usually does when validation fails with your specified message displayed underneath.
+
 ### Zuora
 
 The Zuora utility aims to wrap the Zuora client side library to make it more user friendly.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "chai": "^4.2.0",
     "cheerio": "^1.0.0-rc.2",
     "fetch-mock": "^7.2.0",
+    "jsdom": "15.1.0",
+    "jsdom-global": "3.0.2",
     "mocha": "^5.1.1",
     "node-sass": "^4.9.4",
     "nodemon": "^1.17.5",

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -1,0 +1,17 @@
+const createElement = (config, sandbox) => {
+	let el = document.createElement('input');
+
+	Object.keys(config).forEach((key) => {
+		if (key !== 'addEventListener') {
+			el[key] = config[key];
+		} else {
+			sandbox.stub(el, 'addEventListener').value(config[key]);
+		}
+	});
+
+	return el;
+};
+
+module.exports = {
+	createElement
+};

--- a/tests/utils/loader.spec.js
+++ b/tests/utils/loader.spec.js
@@ -3,6 +3,8 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
 
+global.document = {};
+
 describe('Loader', () => {
 	let loader;
 	let documentStub;

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -15,14 +15,14 @@ class Validation {
 		this.formChanged = false;
 		this.formSubmit = false;
 		this.mutePromptBeforeLeaving = mutePromptBeforeLeaving || false;
+		this.customValidation = new Map();
 	}
 
 	/**
 	 * Initalise
 	 */
 	init () {
-		if (!this.$form.length) return;
-
+		if (!this.$form) return;
 		for (const $el of this.$requiredEls) {
 			if (/(checkbox)/gi.test($el.type)) {
 				$el.addEventListener('change', this.checkElementValidity.bind(this, $el), false);
@@ -45,7 +45,6 @@ class Validation {
 				return this.formChanged && !this.formSubmit || null;
 			};
 		}
-
 		this.checkFormValidity();
 	}
 
@@ -58,18 +57,111 @@ class Validation {
 	}
 
 	/**
+	 * Adds a custom validation function to a given field.
+	 *
+	 * @param {DOMElement} field The field the custom validation is being added on to.
+	 * @param {Function} validator The function that will be run to determine whether the field is valid (needs to return `true` or `false`).
+	 * @param {String} errorMessage The error message to display to the user should the validation fail.
+	 */
+	addCustomValidation ({ field, validator, errorMessage}) {
+		if (this.customValidation.get(field.name)) {
+			throw new Error(`Custom validation for ${field.name} already exists.`);
+		}
+
+		this.customValidation.set(field.name, () => {
+			const id = `custom-validation-for-${field.name}`;
+			const $message = document.createElement('div');
+
+			$message.id = id;
+			$message.className = 'o-forms__errortext ncf__custom-validation-error';
+			$message.innerText = errorMessage;
+
+			const isValid = validator();
+			if (!isValid) {
+				this.showCustomFieldValidationError(field, $message);
+			} else {
+				this.clearCustomFieldValidationError(field);
+			}
+		});
+	}
+
+	/**
+	 * Displays a custom validation error message to the user.
+	 *
+	 * @param {DOMElement} $field The field for which to show a validation error.
+	 * @param {DOMElement} $message The error message to display.
+	 */
+	showCustomFieldValidationError ($field, $message) {
+		const $parent = $field.parentNode;
+		const $oFormsErrorText = $parent.querySelector('.o-forms__errortext');
+
+		$parent.classList.add('o-forms--error');
+
+		if (!document.querySelector(`#custom-validation-for-${$field.name}`)) {
+			// In order for this error to hang around after normal oForms validation happens it
+			// 	needs to exist outside the context of the field.
+			$parent.insertBefore($message, $field.nextSibling);
+		}
+
+		if ($oFormsErrorText && $oFormsErrorText.parentNode.className.indexOf('ncf__custom-validation-error') === -1) {
+			// If there's an oForms error we need to hide it so that we can use the `o-forms--error` class
+			//  on the container to highlight the field as invalid.
+			$oFormsErrorText.style.display = 'none';
+		}
+	}
+
+	/**
+	 * Clears a previously displayed custom validation error.
+	 *
+	 * @param {DOMElement} $field The field related to the error that now needs to be cleared.
+	 */
+	clearCustomFieldValidationError ($field) {
+		const $message = this.$form.querySelector(`#custom-validation-for-${$field.name}`);
+		const $oFormsErrorText = $field.parentNode.querySelector('.o-forms__errortext');
+
+		if ($message) {
+			$message.parentNode.removeChild($message);
+		}
+		if ($oFormsErrorText) {
+			$oFormsErrorText.style.display = null;
+		}
+
+		this.checkElementValidity($field);
+	}
+
+	/**
+	 * Run custom validation (if any)
+	 *
+	 * @returns {Boolean} whether or not the custom validation passed.
+	 */
+	checkCustomValidation () {
+		this.customValidation.forEach((validator) => {
+			validator();
+		});
+
+		return !document.querySelector('.ncf__custom-validation-error');
+	}
+
+	/**
 	 * Checks a single elements validity.
 	 */
 	checkElementValidity ($el) {
-		// Make sure the input element has been updated (for example if this is from a label click for a checkbox).
-		this.oForms.validateInput($el);
+		const passedCustomValidation = this.checkCustomValidation();
+
+		// If field fails custom validation don't `validateInput` as it may pass standard validation
+		if (passedCustomValidation) {
+			// Make sure the input element has been updated (for example if this is from a label click for a checkbox).
+			this.oForms.validateInput($el);
+		}
 	}
 
 	/**
 	 * Update the state of the form to reflect form validity.
 	 */
 	checkFormValidity () {
-		if (this.getInvalidEls().length === 0) {
+		const passedCustomValidation = this.checkCustomValidation();
+
+		if (passedCustomValidation && this.getInvalidEls().length === 0) {
 			this.formValid = true;
 		} else {
 			this.formValid = false;


### PR DESCRIPTION
🐿 v2.12.3

## Feature Description

This is needed for cases like the one in `next-subscribe` (see gif below) where some offerIds aren't available in all countries.

~~I'm getting this up here for review before writing documentation and tests as it feels quite messy to me and could do with optimisation (I've been staring at this problem too long).~~

## Link to Ticket / Card:

https://trello.com/c/YIg1eEwm/1194-5-behaviour-when-user-selects-a-country-subscription-is-not-available-in

## Screenshots:

![](https://user-images.githubusercontent.com/708296/57852537-4de66a00-77db-11e9-991d-d69fe1b99e44.gif)

## Has the necessary documentation been created / updated?
- [x] Yes
- [ ] Not required for this ticket

## Has this been given a review by Design/UX?
- [x] Yes
- [ ] Not required for this ticket
