### PR TITLE
Added trial banner to be used in next-corp-signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ import MyModule from 'n-conversion-forms/utils/my-module';
 ### Table of contents
 
 * [AppBanner](#app-banner)
+* [TrialBanner](#trial-banner)
 * [Country](#country)
 * [Email](#email)
 * [Event Notifier](#event-notifier)
@@ -78,6 +79,11 @@ new AppBanner(window);
 ```
 
 Simple utility to use in conjunction with the `app-banner` partial that performs user agent sniffing. It will remove the App Store or Play Store link which ever is not relevant for the platform the user is on.
+
+### TrialBanner
+
+Displays banner for trial only. Designed to take in dynamic period `trialDuration`. If period is not present, then default 30 day period would be used  
+
 
 ### Country
 

--- a/main.scss
+++ b/main.scss
@@ -13,7 +13,7 @@
 @import './styles/loader';
 @import './styles/message';
 @import './styles/continue-reading';
-@import './styles/app-banner';
+@import './styles/banner';
 @import 'o-fonts/main';
 
 @include oFonts();
@@ -260,7 +260,7 @@
 	@include ncfPaymentType();
 	@include ncfLoader();
 	@include ncfContinueReading();
-	@include ncfAppBanner();
+	@include ncfBanner();
 
 	@include ncfPaymentApplePay();
 

--- a/partials/trial-banner.html
+++ b/partials/trial-banner.html
@@ -1,0 +1,5 @@
+<div id="trialBanner" class="ncf__trial-banner">
+		<p class="o-message__content-main ncf__trial-banner-no-margin">Your free <span class="ncf__strong" >{{#if trialDuration}}{{trialDuration}}{{else}}30{{/if}}</span> day FT.com trial
+			<img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2Fassets%2Fb2b%2Fmacron-desktop-banner.png?source=conversion&height=40" class="ncf__trial-banner-img">
+		</p>
+</div>

--- a/partials/trial-banner.html
+++ b/partials/trial-banner.html
@@ -1,5 +1,5 @@
 <div id="trialBanner" class="ncf__trial-banner">
-		<p class="o-message__content-main ncf__trial-banner-no-margin">Your free <span class="ncf__strong" >{{#if trialDuration}}{{trialDuration}}{{else}}30{{/if}}</span> day FT.com trial
+		<p class="ncf__trial-banner-content">Your free {{#if trialDuration}}<span class="ncf__strong" >{{trialDuration}} </span>{{/if}}FT.com trial
 			<img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2Fassets%2Fb2b%2Fmacron-desktop-banner.png?source=conversion&height=40" class="ncf__trial-banner-img">
 		</p>
 </div>

--- a/partials/trial-banner.html
+++ b/partials/trial-banner.html
@@ -1,5 +1,5 @@
 <div id="trialBanner" class="ncf__trial-banner">
-		<p class="ncf__trial-banner-content">Your free {{#if trialDuration}}<span class="ncf__strong" >{{trialDuration}} </span>{{/if}}FT.com trial
+		<p class="ncf__trial-banner-content">Your free {{#if trialDuration}}<span class="ncf__strong">{{trialDuration}}</span> {{/if}}FT.com trial
 			<img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2Fassets%2Fb2b%2Fmacron-desktop-banner.png?source=conversion&height=40" class="ncf__trial-banner-img">
 		</p>
 </div>

--- a/styles/app-banner.scss
+++ b/styles/app-banner.scss
@@ -1,4 +1,26 @@
 @mixin ncfAppBanner() {
+
+	&__trial-banner {
+		@include oTypographySerif($scale: 0);
+		background-color: #262A33;
+		color: white;
+		text-align: center;
+		line-height: 40px;
+
+		&-img {
+			vertical-align: middle;
+			margin: 0 0 0 30px;
+
+			@include oGridRespondTo($until: S) {
+				display: none;
+			}
+		}
+
+		&-no-margin {
+			margin: 0;
+		}
+	}
+
 	&__app-banner {
 		background: oColorsGetPaletteColor('wheat');
 		border-top: 1px solid oColorsGetPaletteColor('black-10');

--- a/styles/banner.scss
+++ b/styles/banner.scss
@@ -1,4 +1,4 @@
-@mixin ncfAppBanner() {
+@mixin ncfBanner() {
 
 	&__trial-banner {
 		@include oTypographySerif($scale: 0);
@@ -16,7 +16,7 @@
 			}
 		}
 
-		&-no-margin {
+		&-content {
 			margin: 0;
 		}
 	}

--- a/tests/partials/trial-banner.spec.js
+++ b/tests/partials/trial-banner.spec.js
@@ -1,0 +1,16 @@
+const { expect } = require('chai');
+const { fetchPartial } = require('../helpers');
+
+let context = {};
+
+describe('trial-banner template', () => {
+	before(async () => {
+		context.template = await fetchPartial('trial-banner.html');
+	});
+
+	it('should compile', () => {
+		expect(() => {
+			context.template({});
+		}).to.not.throw();
+	});
+});

--- a/tests/partials/trial-banner.spec.js
+++ b/tests/partials/trial-banner.spec.js
@@ -13,4 +13,12 @@ describe('trial-banner template', () => {
 			context.template({});
 		}).to.not.throw();
 	});
+
+	it('should check the yes input if yes passed as value', () => {
+		const $ = context.template({
+			trialDuration: '999 day'
+		});
+
+		expect($.text()).to.contain('Your free 999 day FT.com trial');
+	});
 });


### PR DESCRIPTION
 🐿 v2.12.3

## Feature Description
Added banner with new design for next-corp-signup

## Link to Ticket / Card:
https://trello.com/c/WF2pSe2e/1240-1-add-top-banner-for-b2b-trial-forms

## Screenshots:
Narrow view:
<img width="332" alt="Screenshot 2019-06-06 at 12 37 08" src="https://user-images.githubusercontent.com/26438424/59033318-5a9d3180-8860-11e9-8a8a-cb6fcd44ff9a.png">
Wide view:
<img width="594" alt="Screenshot 2019-06-06 at 12 36 58" src="https://user-images.githubusercontent.com/26438424/59033339-64269980-8860-11e9-8501-d3277b505ccc.png">


## Has the necessary documentation been created / updated?
- [x] Yes
- [ ] Not required for this ticket

## Has this been given a review by Design/UX?
- [x] Yes
- [ ] Not required for this ticket
