### PR TITLE
Add logout button to the debug helper

### DIFF
--- a/partials/debug.html
+++ b/partials/debug.html
@@ -11,6 +11,7 @@
 	</span>
 	{{#if showHelpers}}
 	<span class="ncf__debug-helpers">
+		<button class="ncf__button ncf__button--inverse" onclick="logout();" title="Logout and refresh">Logout</button>
 		<button class="ncf__button ncf__button--inverse" onclick="fillForm();" title="Fill form with debug data">Fill</button>
 		<button class="ncf__button ncf__button--inverse" onclick="fillForm(); submitForm();" title="Fill form with debug data and submit">Fill & Submit</button>
 		{{#if isTest}}
@@ -44,6 +45,16 @@
 		responsibility: 'ADL',
 		position: 'AS'
 	};
+
+	function logout () {
+		const options = {
+			mode: 'no-cors',
+			credentials: 'include'
+		};
+		fetch('https://www.ft.com/logout', options).then(function () {
+			window.location.reload();
+		});
+	}
 
 	function fillForm () {
 		var inputs = document.querySelectorAll(FORM_SELECTOR + ' input, ' + FORM_SELECTOR + ' select');


### PR DESCRIPTION
## Feature Description
Ever opened a new tab to go to `ft.com/logout` to then close the tab and refresh your page to remove a stale session? NO MORE!

Hit the logout button in the helper and it will run a logout request in the background, then refresh the page for you in an anonymous state!
