### PR TITLE
Fix updateOptions method of payment terms util

### DIFF
--- a/partials/payment-term.html
+++ b/partials/payment-term.html
@@ -10,14 +10,15 @@
 			{{#ifEquals this.name 'trial'}}
 			<span class="ncf__payment-term__title">Try the FT</span>
 			<div class="ncf__payment-term__description">
-				4 weeks for {{trialPrice}}<br />unless you cancel during your trial you will be billed {{price}} per month after the trial period
+				4 weeks for <span class="ncf__payment-term__trial-price">{{trialPrice}}</span><br />
+				unless you cancel during your trial you will be billed <span class="ncf__payment-term__price">{{price}}</span> per month after the trial period
 			</div>
 			{{/ifEquals}}
 
 			{{#ifEquals this.name 'annual'}}
 			<span class="ncf__payment-term__title">Pay annually</span>
 			<div class="ncf__payment-term__description">
-				Single <span class="ncf__strong">{{price}}</span> payment
+				Single <span class="ncf__payment-term__price ncf__strong">{{price}}</span> payment
 				{{#unless discount}}<br />Save up to 25% when you pay annually{{/unless}}
 			</div>
 			{{/ifEquals}}
@@ -25,14 +26,14 @@
 			{{#ifEquals this.name 'quarterly'}}
 			<span class="ncf__payment-term__title">Pay quarterly</span>
 			<div class="ncf__payment-term__description">
-				{{price}} per quarter
+				<span class="ncf__payment-term__price">{{price}}</span> per quarter
 			</div>
 			{{/ifEquals}}
 
 			{{#ifEquals this.name 'monthly'}}
 			<span class="ncf__payment-term__title">Pay monthly</span>
 			<div class="ncf__payment-term__description">
-				{{price}} per month
+				<span class="ncf__payment-term__price">{{price}}</span> per month
 			</div>
 			{{/ifEquals}}
 		</label>

--- a/tests/utils/payment-term.spec.js
+++ b/tests/utils/payment-term.spec.js
@@ -17,7 +17,8 @@ describe('PaymentTerm', () => {
 			remove: sandbox.stub(),
 			insertBefore: sandbox.stub(),
 			parentElement: elementStub,
-			addEventListener: sandbox.stub()
+			addEventListener: sandbox.stub(),
+			value: 'test'
 		};
 		documentStub = {
 			querySelector: sandbox.stub()
@@ -86,47 +87,30 @@ describe('PaymentTerm', () => {
 				elementStub.querySelectorAll.returns([elementStub]);
 			});
 
-			it('should throw if no options given', () => {
+			it('should throw an error if not all terms have an update', () => {
 				expect(() => {
-					paymentTerm.updateOptions();
+					paymentTerm.updateOptions([]);
 				}).to.throw();
 			});
 
-			it('should throw if options not array', () => {
-				expect(() => {
-					paymentTerm.updateOptions('test');
-				}).to.throw();
+			it('should replace the price with the correct updated price', () => {
+				const priceStub = {};
+				elementStub.querySelector.withArgs('.ncf__payment-term__price').returns(priceStub);
+				paymentTerm.updateOptions([{
+					value: 'test',
+					price: '£1.01'
+				}]);
+				expect(priceStub.innerHTML).to.equal('£1.01');
 			});
 
-			it('should clone two nodes for each option', () => {
-				const options = [{}, {}];
-				paymentTerm.updateOptions(options);
-
-				expect(elementStub.cloneNode.callCount).to.equal(options.length * 2);
-			});
-
-			it('should set the value for each input', () => {
-				const options = [{ value: 1 }, { value: 2 }];
-				paymentTerm.updateOptions(options);
-
-				expect(elementStub.setAttribute.calledWith('value', options[0].value)).to.be.true;
-				expect(elementStub.setAttribute.calledWith('value', options[1].value)).to.be.true;
-			});
-
-			it('should set the id for each input', () => {
-				const options = [{ value: 1 }, { value: 2 }];
-				paymentTerm.updateOptions(options);
-
-				expect(elementStub.setAttribute.calledWith('id', options[0].value)).to.be.true;
-				expect(elementStub.setAttribute.calledWith('id', options[1].value)).to.be.true;
-			});
-
-			it('should set the for for each label', () => {
-				const options = [{ value: 1 }, { value: 2 }];
-				paymentTerm.updateOptions(options);
-
-				expect(elementStub.setAttribute.calledWith('for', options[0].value)).to.be.true;
-				expect(elementStub.setAttribute.calledWith('for', options[1].value)).to.be.true;
+			it('should replace the trial price with the correct updated trial price', () => {
+				const trialPriceStub = {};
+				elementStub.querySelector.withArgs('.ncf__payment-term__trial-price').returns(trialPriceStub);
+				paymentTerm.updateOptions([{
+					value: 'test',
+					trialPrice: '£1.01'
+				}]);
+				expect(trialPriceStub.innerHTML).to.equal('£1.01');
 			});
 		});
 	});

--- a/utils/payment-term.js
+++ b/utils/payment-term.js
@@ -15,8 +15,10 @@
  * paymentTerm.updateOptions(options);
  */
 
-const LABEL_TITLE_CLASS = '.ncf__payment-term__label--title';
-const LABEL_DESCRIPTION_CLASS = '.ncf__payment-term__label--description';
+const ITEM_CLASS = '.ncf__payment-term__item';
+const VALUE_CLASS = '.ncf__payment-term__item input';
+const PRICE_CLASS = '.ncf__payment-term__price';
+const TRIAL_PRICE_CLASS = '.ncf__payment-term__trial-price';
 
 class PaymentTerm {
 	/**
@@ -64,34 +66,25 @@ class PaymentTerm {
 	 * @param {Array} options Array of objects contain terms information
 	 */
 	updateOptions (options) {
-		const selected = this.getSelected();
-		const inputToCopy = this.$paymentTerm.querySelector('input');
-		const labelToCopy = this.$paymentTerm.querySelector('label');
-		const container = inputToCopy.parentElement;
+		const terms = this.$paymentTerm.querySelectorAll(ITEM_CLASS);
+		terms.forEach(term => {
+			const value = term.querySelector(VALUE_CLASS).value;
+			const price = term.querySelector(PRICE_CLASS);
+			const trialPrice = term.querySelector(TRIAL_PRICE_CLASS);
+			const update = options.find(option => option.value === value);
 
-		// Reduce to create an array of new input and label elements
-		const newElements = options.reduce((acc, option) => {
-			const input = inputToCopy.cloneNode();
-			input.setAttribute('id', option.value);
-			input.setAttribute('value', option.value);
-			input.checked = option.value === selected;
+			if (!update) {
+				throw new Error(`Payment term update not found for "${value}"`);
+			}
 
-			const label = labelToCopy.cloneNode(true);
-			label.setAttribute('for', option.value);
-			label.querySelector(LABEL_TITLE_CLASS).innerText = option.name;
-			label.querySelector(LABEL_DESCRIPTION_CLASS).innerHTML = option.description;
-
-			return acc.concat([input, label]);
-		}, []);
-
-		// Remove existing
-		this.$paymentTerm
-			.querySelectorAll('input,label')
-			.forEach(element => element.remove());
-
-		// Add new elements
-		newElements
-			.forEach(element => container.insertBefore(element, container.lastElementChild));
+			// Update prices if they are found in the term
+			if (price) {
+				price.innerHTML = update.price;
+			}
+			if (trialPrice) {
+				trialPrice.innerHTML = update.trialPrice;
+			}
+		});
 	}
 }
 


### PR DESCRIPTION
## Feature Description
Now the copy is not set in the response use the existing terms and just update the price.

## Link to Ticket / Card:
https://trello.com/c/TSVDTwjG/1205-3-add-save-25-terms-copy-when-not-a-sale-offer

