### PR TITLE
Move all payment term copy into partial

### DIFF
--- a/partials/payment-term.html
+++ b/partials/payment-term.html
@@ -1,15 +1,40 @@
 <div id="paymentTermField" class="o-forms__group ncf__payment-term">
 	{{#each options}}
 	<div class="ncf__payment-term__item{{#if discount}} ncf__payment-term__item--discount{{/if}}">
-		<input type="radio" id="{{this.value}}" name="paymentTerm" value="{{this.value}}" class="o-forms__radio o-forms__radio--right ncf__payment-term__input o-forms__radio-button--my-custom-theme" {{#if this.selected}} checked="checked" {{/if}}>
+		<input type="radio" id="{{this.value}}" name="paymentTerm" value="{{this.value}}" class="o-forms__radio o-forms__radio--right ncf__payment-term__input o-forms__radio-button--my-custom-theme"{{#if this.selected}} checked="checked"{{/if}}>
 		<label for="{{this.value}}" class="o-forms__label ncf__payment-term__label">
 			{{#if discount}}
 			<span class="ncf__payment-term__discount">Save {{this.discount}}</span>
 			{{/if}}
-			<span class="ncf__payment-term__title">{{this.name}}</span>
+
+			{{#ifEquals this.name 'trial'}}
+			<span class="ncf__payment-term__title">Try the FT</span>
 			<div class="ncf__payment-term__description">
-				{{{this.description}}}
+				4 weeks for {{trialPrice}}<br />unless you cancel during your trial you will be billed {{price}} per month after the trial period
 			</div>
+			{{/ifEquals}}
+
+			{{#ifEquals this.name 'annual'}}
+			<span class="ncf__payment-term__title">Pay annually</span>
+			<div class="ncf__payment-term__description">
+				Single <span class="ncf__strong">{{price}}</span> payment
+				{{#unless discount}}<br />Save up to 25% when you pay annually{{/unless}}
+			</div>
+			{{/ifEquals}}
+
+			{{#ifEquals this.name 'quarterly'}}
+			<span class="ncf__payment-term__title">Pay quarterly</span>
+			<div class="ncf__payment-term__description">
+				{{price}} per quarter
+			</div>
+			{{/ifEquals}}
+
+			{{#ifEquals this.name 'monthly'}}
+			<span class="ncf__payment-term__title">Pay monthly</span>
+			<div class="ncf__payment-term__description">
+				{{price}} per month
+			</div>
+			{{/ifEquals}}
 		</label>
 	</div>
 	{{/each}}

--- a/tests/partials/payment-term.spec.js
+++ b/tests/partials/payment-term.spec.js
@@ -4,6 +4,8 @@ const {
 } = require('../helpers');
 
 let context = {};
+const TITLE_SELECTOR = '.ncf__payment-term__title';
+const DESCRIPTION_SELECTOR = '.ncf__payment-term__description';
 
 describe('payment-term', () => {
 	before(async () => {
@@ -25,22 +27,114 @@ describe('payment-term', () => {
 		expect($('input').length).to.equal(3);
 	});
 
-	it('should populate the name', () => {
-		const name = 'Test';
-		const $ = context.template({ options: [{ name }]});
-		expect($('.ncf__payment-term__title').text()).to.equal(name);
+	describe('trial', () => {
+		it('should show the correct title copy', () => {
+			const name = 'trial';
+			const $ = context.template({ options: [{
+				name
+			}]});
+			expect($(TITLE_SELECTOR).text()).to.equal('Try the FT');
+		});
+
+		it('should show the price', () => {
+			const name = 'trial';
+			const price = '£1.01';
+			const $ = context.template({ options: [{
+				name,
+				price
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.contain(price);
+		});
+
+		it('should show the trial price', () => {
+			const name = 'trial';
+			const price = '£1.01';
+			const trialPrice = '£2.01';
+			const $ = context.template({ options: [{
+				name,
+				price,
+				trialPrice
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.contain(trialPrice);
+		});
 	});
 
-	it('should populate the description', () => {
-		const description = 'Test';
-		const $ = context.template({ options: [{ description }]});
-		expect($('.ncf__payment-term__description').text()).to.contain(description);
+	describe('annual', () => {
+		it('should show the correct title copy', () => {
+			const name = 'annual';
+			const $ = context.template({ options: [{
+				name
+			}]});
+			expect($(TITLE_SELECTOR).text()).to.contain('annually');
+		});
+
+		it('should show the price', () => {
+			const name = 'annual';
+			const price = '£1.01';
+			const $ = context.template({ options: [{
+				name,
+				price
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.contain(price);
+		});
+
+		it('should show discount copy if not discounted', () => {
+			const name = 'annual';
+			const $ = context.template({ options: [{
+				name
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.contain('Save up to');
+		});
+
+		it('should not show discount copy if discounted', () => {
+			const name = 'annual';
+			const discount = '25%';
+			const $ = context.template({ options: [{
+				name,
+				discount
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.not.contain('Save up to');
+		});
 	});
 
-	it('should allow HTML in the description', () => {
-		const description = 'Test with an <a>anchor</a>';
-		const $ = context.template({ options: [{ description }]});
-		expect($('.ncf__payment-term__description a').length).to.equal(1);
+	describe('quarterly', () => {
+		it('should show the correct title copy', () => {
+			const name = 'quarterly';
+			const $ = context.template({ options: [{
+				name
+			}]});
+			expect($(TITLE_SELECTOR).text()).to.contain('quarterly');
+		});
+
+		it('should show the price', () => {
+			const name = 'quarterly';
+			const price = '£1.01';
+			const $ = context.template({ options: [{
+				name,
+				price
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.contain(price);
+		});
+	});
+
+	describe('monthly', () => {
+		it('should show the correct title copy', () => {
+			const name = 'monthly';
+			const $ = context.template({ options: [{
+				name
+			}]});
+			expect($(TITLE_SELECTOR).text()).to.contain('monthly');
+		});
+
+		it('should show the price', () => {
+			const name = 'monthly';
+			const price = '£1.01';
+			const $ = context.template({ options: [{
+				name,
+				price
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.contain(price);
+		});
 	});
 
 	it('should populate the value', () => {


### PR DESCRIPTION
## Feature Description
Moves all the static copy about payment terms into the template and out of next-subscribe. This makes this module more portable but also removes some templating work out of next-subscribe.

This also implements the feature in the card where we show extra copy for the annual term if not discounted.

Implemented with https://github.com/Financial-Times/next-subscribe/pull/412

## Link to Ticket / Card:
https://trello.com/c/TSVDTwjG/1205-3-add-save-25-terms-copy-when-not-a-sale-offer

