### PR TITLE
Added autocomplete attr to firstname, lastname and phone

### DIFF
--- a/partials/firstname.html
+++ b/partials/firstname.html
@@ -3,6 +3,7 @@
 	<label for="firstName" class="o-forms__label">First name</label>
 
 	<input type="text" id="firstName" name="firstName" value="{{value}}" placeholder="Enter your first name"
+				autocomplete="on"
 				class="o-forms__text js-field__input js-item__value"
 				data-trackable="field-name"
 				aria-required="true" required

--- a/partials/lastname.html
+++ b/partials/lastname.html
@@ -3,6 +3,7 @@
 	<label for="lastName" class="o-forms__label">Last name</label>
 
 	<input type="text" id="lastName" name="lastName" value="{{value}}" placeholder="Enter your last name"
+				autocomplete="on"
 				class="o-forms__text js-field__input js-item__value"
 				data-trackable="field-lastname"
 				aria-required="true" required

--- a/partials/phone.html
+++ b/partials/phone.html
@@ -12,6 +12,7 @@
 	</small>
 
 	<input type="tel" id="primaryTelephone" name="primaryTelephone" value="{{value}}" placeholder="Enter your phone number"
+				autocomplete="on"
 				class="o-forms__text js-field__input js-item__value"
 				minLength="5"
 				maxLength="15"


### PR DESCRIPTION
 🐿 v2.12.3

## Feature Description
Added `autocomplete="on"` to the three fields indicated in the accessibility report (`firstname`, `lastname` and `phone`).

## Link to Ticket / Card:

https://trello.com/c/z11SBdhZ/1280-dacautocompleteissue1

## Screenshots:

I have just made sure the attributes are there on the rendered form.

## Has the necessary documentation been created / updated?
- [ ] Yes
- [X] Not required for this ticket

## Has this been given a review by Design/UX?
- [ ] Yes
- [X] Not required for this ticket
