### PR TITLE
Add the app banner partial and utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ import MyModule from 'n-conversion-forms/utils/my-module';
 
 ### Table of contents
 
+* [AppBanner](#app-banner)
 * [Country](#country)
 * [Email](#email)
 * [Event Notifier](#event-notifier)
@@ -69,6 +70,14 @@ import MyModule from 'n-conversion-forms/utils/my-module';
 * [Tracking](#tracking)
 * [Validation](#validation)
 * [Zuora](#zuora)
+
+### AppBanner
+
+```js
+new AppBanner(window);
+```
+
+Simple utility to use in conjunction with the `app-banner` partial that performs user agent sniffing. It will remove the App Store or Play Store link which ever is not relevant for the platform the user is on.
 
 ### Country
 

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -2,6 +2,7 @@
 
 ## Content
 
+* [App Banner](#app-banner)
 * [Continue Reading](#continue-reading)
 * [Decision Maker](#decision-maker)
 * [Fieldset](#fieldset)
@@ -11,6 +12,14 @@
 * [Loader](#loader)
 * [Message](#message)
 * [Phone](#phone)
+
+## App Banner
+
+Banner that appears on confirmation pages to inform the user of our App
+
+```handlebars
+{{> n-conversion-forms/partials/app-banner }}
+```
 
 ## Continue Reading
 

--- a/main.scss
+++ b/main.scss
@@ -13,6 +13,7 @@
 @import './styles/loader';
 @import './styles/message';
 @import './styles/continue-reading';
+@import './styles/app-banner';
 @import 'o-fonts/main';
 
 @include oFonts();
@@ -259,6 +260,7 @@
 	@include ncfPaymentType();
 	@include ncfLoader();
 	@include ncfContinueReading();
+	@include ncfAppBanner();
 
 	@include ncfPaymentApplePay();
 

--- a/partials/app-banner.html
+++ b/partials/app-banner.html
@@ -1,0 +1,19 @@
+<div id="appBanner" class="ncf__app-banner">
+	<div class="ncf__app-banner-inner">
+		<div class="ncf__app-banner-image">
+			<img alt="FT app" src="https://www.ft.com/__origami/service/image/v2/images/raw/https://s3-eu-west-1.amazonaws.com/envoy-b2b-trial/phone.png?source=ip-envoy" />
+		</div>
+		<div class="ncf__app-banner-content">
+			<h2 class="ncf__app-banner-header">Get our free App</h2>
+			Download the <span class="ncf__app-banner-strong">FT app</span> to access articles on the move.
+		</div>
+		<div class="ncf__app-banner-actions">
+			<div class="ncf__app-banner-action ncf__app-banner-action--ios">
+				<a href="https://itunes.apple.com/app/apple-store/id1200842933?pt=246269&ct=onsite-app-promotion&mt=8" target="_blank" role="link"><img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg" alt="Download from the iOS App store" height="35"></a>
+			</div>
+			<div class="ncf__app-banner-action ncf__app-banner-action--android">
+				<a href="https://play.google.com/store/apps/details?id=com.ft.news&referrer=utm_source%3Donsite-app-promotion%26utm_campaign%3DOnsite%2520Messaging" target="_blank" role="link"><img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy" height="35" alt="Download on Google Play"></a>
+			</div>
+		</div>
+	</div>
+</div>

--- a/styles/app-banner.scss
+++ b/styles/app-banner.scss
@@ -1,0 +1,53 @@
+@mixin ncfAppBanner() {
+	&__app-banner {
+		background: oColorsGetPaletteColor('wheat');
+		border-top: 1px solid oColorsGetPaletteColor('black-10');
+		border-bottom: 1px solid oColorsGetPaletteColor('black-10');
+
+		&-inner {
+			display: grid;
+			grid-template-columns: 100px 1fr;
+			grid-template-rows: 1fr 1fr;
+			column-gap: 14px;
+			overflow: hidden;
+			max-width: 700px;
+			align-items: center;
+			margin: 0 auto;
+			padding: 10px;
+
+			@include oGridRespondTo($from: M) {
+				grid-template-columns: 100px 1fr 240px;
+				grid-template-rows: 140px;
+			}
+		}
+
+		&-image {
+
+			img {
+				width: 100px;
+			}
+
+			@include oGridRespondTo($until: M) {
+				grid-row: span 2;
+			}
+		}
+
+		&-strong {
+			font-weight: oFontsWeight('semibold');
+		}
+
+		&-header {
+			@include oTypographySize(0);
+			font-weight: oFontsWeight('semibold');
+			margin: 0 0 4px;
+		}
+
+		&-action {
+			display: inline-block;
+
+			a {
+				border: 0;
+			}
+		}
+	}
+}

--- a/tests/partials/app-banner.spec.js
+++ b/tests/partials/app-banner.spec.js
@@ -1,0 +1,16 @@
+const { expect } = require('chai');
+const { fetchPartial } = require('../helpers');
+
+let context = {};
+
+describe('app-banner template', () => {
+	before(async () => {
+		context.template = await fetchPartial('app-banner.html');
+	});
+
+	it('should compile', () => {
+		expect(() => {
+			context.template({});
+		}).to.not.throw();
+	});
+});

--- a/tests/utils/app-banner.spec.js
+++ b/tests/utils/app-banner.spec.js
@@ -1,0 +1,62 @@
+const AppBanner = require('../../utils/app-banner');
+const expect = require('chai').expect;
+const sandbox = require('sinon').createSandbox();
+
+describe('Apple Pay', () => {
+	let window;
+	let element;
+	let iosAction;
+	let androidAction;
+
+	beforeEach(() => {
+		iosAction = { remove: sandbox.stub() };
+		androidAction = { remove: sandbox.stub() };
+		element = { querySelector: sandbox.stub() };
+		window = { document: { querySelector: sandbox.stub().returns(element) }, navigator: { userAgent: '' } };
+
+		element.querySelector.withArgs('.ncf__app-banner-action--android').returns(androidAction);
+		element.querySelector.withArgs('.ncf__app-banner-action--ios').returns(iosAction);
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	describe('constructor', () => {
+		it('should throw an error if window not provided', () => {
+			expect(() => {
+				new AppBanner();
+			}).to.throw();
+		});
+
+		it('should throw an error if banner not found', () => {
+			window.document.querySelector.returns(false);
+			expect(() => {
+				new AppBanner(window);
+			}).to.throw();
+		});
+
+		it('should not remove any actions if the user agent isn\'t sniffed', () => {
+			new AppBanner(window);
+
+			expect(iosAction.remove.called).to.be.false;
+			expect(androidAction.remove.called).to.be.false;
+		});
+
+		it('should remove ios action if the user agent is android', () => {
+			window.navigator.userAgent = 'android';
+			new AppBanner(window);
+
+			expect(iosAction.remove.called).to.be.true;
+			expect(androidAction.remove.called).to.be.false;
+		});
+
+		it('should remove android action if the user agent is ios', () => {
+			window.navigator.userAgent = 'iphone';
+			new AppBanner(window);
+
+			expect(iosAction.remove.called).to.be.false;
+			expect(androidAction.remove.called).to.be.true;
+		});
+	});
+});

--- a/utils/app-banner.js
+++ b/utils/app-banner.js
@@ -1,0 +1,25 @@
+class AppBanner {
+	constructor (window) {
+		if (!window) {
+			throw new Error('Please supply a Window object');
+		}
+
+		this.$banner = window.document.querySelector('.ncf__app-banner');
+
+		if (!this.$banner) {
+			throw new Error('Please include the app banner partial on the page');
+		}
+
+		this.$androidAction = this.$banner.querySelector('.ncf__app-banner-action--android');
+		this.$iosAction = this.$banner.querySelector('.ncf__app-banner-action--ios');
+
+		// If user agent can be detected remove the action that's not needed
+		if (/(android)/i.test(window.navigator.userAgent)) {
+			this.$iosAction.remove();
+		} else if (/(ipad|iphone|ipod)/i.test(window.navigator.userAgent)) {
+			this.$androidAction.remove();
+		}
+	}
+}
+
+module.exports = AppBanner;


### PR DESCRIPTION
## Feature Description
Banner and utility are part of the corp signup b2b work. These can easily be ported across to work in the next-subscribe work.

## Link to Ticket / Card:
https://trello.com/c/GIAR14DQ/1253-5-add-bottom-app-banner-to-confirmation-page

## Screenshots:
<img width="547" alt="Screenshot 2019-06-05 at 17 35 11" src="https://user-images.githubusercontent.com/1721150/58973631-50bff380-87b8-11e9-99a9-6abfb6b20fac.png">
<img width="998" alt="Screenshot 2019-06-05 at 17 35 19" src="https://user-images.githubusercontent.com/1721150/58973637-5289b700-87b8-11e9-9ac5-202b7be9c868.png">



## Has the necessary documentation been created / updated?
- [X] Yes
- [ ] Not required for this ticket

## Has this been given a review by Design/UX?
- [X] Yes
- [ ] Not required for this ticket
