### PR TITLE
Add the confirmation page for licence subscriptions

### DIFF
--- a/demos/data.json
+++ b/demos/data.json
@@ -144,5 +144,11 @@
     "params": {
       "value": "yes"
     }
+  },
+  "licence-confirmation": {
+    "params": {
+      "isTrial": true,
+      "duration": "30 day"
+    }
   }
 }

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -44,7 +44,7 @@ This is useful for cases where you'd want to pass in markup to use within the he
 ```handlebars
 {{#> n-conversion-forms/partials/fieldset headingLevel="h1" legend="Details" hideLegend="true" }}
   {{#*inline "header"}}
-    <span class="o-normalise-visually-hidden"></span>Details<span class="o-normalise-visually-hidden"> (page 1 of 3)</span>
+    Details<span class="o-normalise-visually-hidden"> (page 1 of 3)</span>
   {{/inline}}
 {{/ n-conversion-forms/partials/fieldset }}
 ```

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -97,6 +97,7 @@ Confirmation page for subscribing to a company licence.
 
 ### Options
 
++ `isEmbedded`: boolean - Sets links to reference top frame when embedded
 + `isTrial`: boolean - Is the licence a trial or not
 + `duration`: string - How long the licence will last for
 

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -37,6 +37,20 @@ Renders a fieldset.
 
 ### Inline Partials
 
+#### header
+
+This is useful for cases where you'd want to pass in markup to use within the header element. For example, you may want to specify a more accessibility friendly header as follows:
+
+```handlebars
+{{#> n-conversion-forms/partials/fieldset headingLevel="h1" legend="Details" hideLegend="true" }}
+  {{#*inline "header"}}
+    <span class="o-normalise-visually-hidden"></span>Details<span class="o-normalise-visually-hidden"> (page 1 of 3)</span>
+  {{/inline}}
+{{/ n-conversion-forms/partials/fieldset }}
+```
+
+*NB*: The `headingLevel` option is required in order for this to work.
+
 #### fields
 
 The form fields to be displayed in this fieldset.
@@ -48,6 +62,7 @@ The form fields to be displayed in this fieldset.
   {{/inline}}
 {{/ n-conversion-forms/partials/fieldset }}
 ```
+
 ## firstname
 
 A form field for adding a user's first name.
@@ -76,19 +91,18 @@ A form field for adding a user's last name.
 {{> n-conversion-forms/partials/lastname value=Smith hasError=true isDisabled=true }}
 ```
 
-## header
+## licence-confirmation
 
-This is useful for cases where you'd want to pass in markup to use within the header element. For example, you may want to specify a more accessibility friendly header as follows:
+Confirmation page for subscribing to a company licence.
+
+### Options
+
++ `isTrial`: boolean - Is the licence a trial or not
++ `duration`: string - How long the licence will last for
 
 ```handlebars
-{{#> n-conversion-forms/partials/fieldset headingLevel="h1" legend="Details" hideLegend="true" }}
-  {{#*inline "header"}}
-    <span class="o-normalise-visually-hidden"></span>Details<span class="o-normalise-visually-hidden"> (page 1 of 3)</span>
-  {{/inline}}
-{{/ n-conversion-forms/partials/fieldset }}
+{{> n-conversion-forms/partials/licence-confirmation isTrial=true }}
 ```
-
-*NB*: The `headingLevel` option is required in order for this to work.
 
 ## Loader
 

--- a/main.scss
+++ b/main.scss
@@ -131,6 +131,10 @@
 		}
 	}
 
+	&__link {
+		@include oTypographyLink;
+	}
+
 	&__link--external {
 		@include oTypographyLinkExternal;
 	}

--- a/partials/licence-confirmation.html
+++ b/partials/licence-confirmation.html
@@ -19,10 +19,10 @@
 	</p>
 
 	<p class="ncf__paragraph ncf__center">
