### PR TITLE
Add payment term display to the package-change component

### DIFF
--- a/demos/data.json
+++ b/demos/data.json
@@ -42,11 +42,25 @@
     "params": {
       "changePackageUrl": "/foo",
       "currentPackage": "Digital",
-      "class": "extra-css-classes-here space-separated",
-      "formData": [{
-        "name": "foo",
-        "value": "bar"
-      }]
+      "terms": [
+        {
+          "name": "annual",
+          "price": "£1000"
+        },
+        {
+          "name": "quarterly",
+          "price": "£100"
+        },
+        {
+          "name": "monthly",
+          "price": "£10",
+          "discount": "25%"
+        },
+        {
+          "name": "trial",
+          "trialPrice": "£1"
+        }
+      ]
     }
   },
   "payment-term": {

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -11,6 +11,7 @@
 * [Header](#header)
 * [Loader](#loader)
 * [Message](#message)
+* [Package Change](#package-change)
 * [Payment Term](#payment-term)
 * [Phone](#phone)
 * [Submit](#submit)
@@ -170,6 +171,20 @@ i.e `{{> n-conversion-forms/partials/message isError=true message=flash.message 
   + `link`: string - The link to go to when clicking the button.
   + `isSecondary`: boolean - Whether to render this button using secondary styling from [o-buttons](https://registry.origami.ft.com/components/o-buttons).
   + `text`: string - The text the user will see on the button.
+
+## Package Change
+
+Displays a link for users to click to change their currently selected package. If payment terms are supplied these will also be displayed.
+
+### Options
+
++ `currentPackage`: string - Package name
++ `changePackageUrl`: string - Link to a place to change the package
++ `terms`: array - An array of objects that can have the following properties
+  + `name`: string - Payment term name i.e. "annual"
+  + `price`: string - Price of the payment term
+  + `trialPrice`: string - Trial price of the term if applicable
+  + `discount`: string - Displays a sale label on the term
 
 ## Payment term
 

--- a/main.scss
+++ b/main.scss
@@ -7,6 +7,8 @@
 @import 'o-message/main';
 @import 'o-icons/main';
 @import 'o-stepped-progress/main';
+@import 'o-fonts/main';
+@import './styles/package-change';
 @import './styles/payment';
 @import './styles/payment-term';
 @import './styles/payment-type';
@@ -14,7 +16,6 @@
 @import './styles/message';
 @import './styles/continue-reading';
 @import './styles/banner';
-@import 'o-fonts/main';
 
 @include oFonts();
 @include oFormsBaseFeatures();
@@ -256,6 +257,7 @@
 	}
 
 	@include ncfMessage();
+	@include ncfPackageChange();
 	@include ncfPaymentTerm();
 	@include ncfPaymentType();
 	@include ncfLoader();

--- a/partials/package-change.html
+++ b/partials/package-change.html
@@ -1,9 +1,61 @@
-<div class="ncf__center o-message o-message--notice-bleed o-message--inform" data-o-component="o-message">
-	<div class="o-message__container">
-		<div class="o-message__content">
-			<p class="o-message__content-main">You have chosen <span class="ncf__strong">{{currentPackage}}</span></p>
-			<div class="o-message__actions">
-				<a href="{{changePackageUrl}}" class="ncf__button ncf__button--mono ncf__button--baseline" data-trackable="change">Change</a>
+<div class="ncf__package-change">
+	<div class="o-grid-container o-grid-container--bleed">
+		<div class="o-grid-row">
+			<div data-o-grid-colspan="12 S10 M8 L6 XL5 center">
+				<div class="ncf__package-change__package">
+					<p class="ncf__package-change__content">You have chosen <span class="ncf__strong">{{currentPackage}}</span></p>
+					<div class="ncf__package-change__actions">
+						<a href="{{changePackageUrl}}" class="ncf__button ncf__button--mono ncf__button--baseline" data-trackable="change">Change</a>
+					</div>
+				</div>
+				{{#if terms}}
+				<div class="ncf__package-change__terms">
+					{{#each terms}}
+					<div class="ncf__package-change__term">
+						{{#ifEquals this.name 'trial'}}
+						<span class="ncf__package-change__title">Try the FT</span>
+						<div class="ncf__package-change__description">
+							4 weeks for <span class="ncf__package-change__trial-price">{{trialPrice}}</span>
+						</div>
+						{{/ifEquals}}
+
+						{{#ifEquals this.name 'annual'}}
+						<span class="ncf__package-change__title">Pay annually</span>
+						<div class="ncf__package-change__description">
+							Single <span class="ncf__package-change__price">{{price}}</span> payment*
+						</div>
+						{{/ifEquals}}
+
+						{{#ifEquals this.name 'quarterly'}}
+						<span class="ncf__package-change__title">Pay quarterly</span>
+						<div class="ncf__package-change__description">
+							<span class="ncf__package-change__price">{{price}}</span> per quarter
+						</div>
+						{{/ifEquals}}
+
+						{{#ifEquals this.name 'monthly'}}
+						<span class="ncf__package-change__title">Pay monthly</span>
+						<div class="ncf__package-change__description">
+							<span class="ncf__package-change__price">{{price}}</span> per month
+						</div>
+						{{/ifEquals}}
+
+						{{#if this.discount}}
+						<div class="ncf__package-change__discount">Save {{this.discount}}</div>
+						{{/if}}
+					</div>
+					{{/each}}
+					{{#each terms}}
+					{{#unless this.discount}}
+					{{#ifEquals this.name 'annual'}}
+					<div class="ncf__package-change__annual-copy">
+						* Save up to 25% when you pay annually. Discount varies across member states and across our subscription packages.
+					</div>
+					{{/ifEquals}}
+					{{/unless}}
+					{{/each}}
+				</div>
+				{{/if}}
 			</div>
 		</div>
 	</div>

--- a/styles/package-change.scss
+++ b/styles/package-change.scss
@@ -1,0 +1,50 @@
+@include oGridGenerate;
+
+@mixin ncfPackageChange() {
+	&__package-change {
+		@include oTypographySans($scale: 0);
+		background-color: oColorsGetPaletteColor('wheat');
+		padding: 0 20px;
+
+		@include oGridRespondTo($from: S) {
+			padding: 0;
+		}
+
+		&__package {
+			display: grid;
+			grid-template-columns: 1fr min-content;
+			align-items: center;
+		}
+
+		&__terms {
+			margin-bottom: 20px;
+		}
+
+		&__term {
+			border-top: 1px solid oColorsGetPaletteColor('black-20');
+			padding: 8px 0;
+			display: grid;
+			grid-template-columns: 2fr 2fr 1fr;
+
+			@include oGridRespondTo($until: S) {
+				grid-template-columns: 1fr 1fr;
+			}
+		}
+
+		&__title {
+			font-weight: oFontsWeight('semibold');
+
+			@include oGridRespondTo($until: S) {
+				grid-column: span 2;
+			}
+		}
+
+		&__discount {
+			justify-self: end;
+		}
+
+		&__annual-copy {
+			@include oTypographySize($scale: -1);
+		}
+	}
+}

--- a/tests/partials/package-change.spec.js
+++ b/tests/partials/package-change.spec.js
@@ -4,6 +4,11 @@ const {
 const expect = require('chai').expect;
 
 let context = {};
+const CONTENT_SELECTOR = '.ncf__package-change__content';
+const TITLE_SELECTOR = '.ncf__package-change__title';
+const DESCRIPTION_SELECTOR = '.ncf__package-change__description';
+const ANNUAL_COPY_SELECTOR = '.ncf__package-change__annual-copy';
+const DISCOUNT_SELECTOR = '.ncf__package-change__discount';
 
 describe('package-change template', () => {
 	before(async () => {
@@ -21,6 +26,120 @@ describe('package-change template', () => {
 		const data = { currentPackage: 'Digital' };
 		const $ = context.template(data);
 
-		expect($('.ncf__center').text()).to.contain(data.currentPackage);
+		expect($(CONTENT_SELECTOR).text()).to.contain(data.currentPackage);
+	});
+
+	describe('trial', () => {
+		it('should show the correct title copy', () => {
+			const name = 'trial';
+			const $ = context.template({ terms: [{
+				name
+			}]});
+			expect($(TITLE_SELECTOR).text()).to.equal('Try the FT');
+		});
+
+		it('should show the trial price', () => {
+			const name = 'trial';
+			const price = '£1.01';
+			const trialPrice = '£2.01';
+			const $ = context.template({ terms: [{
+				name,
+				price,
+				trialPrice
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.contain(trialPrice);
+		});
+	});
+
+	describe('annual', () => {
+		it('should show the correct title copy', () => {
+			const name = 'annual';
+			const $ = context.template({ terms: [{
+				name
+			}]});
+			expect($(TITLE_SELECTOR).text()).to.contain('annually');
+		});
+
+		it('should show the price', () => {
+			const name = 'annual';
+			const price = '£1.01';
+			const $ = context.template({ terms: [{
+				name,
+				price
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.contain(price);
+		});
+
+		it('should show discount copy if not discounted', () => {
+			const name = 'annual';
+			const $ = context.template({ terms: [{
+				name
+			}]});
+			expect($(ANNUAL_COPY_SELECTOR).length).to.equal(1);
+		});
+
+		it('should not show discount copy if discounted', () => {
+			const name = 'annual';
+			const discount = '25%';
+			const $ = context.template({ terms: [{
+				name,
+				discount
+			}]});
+			expect($(ANNUAL_COPY_SELECTOR).length).to.not.equal(1);
+		});
+	});
+
+	describe('quarterly', () => {
+		it('should show the correct title copy', () => {
+			const name = 'quarterly';
+			const $ = context.template({ terms: [{
+				name
+			}]});
+			expect($(TITLE_SELECTOR).text()).to.contain('quarterly');
+		});
+
+		it('should show the price', () => {
+			const name = 'quarterly';
+			const price = '£1.01';
+			const $ = context.template({ terms: [{
+				name,
+				price
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.contain(price);
+		});
+	});
+
+	describe('monthly', () => {
+		it('should show the correct title copy', () => {
+			const name = 'monthly';
+			const $ = context.template({ terms: [{
+				name
+			}]});
+			expect($(TITLE_SELECTOR).text()).to.contain('monthly');
+		});
+
+		it('should show the price', () => {
+			const name = 'monthly';
+			const price = '£1.01';
+			const $ = context.template({ terms: [{
+				name,
+				price
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.contain(price);
+		});
+	});
+
+	it('should not have discount text by default', () => {
+		const option1 = { value: 'option1' };
+		const option2 = { value: 'option2', selected: true };
+		const $ = context.template({ terms: [option1, option2]});
+		expect($(DISCOUNT_SELECTOR).length).to.equal(0);
+	});
+
+	it('should have discount text if a discount is passed', () => {
+		const option1 = { value: 'option1', discount: '25%' };
+		const option2 = { value: 'option2', selected: true };
+		const $ = context.template({ terms: [option1, option2]});
+		expect($(DISCOUNT_SELECTOR).length).to.equal(1);
 	});
 });


### PR DESCRIPTION
## Feature Description
Displays payment terms including prices in the package-change component.

## Link to Ticket / Card:
https://trello.com/c/M5xVHmPw/1231-5show-cost-on-the-stepped-buy-flow

## Screenshots:

| Desktop | Mobile |
| --- | --- |
| <img width="670" alt="Screenshot 2019-06-10 at 15 39 20" src="https://user-images.githubusercontent.com/1721150/59203213-0793e900-8b96-11e9-8f59-69c90193c574.png"> | <img width="412" alt="Screenshot 2019-06-10 at 15 39 39" src="https://user-images.githubusercontent.com/1721150/59203218-08c51600-8b96-11e9-85cc-c53480ebc192.png"> |


## Has the necessary documentation been created / updated?
- [x] Yes
- [ ] Not required for this ticket

## Has this been given a review by Design/UX?
- [x] Yes
- [ ] Not required for this ticket
