### PR TITLE
Tweak font size and padding on discount label

### DIFF
--- a/styles/payment-term.scss
+++ b/styles/payment-term.scss
@@ -56,9 +56,10 @@
 			background-color: oColorsGetPaletteColor('black');
 			color: oColorsGetPaletteColor('white');
 			position: absolute;
-			padding: 8px 16px;
+			padding: 6px 16px;
 			right: -11px;
-			top: -21px;
+			top: -17px;
+			@include oTypographySize($scale: -1);
 
 			&::after {
 				content: '';


### PR DESCRIPTION
## Feature Description
After implementation it was needed to be tweaked a little.

## Link to Ticket / Card:
https://trello.com/c/vGowLNS4/1214-5-sale-price-shown-on-payment-page

## Screenshots:
<img width="885" alt="Screenshot 2019-06-07 at 14 32 04" src="https://user-images.githubusercontent.com/1721150/59107665-0ca42e80-8931-11e9-8e21-8b26953ae007.png">

## Has the necessary documentation been created / updated?
- [ ] Yes
- [X] Not required for this ticket

## Has this been given a review by Design/UX?
- [X] Yes
- [ ] Not required for this ticket
