### PR TITLE
Add autocomplete to firstname

### DIFF
--- a/partials/company-name.html
+++ b/partials/company-name.html
@@ -3,6 +3,7 @@
 	<label for="companyName" class="o-forms__label">Company name</label>
 
 	<input type="text" id="companyName" name="company" value="{{value}}" placeholder="Enter your company name"
+				autocomplete="organization"
 				class="o-forms__text js-field__input js-item__value"
 				data-trackable="company-name"
 				aria-required="true" required

--- a/partials/email.html
+++ b/partials/email.html
@@ -16,6 +16,7 @@
 	</small>
 
 	<input type="email" id="email" name="email" value="{{value}}" placeholder="Enter your email address"
+				autocomplete="email"
 				class="no-mouseflow o-forms__text js-field__input js-item__value{{#if readonly}} o-forms__field-disabled{{/if}}"
 				data-trackable="field-email"
 				aria-describedby="email-description"
@@ -33,6 +34,7 @@
 	</label>
 
 	<input type="email" id="emailConfirm" name="emailConfirm" placeholder="Confirm your email address"
+				autocomplete="email"
 				class="no-mouseflow o-forms__text js-field__input js-item__value{{#if readonly}} o-forms__field-disabled{{/if}}"
 				data-trackable="field-emailConfrm"
 				aria-required="true" required

--- a/partials/firstname.html
+++ b/partials/firstname.html
@@ -3,7 +3,7 @@
 	<label for="firstName" class="o-forms__label">First name</label>
 
 	<input type="text" id="firstName" name="firstName" value="{{value}}" placeholder="Enter your first name"
-				autocomplete="on"
+				autocomplete="given-name"
 				class="o-forms__text js-field__input js-item__value"
 				data-trackable="field-name"
 				aria-required="true" required

--- a/partials/firstname.html
+++ b/partials/firstname.html
@@ -3,6 +3,7 @@
 	<label for="firstName" class="o-forms__label">First name</label>
 
 	<input type="text" id="firstName" name="firstName" value="{{value}}" placeholder="Enter your first name"
+				autocomplete="on"
 				class="o-forms__text js-field__input js-item__value"
 				data-trackable="field-name"
 				aria-required="true" required

--- a/partials/lastname.html
+++ b/partials/lastname.html
@@ -3,6 +3,7 @@
 	<label for="lastName" class="o-forms__label">Last name</label>
 
 	<input type="text" id="lastName" name="lastName" value="{{value}}" placeholder="Enter your last name"
+				autocomplete="on"
 				class="o-forms__text js-field__input js-item__value"
 				data-trackable="field-lastname"
 				aria-required="true" required

--- a/partials/lastname.html
+++ b/partials/lastname.html
@@ -3,7 +3,7 @@
 	<label for="lastName" class="o-forms__label">Last name</label>
 
 	<input type="text" id="lastName" name="lastName" value="{{value}}" placeholder="Enter your last name"
-				autocomplete="on"
+				autocomplete="family-name"
 				class="o-forms__text js-field__input js-item__value"
 				data-trackable="field-lastname"
 				aria-required="true" required

--- a/partials/password.html
+++ b/partials/password.html
@@ -6,11 +6,7 @@
 	<div class="o-forms__affix-wrapper js-show-password">
 		<input type="password" id="password" name="password" placeholder="Enter a password"
 					class="no-mouseflow o-forms__text o-forms__text--suffixed js-field__input js-show-password__password-input js-item__value"
-					{{#if unknownUser}}
 					autocomplete="new-password"
-					{{else}}
-					autocomplete="current-password"
-					{{/if}}
 					data-trackable="field-password"
 					aria-describedby="password-description"
 					aria-required="true" required

--- a/partials/password.html
+++ b/partials/password.html
@@ -6,6 +6,11 @@
 	<div class="o-forms__affix-wrapper js-show-password">
 		<input type="password" id="password" name="password" placeholder="Enter a password"
 					class="no-mouseflow o-forms__text o-forms__text--suffixed js-field__input js-show-password__password-input js-item__value"
+					{{#if unknownUser}}
+					autocomplete="new-password"
+					{{else}}
+					autocomplete="current-password"
+					{{/if}}
 					data-trackable="field-password"
 					aria-describedby="password-description"
 					aria-required="true" required

--- a/partials/phone.html
+++ b/partials/phone.html
@@ -12,7 +12,7 @@
 	</small>
 
 	<input type="tel" id="primaryTelephone" name="primaryTelephone" value="{{value}}" placeholder="Enter your phone number"
-				autocomplete="on"
+				autocomplete="tel"
 				class="o-forms__text js-field__input js-item__value"
 				minLength="5"
 				maxLength="15"

--- a/partials/phone.html
+++ b/partials/phone.html
@@ -12,6 +12,7 @@
 	</small>
 
 	<input type="tel" id="primaryTelephone" name="primaryTelephone" value="{{value}}" placeholder="Enter your phone number"
+				autocomplete="on"
 				class="o-forms__text js-field__input js-item__value"
 				minLength="5"
 				maxLength="15"

--- a/partials/postcode.html
+++ b/partials/postcode.html
@@ -14,6 +14,7 @@
 		{{/if}}
 		value="{{value}}"
 		placeholder="{{#if isZipCode}}Zip code{{else}}Post code{{/if}}"
+		autocomplete="postal-code"
 		class="o-forms__text js-field__input js-item__value"
 		data-trackable="post-code"
 		aria-required="true" required


### PR DESCRIPTION
## Feature Description
Added "autocomplete" attributes to all input fields in the signup form, based on the [input purposes spec](https://www.w3.org/TR/WCAG21/#input-purposes).

## Link to Ticket / Card:
https://trello.com/c/z11SBdhZ/1280-dacautocompleteissue1

## Screenshots:
I have trouble running `next-signup` locally at the moment. I'd be great if someone could do a sanity check on it. 

## Has the necessary documentation been created / updated?
- [ ] Yes
- [X] Not required for this ticket

## Has this been given a review by Design/UX?
- [ ] Yes
- [ ] Not required for this ticket