-		<a href="/myft" class="ncf__button ncf__button--submit">Go to myFT</a>
+		<a href="/myft" class="ncf__button ncf__button--submit"{{#if isEmbedded}} target="_top"{{/if}}>Go to myFT</a>
 	</p>
 
 	<p class="ncf__paragraph ncf__center">
-		<a href="/" class="ncf__link">Go to the homepage</a>
+		<a href="/" class="ncf__link"{{#if isEmbedded}} target="_top"{{/if}}>Go to the homepage</a>
 	</p>
 </div>

--- a/partials/licence-confirmation.html
+++ b/partials/licence-confirmation.html
@@ -1,0 +1,28 @@
+<div class="ncf ncf__wrapper">
+	<div class="ncf__center">
+		<div class="ncf__icon ncf__icon--tick ncf__icon--large"></div>
+		<div class="ncf__paragraph">
+			{{#if isTrial}}
+			<h1 class="ncf__header ncf__header--confirmation">Your{{#if duration}} {{duration}}{{/if}} trial has started</h1>
+			{{else}}
+			<h1 class="ncf__header ncf__header--confirmation">Great news, you have joined your company licence</h1>
+			{{/if}}
+		</div>
+	</div>
+
+	<p class="ncf__paragraph">
+		Go to myFT to personalise your feed & follow topics & articles of interest to you. Set this up now or later.
+	</p>
+
+	<p class="ncf__paragraph">
+		Explore the homepage & enjoy your unlimited access & exclusive content.
+	</p>
+
+	<p class="ncf__paragraph ncf__center">
+		<a href="/myft" class="ncf__button ncf__button--submit">Go to myFT</a>
+	</p>
+
+	<p class="ncf__paragraph ncf__center">
+		<a href="/" class="ncf__link">Go to the homepage</a>
+	</p>
+</div>

--- a/tests/partials/licence-confirmation.spec.js
+++ b/tests/partials/licence-confirmation.spec.js
@@ -40,4 +40,18 @@ describe('licence-confirmation template', () => {
 
 		expect($.text()).to.contain(duration);
 	});
+
+	it('should not have links with any target attribute', () => {
+		const $ = context.template({});
+
+		expect($('a[target]').length).to.equal(0);
+	});
+
+	it('should add target top to links when the form is embedded', () => {
+		const $ = context.template({
+			isEmbedded: true
+		});
+
+		expect($('a[target="_top"]').length).to.be.greaterThan(0);
+	});
 });

--- a/tests/partials/licence-confirmation.spec.js
+++ b/tests/partials/licence-confirmation.spec.js
@@ -1,0 +1,43 @@
+const { expect } = require('chai');
+const { fetchPartial } = require('../helpers');
+
+let context = {};
+
+describe('licence-confirmation template', () => {
+	before(async () => {
+		context.template = await fetchPartial('licence-confirmation.html');
+	});
+
+	it('should not mention trial by default', () => {
+		const $ = context.template({});
+
+		expect($.text()).not.to.contain('trial');
+	});
+
+	it('should mention trial when isTrial is set', () => {
+		const $ = context.template({
+			isTrial: true
+		});
+
+		expect($.text()).to.contain('trial');
+	});
+
+	it('should not include the duration if isTrial not set', () => {
+		const duration = '30 days';
+		const $ = context.template({
+			duration
+		});
+
+		expect($.text()).not.to.contain(duration);
+	});
+
+	it('should include the duration if isTrial set', () => {
+		const duration = '30 days';
+		const $ = context.template({
+			isTrial: true,
+			duration
+		});
+
+		expect($.text()).to.contain(duration);
+	});
+});


### PR DESCRIPTION
## Feature Description
This is the confirmation page for licence subscriptions

## Link to Ticket / Card:
https://trello.com/c/21YM5ELJ/1252-1-b2b-trial-confirmation-page

## Screenshots:
| Full | Trial |
| --- | --- |
| <img width="537" alt="Screenshot 2019-06-03 at 12 52 41" src="https://user-images.githubusercontent.com/1721150/58799975-a05abf80-85fe-11e9-97f9-37565dc0dd94.png"> | <img width="489" alt="Screenshot 2019-06-03 at 12 56 51" src="https://user-images.githubusercontent.com/1721150/58800195-2119bb80-85ff-11e9-8c88-fc4fba02c974.png"> |


## Has the necessary documentation been created / updated?
- [X] Yes
- [ ] Not required for this ticket

## Has this been given a review by Design/UX?
- [ ] Yes
- [ ] Not required for this ticket
