### PR TITLE
Add the discount label for payment terms

### DIFF
--- a/demos/data.json
+++ b/demos/data.json
@@ -61,6 +61,11 @@
           "value": "Test 1",
           "description": "The <strong>quick</strong> brown fox<br />jumped over the lazy <a href=\"#\">hare</a>.",
           "selected": true
+        }, {
+          "name": "Test 2",
+          "value": "Test 2",
+          "description": "The <strong>quick</strong> brown fox<br />jumped over the lazy <a href=\"#\">hare</a>.",
+          "discount": "25%"
         }
       ]
     }

--- a/partials/payment-term.html
+++ b/partials/payment-term.html
@@ -1,12 +1,17 @@
 <div id="paymentTermField" class="o-forms__group ncf__payment-term">
 	{{#each options}}
-	<input type="radio" id="{{this.value}}" name="paymentTerm" value="{{this.value}}" class="o-forms__radio o-forms__radio--right ncf__payment-term__input o-forms__radio-button--my-custom-theme" {{#if this.selected}} checked="checked" {{/if}}>
-	<label for="{{this.value}}" class="o-forms__label ncf__payment-term__label">
-		<span class="ncf__payment-term__label--title">{{this.name}}</span>
-		<div class="ncf__payment-term__label--description">
-			{{{this.description}}}
-		</div>
-	</label>
+	<div class="ncf__payment-term__item{{#if discount}} ncf__payment-term__item--discount{{/if}}">
+		<input type="radio" id="{{this.value}}" name="paymentTerm" value="{{this.value}}" class="o-forms__radio o-forms__radio--right ncf__payment-term__input o-forms__radio-button--my-custom-theme" {{#if this.selected}} checked="checked" {{/if}}>
+		<label for="{{this.value}}" class="o-forms__label ncf__payment-term__label">
+			{{#if discount}}
+			<span class="ncf__payment-term__discount">Save {{this.discount}}</span>
+			{{/if}}
+			<span class="ncf__payment-term__title">{{this.name}}</span>
+			<div class="ncf__payment-term__description">
+				{{{this.description}}}
+			</div>
+		</label>
+	</div>
 	{{/each}}
 	<div class="ncf__payment-term__legal">
 		<p>

--- a/styles/payment-term.scss
+++ b/styles/payment-term.scss
@@ -35,13 +35,43 @@
 			}
 		}
 
-		&__label--title {
+		&__item {
+			margin-bottom: 10px;
+
+			&--discount {
+				margin-top: 26px;
+			}
+		}
+
+		&__title {
 			font-weight: oFontsWeight('semibold');
 			@include oTypographySans($scale: 2);
 		}
 
-		&__label--description {
+		&__description {
 			padding-top: 14px;
+		}
+
+		&__discount {
+			background-color: oColorsGetPaletteColor('black');
+			color: oColorsGetPaletteColor('white');
+			position: absolute;
+			padding: 8px 16px;
+			right: -11px;
+			top: -21px;
+
+			&::after {
+				content: '';
+				width: 0;
+				height: 0;
+				border-top: 6px solid transparent;
+				border-bottom: 6px solid transparent;
+				border-right: 6px solid oColorsGetPaletteColor('black-70');
+				transform: rotate(45deg);
+				position: absolute;
+				bottom: -8px;
+				right: 4px;
+			}
 		}
 
 		&__legal {

--- a/tests/partials/payment-term.spec.js
+++ b/tests/partials/payment-term.spec.js
@@ -28,19 +28,19 @@ describe('payment-term', () => {
 	it('should populate the name', () => {
 		const name = 'Test';
 		const $ = context.template({ options: [{ name }]});
-		expect($('.ncf__payment-term__label--title').text()).to.equal(name);
+		expect($('.ncf__payment-term__title').text()).to.equal(name);
 	});
 
 	it('should populate the description', () => {
 		const description = 'Test';
 		const $ = context.template({ options: [{ description }]});
-		expect($('.ncf__payment-term__label--description').text()).to.contain(description);
+		expect($('.ncf__payment-term__description').text()).to.contain(description);
 	});
 
 	it('should allow HTML in the description', () => {
 		const description = 'Test with an <a>anchor</a>';
 		const $ = context.template({ options: [{ description }]});
-		expect($('.ncf__payment-term__label--description a').length).to.equal(1);
+		expect($('.ncf__payment-term__description a').length).to.equal(1);
 	});
 
 	it('should populate the value', () => {
@@ -56,5 +56,19 @@ describe('payment-term', () => {
 		const option2 = { value: 'option2', selected: true };
 		const $ = context.template({ options: [option1, option2]});
 		expect($('input[checked]').attr('value')).to.equal(option2.value);
+	});
+
+	it('should not have discount text by default', () => {
+		const option1 = { value: 'option1' };
+		const option2 = { value: 'option2', selected: true };
+		const $ = context.template({ options: [option1, option2]});
+		expect($('.ncf__payment-term__discount').length).to.equal(0);
+	});
+
+	it('should have discount text if a discount is passed', () => {
+		const option1 = { value: 'option1', discount: '25%' };
+		const option2 = { value: 'option2', selected: true };
+		const $ = context.template({ options: [option1, option2]});
+		expect($('.ncf__payment-term__discount').length).to.equal(1);
 	});
 });


### PR DESCRIPTION
## Feature Description
Allows us to display discounted offers

## Link to Ticket / Card:
https://trello.com/c/vGowLNS4/1214-5-sale-price-shown-on-payment-page

## Screenshots:
<img width="893" alt="Screenshot 2019-06-06 at 16 17 14" src="https://user-images.githubusercontent.com/1721150/59044746-9511c900-8876-11e9-9020-4290cfd3250d.png">


## Has the necessary documentation been created / updated?
- [X] Yes
- [ ] Not required for this ticket

## Has this been given a review by Design/UX?
- [X] Yes
- [ ] Not required for this ticket
