### PR TITLE
Include credentials in the email exists call

### DIFF
--- a/tests/utils/email.spec.js
+++ b/tests/utils/email.spec.js
@@ -151,6 +151,7 @@ describe('Email', () => {
 			expect(fetchMock.called(url)).to.be.true;
 			expect(fetchMock.lastOptions(url)).to.deep.equal({
 				method: 'POST',
+				credentials: 'include',
 				headers: {
 					'Content-Type': 'application/json'
 				},

--- a/utils/email.js
+++ b/utils/email.js
@@ -75,6 +75,7 @@ class Email {
 		if (this.$email.value) {
 			return fetch(url, {
 				method: 'POST',
+				credentials: 'include',
 				headers: {
 					'Content-Type': 'application/json'
 				},


### PR DESCRIPTION
## Feature Description
I've got a hunch that some browsers are triggering CORs and therefore will need this option set to be able to get the cookies.

## Link to Ticket / Card:
https://trello.com/c/VphFoylC/1224-receiving-lots-of-token-mismatch-errors
