### PR TITLE
Don't fill hidden input fields with helper

### DIFF
--- a/partials/debug.html
+++ b/partials/debug.html
@@ -59,8 +59,10 @@
 	function fillForm () {
 		var inputs = document.querySelectorAll(FORM_SELECTOR + ' input, ' + FORM_SELECTOR + ' select');
 		inputs.forEach(function (input) {
-			var value = debugData[input.name];
-			input.value = value;
+			if (!/hidden/i.test(input.type)) {
+				var value = debugData[input.name];
+				input.value = value;
+			}
 		});
 		var checkboxes = document.querySelectorAll(FORM_SELECTOR + ' input[type="checkbox"]');
 		checkboxes.forEach(function (checkbox) {


### PR DESCRIPTION
 🐿 v2.12.3

## Feature Description

Realised this was messing up the `csrfToken` in `next-subscribe`.

## Has the necessary documentation been created / updated?
- [x] Not required for this ticket

## Has this been given a review by Design/UX?
- [x] Not required for this ticket
