### PR TITLE
Add the continue reading component

### DIFF
--- a/demos/data.json
+++ b/demos/data.json
@@ -150,5 +150,11 @@
       "isTrial": true,
       "duration": "30 day"
     }
+  },
+  "continue-reading": {
+    "params": {
+      "quote": "The quick brown fox jumped over the lazy hare",
+      "link": "https://google.com"
+    }
   }
 }

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -2,6 +2,7 @@
 
 ## Content
 
+* [Continue Reading](#continue-reading)
 * [Decision Maker](#decision-maker)
 * [Fieldset](#fieldset)
 * [Firstname](#firstname)
@@ -10,6 +11,19 @@
 * [Loader](#loader)
 * [Message](#message)
 * [Phone](#phone)
+
+## Continue Reading
+
+A message to inform the user they can read an article once they've subscribed.
+
+```handlebars
+{{> n-conversion-forms/partials/continue-reading  }}
+```
+
+### Options
++ `isEmbedded`: boolean - Sets links to reference top frame when embedded.
++ `quote`: string - Title displayed between the quote marks.
++ `link`: string - Location of the continue reading button.
 
 ## Decision Maker
 

--- a/main.scss
+++ b/main.scss
@@ -12,6 +12,7 @@
 @import './styles/payment-type';
 @import './styles/loader';
 @import './styles/message';
+@import './styles/continue-reading';
 @import 'o-fonts/main';
 
 @include oFonts();
@@ -257,6 +258,7 @@
 	@include ncfPaymentTerm();
 	@include ncfPaymentType();
 	@include ncfLoader();
+	@include ncfContinueReading();
 
 	@include ncfPaymentApplePay();
 

--- a/partials/continue-reading.html
+++ b/partials/continue-reading.html
@@ -1,0 +1,13 @@
+<div class="ncf__continue-reading-wrapper">
+	{{#if link}}
+	<p class="ncf__continue-reading-title">You can now continue reading:</p>
+	{{else}}
+	<p class="ncf__continue-reading-title">Become an FT subscriber to read:</p>
+	{{/if}}
+	<blockquote class="ncf__continue-reading-quote">{{quote}}</blockquote>
+	{{#if link}}
+	<p class="ncf__center">
+		<a href="{{link}}"{{#if isEmbedded}} target="_top"{{/if}} class="ncf__button ncf__button--secondary">Continue reading</a>
+	</p>
+	{{/if}}
+</div>

--- a/styles/continue-reading.scss
+++ b/styles/continue-reading.scss
@@ -1,0 +1,38 @@
+@mixin ncfContinueReading() {
+	&__continue-reading-wrapper {
+		padding: 14px;
+		background-color: oColorsGetPaletteColor('paper');
+	}
+
+	&__continue-reading-title {
+		@include oTypographySans($scale: -1);
+		padding: 0;
+		margin: 0 0 14px;
+	}
+
+	&__continue-reading-quote {
+		@include oTypographyDisplay($scale: 1, $line-height: 23px);
+		font-weight: oFontsWeight('semibold');
+		margin: 0;
+		padding: 0 12px;
+		position: relative;
+		z-index: 1;
+
+		&::after,
+		&::before {
+			z-index: -1;
+			content: '';
+			position: absolute;
+			margin-left: -15px;
+		}
+
+		&::before {
+			@include oIconsGetIcon('speech-left', oColorsGetPaletteColor('black-10'), 30);
+			top: -8px;
+		}
+
+		&::after {
+			@include oIconsGetIcon('speech-right', oColorsGetPaletteColor('black-10'), 30);
+		}
+	}
+}

--- a/tests/partials/continue-reading.spec.js
+++ b/tests/partials/continue-reading.spec.js
@@ -1,0 +1,53 @@
+const { expect } = require('chai');
+const { fetchPartial } = require('../helpers');
+
+let context = {};
+
+describe('continue-reading template', () => {
+	before(async () => {
+		context.template = await fetchPartial('continue-reading.html');
+	});
+
+	it('should display the given quote', () => {
+		const quote = 'This is the given quote';
+		const $ = context.template({
+			quote
+		});
+
+		expect($.text()).to.contain(quote);
+	});
+
+	it('should not display a link by default', () => {
+		const $ = context.template({});
+
+		expect($('a').length).to.equal(0);
+	});
+
+	it('should display a link if passed', () => {
+		const link = 'https://google.com';
+		const $ = context.template({
+			link
+		});
+
+		expect($('a').attr('href')).to.equal(link);
+	});
+
+	it('should not have links with any target attribute', () => {
+		const link = 'https://google.com';
+		const $ = context.template({
+			link
+		});
+
+		expect($('a[target]').length).to.equal(0);
+	});
+
+	it('should add target top to links when the form is embedded', () => {
+		const link = 'https://google.com';
+		const $ = context.template({
+			link,
+			isEmbedded: true
+		});
+
+		expect($('a[target="_top"]').length).to.be.greaterThan(0);
+	});
+});


### PR DESCRIPTION
## Feature Description
Display the content article the user was reading including a link if they can read it.

## Link to Ticket / Card:
https://trello.com/c/ADGmnXnY/1268-1-content-message-on-b2b-trial-form

## Screenshots:
<img width="472" alt="Screenshot 2019-06-04 at 09 37 40" src="https://user-images.githubusercontent.com/1721150/58865190-04888c80-86ae-11e9-9152-bd54053eec8f.png">
<img width="351" alt="Screenshot 2019-06-04 at 09 43 48" src="https://user-images.githubusercontent.com/1721150/58865194-06525000-86ae-11e9-851d-d3727e19dbf7.png">



## Has the necessary documentation been created / updated?
- [ ] Yes
- [X] Not required for this ticket

## Has this been given a review by Design/UX?
- [ ] Yes
- [ ] Not required for this ticket
