### PR TITLE
Price offer update

### DIFF
--- a/demos/data.json
+++ b/demos/data.json
@@ -45,7 +45,8 @@
       "terms": [
         {
           "name": "annual",
-          "price": "£1000"
+          "price": "£1000",
+          "weeklyPrice": "£4.5"
         },
         {
           "name": "quarterly",

--- a/demos/main.scss
+++ b/demos/main.scss
@@ -19,3 +19,14 @@ body {
 		z-index: 1001;
 	}
 }
+
+.o-techdocs-card {
+  resize: both;
+  overflow: auto;
+  max-width: none;
+  height: 300px;
+}
+
+.o-techdocs-card__content {
+  height: 100%;
+}

--- a/demos/main.scss
+++ b/demos/main.scss
@@ -21,12 +21,12 @@ body {
 }
 
 .o-techdocs-card {
-  resize: both;
-  overflow: auto;
-  max-width: none;
-  height: 300px;
+	resize: both;
+	overflow: auto;
+	max-width: none;
+	height: 300px;
 }
 
 .o-techdocs-card__content {
-  height: 100%;
+	height: 100%;
 }

--- a/partials/package-change.html
+++ b/partials/package-change.html
@@ -11,14 +11,12 @@
 				{{#if terms}}
 				<div class="ncf__package-change__terms">
 					{{#each terms}}
-					<div class="ncf__package-change__term">
+					<div class="ncf__package-change__term{{#if this.discount}} ncf__package-change__term--discounted{{/if}}">
 						{{#ifEquals this.name 'trial'}}
 						<span class="ncf__package-change__title">Try the FT</span>
-						<span>
-							{{#if this.discount}}
-							<span class="ncf__package-change__discount">Save {{this.discount}}</span>
-							{{/if}}
-						</span>
+						{{#if this.discount}}
+						<span class="ncf__package-change__discount">Save {{this.discount}}</span>
+						{{/if}}
 						<div class="ncf__package-change__description">
 							4 weeks for <span class="ncf__package-change__trial-price">{{trialPrice}}</span>
 						</div>
@@ -26,11 +24,9 @@
 
 						{{#ifEquals this.name 'annual'}}
 						<span class="ncf__package-change__title">Annually</span>
-						<span>
-							{{#if this.discount}}
-							<span class="ncf__package-change__discount">Save {{this.discount}}</span>
-							{{/if}}
-						</span>
+						{{#if this.discount}}
+						<span class="ncf__package-change__discount">Save {{this.discount}}</span>
+						{{/if}}
 						<div class="ncf__package-change__description">
 							Single <span class="ncf__package-change__price">{{price}}</span> payment*
 						</div>
@@ -43,11 +39,9 @@
 
 						{{#ifEquals this.name 'quarterly'}}
 						<span class="ncf__package-change__title">Quarterly</span>
-						<span>
-							{{#if this.discount}}
-							<span class="ncf__package-change__discount">Save {{this.discount}}</span>
-							{{/if}}
-						</span>
+						{{#if this.discount}}
+						<span class="ncf__package-change__discount">Save {{this.discount}}</span>
+						{{/if}}
 						<div class="ncf__package-change__description">
 							<span class="ncf__package-change__price">{{price}}</span> per quarter
 						</div>
@@ -55,11 +49,9 @@
 
 						{{#ifEquals this.name 'monthly'}}
 						<span class="ncf__package-change__title">Monthly</span>
-						<span>
-							{{#if this.discount}}
-							<span class="ncf__package-change__discount">Save {{this.discount}}</span>
-							{{/if}}
-						</span>
+						{{#if this.discount}}
+						<span class="ncf__package-change__discount">Save {{this.discount}}</span>
+						{{/if}}
 						<div class="ncf__package-change__description">
 							<span class="ncf__package-change__price">{{price}}</span> per month
 						</div>

--- a/partials/package-change.html
+++ b/partials/package-change.html
@@ -14,35 +14,40 @@
 					<div class="ncf__package-change__term">
 						{{#ifEquals this.name 'trial'}}
 						<span class="ncf__package-change__title">Try the FT</span>
+						<span class="ncf__package-change__discount">{{#if this.discount}}Save {{this.discount}}{{/if}}</span>
 						<div class="ncf__package-change__description">
 							4 weeks for <span class="ncf__package-change__trial-price">{{trialPrice}}</span>
 						</div>
 						{{/ifEquals}}
 
 						{{#ifEquals this.name 'annual'}}
-						<span class="ncf__package-change__title">Pay annually</span>
+						<span class="ncf__package-change__title">Annually</span>
+						<span class="ncf__package-change__discount">{{#if this.discount}}Save {{this.discount}}{{/if}}</span>
 						<div class="ncf__package-change__description">
 							Single <span class="ncf__package-change__price">{{price}}</span> payment*
 						</div>
+						{{#if weeklyPrice}}
+						<div class="ncf__package-change__weekly-price">
+							Just <span class="ncf__package-change__price">{{weeklyPrice}}</span> per week
+						</div>
+						{{/if}}
 						{{/ifEquals}}
 
 						{{#ifEquals this.name 'quarterly'}}
-						<span class="ncf__package-change__title">Pay quarterly</span>
+						<span class="ncf__package-change__title">Quarterly</span>
+						<span class="ncf__package-change__discount">{{#if this.discount}}Save {{this.discount}}{{/if}}</span>
 						<div class="ncf__package-change__description">
 							<span class="ncf__package-change__price">{{price}}</span> per quarter
 						</div>
 						{{/ifEquals}}
 
 						{{#ifEquals this.name 'monthly'}}
-						<span class="ncf__package-change__title">Pay monthly</span>
+						<span class="ncf__package-change__title">Monthly</span>
+						<span class="ncf__package-change__discount">{{#if this.discount}}Save {{this.discount}}{{/if}}</span>
 						<div class="ncf__package-change__description">
 							<span class="ncf__package-change__price">{{price}}</span> per month
 						</div>
 						{{/ifEquals}}
-
-						{{#if this.discount}}
-						<div class="ncf__package-change__discount">Save {{this.discount}}</div>
-						{{/if}}
 					</div>
 					{{/each}}
 					{{#each terms}}

--- a/partials/package-change.html
+++ b/partials/package-change.html
@@ -14,7 +14,11 @@
 					<div class="ncf__package-change__term">
 						{{#ifEquals this.name 'trial'}}
 						<span class="ncf__package-change__title">Try the FT</span>
-						<span class="ncf__package-change__discount">{{#if this.discount}}Save {{this.discount}}{{/if}}</span>
+						<span>
+							{{#if this.discount}}
+							<span class="ncf__package-change__discount">Save {{this.discount}}</span>
+							{{/if}}
+						</span>
 						<div class="ncf__package-change__description">
 							4 weeks for <span class="ncf__package-change__trial-price">{{trialPrice}}</span>
 						</div>
@@ -22,7 +26,11 @@
 
 						{{#ifEquals this.name 'annual'}}
 						<span class="ncf__package-change__title">Annually</span>
-						<span class="ncf__package-change__discount">{{#if this.discount}}Save {{this.discount}}{{/if}}</span>
+						<span>
+							{{#if this.discount}}
+							<span class="ncf__package-change__discount">Save {{this.discount}}</span>
+							{{/if}}
+						</span>
 						<div class="ncf__package-change__description">
 							Single <span class="ncf__package-change__price">{{price}}</span> payment*
 						</div>
@@ -35,7 +43,11 @@
 
 						{{#ifEquals this.name 'quarterly'}}
 						<span class="ncf__package-change__title">Quarterly</span>
-						<span class="ncf__package-change__discount">{{#if this.discount}}Save {{this.discount}}{{/if}}</span>
+						<span>
+							{{#if this.discount}}
+							<span class="ncf__package-change__discount">Save {{this.discount}}</span>
+							{{/if}}
+						</span>
 						<div class="ncf__package-change__description">
 							<span class="ncf__package-change__price">{{price}}</span> per quarter
 						</div>
@@ -43,7 +55,11 @@
 
 						{{#ifEquals this.name 'monthly'}}
 						<span class="ncf__package-change__title">Monthly</span>
-						<span class="ncf__package-change__discount">{{#if this.discount}}Save {{this.discount}}{{/if}}</span>
+						<span>
+							{{#if this.discount}}
+							<span class="ncf__package-change__discount">Save {{this.discount}}</span>
+							{{/if}}
+						</span>
 						<div class="ncf__package-change__description">
 							<span class="ncf__package-change__price">{{price}}</span> per month
 						</div>

--- a/styles/package-change.scss
+++ b/styles/package-change.scss
@@ -21,29 +21,33 @@
 		}
 
 		&__term {
-			border-top: 1px solid oColorsGetPaletteColor('black-20');
-			padding: 8px 0;
+			padding: 4px 0;
 			display: grid;
-			grid-template-columns: 2fr 2fr 1fr;
-
-			@include oGridRespondTo($until: S) {
-				grid-template-columns: 1fr 1fr;
-			}
+			grid-template-columns: max-content max-content 1fr;
 		}
 
 		&__title {
 			font-weight: oFontsWeight('semibold');
-
-			@include oGridRespondTo($until: S) {
-				grid-column: span 2;
-			}
+			padding-right: 10px;
 		}
 
-		&__discount {
+		&__description {
 			justify-self: end;
 		}
 
+		&__discount {
+			color: oColorsGetPaletteColor('claret-70');
+		}
+
+		&__weekly-price {
+			justify-self: end;
+			grid-column: span 3;
+			@include oTypographySize($scale: -1);
+			color: oColorsGetPaletteColor('black-60');
+		}
+
 		&__annual-copy {
+			padding-top: 8px;
 			@include oTypographySize($scale: -1);
 		}
 	}

--- a/styles/package-change.scss
+++ b/styles/package-change.scss
@@ -23,7 +23,10 @@
 		&__term {
 			padding: 4px 0;
 			display: grid;
-			grid-template-columns: max-content max-content 1fr;
+			grid-template-columns: max-content 1fr;
+			&--discounted {
+				grid-template-columns: max-content max-content 1fr;
+			}
 		}
 
 		&__title {

--- a/tests/partials/package-change.spec.js
+++ b/tests/partials/package-change.spec.js
@@ -57,7 +57,7 @@ describe('package-change template', () => {
 			const $ = context.template({ terms: [{
 				name
 			}]});
-			expect($(TITLE_SELECTOR).text()).to.contain('annually');
+			expect($(TITLE_SELECTOR).text()).to.contain('Annually');
 		});
 
 		it('should show the price', () => {
@@ -95,7 +95,7 @@ describe('package-change template', () => {
 			const $ = context.template({ terms: [{
 				name
 			}]});
-			expect($(TITLE_SELECTOR).text()).to.contain('quarterly');
+			expect($(TITLE_SELECTOR).text()).to.contain('Quarterly');
 		});
 
 		it('should show the price', () => {
@@ -115,7 +115,7 @@ describe('package-change template', () => {
 			const $ = context.template({ terms: [{
 				name
 			}]});
-			expect($(TITLE_SELECTOR).text()).to.contain('monthly');
+			expect($(TITLE_SELECTOR).text()).to.contain('Monthly');
 		});
 
 		it('should show the price', () => {
@@ -130,15 +130,15 @@ describe('package-change template', () => {
 	});
 
 	it('should not have discount text by default', () => {
-		const option1 = { value: 'option1' };
-		const option2 = { value: 'option2', selected: true };
+		const option1 = { name: 'quarterly', price: '£10' };
+		const option2 = { name: 'monthly', price: '£20' };
 		const $ = context.template({ terms: [option1, option2]});
 		expect($(DISCOUNT_SELECTOR).length).to.equal(0);
 	});
 
 	it('should have discount text if a discount is passed', () => {
-		const option1 = { value: 'option1', discount: '25%' };
-		const option2 = { value: 'option2', selected: true };
+		const option1 = { name: 'quarterly', discount: '25%', price: '£10' };
+		const option2 = { name: 'monthly', price: '£20' };
 		const $ = context.template({ terms: [option1, option2]});
 		expect($(DISCOUNT_SELECTOR).length).to.equal(1);
 	});


### PR DESCRIPTION
## Feature Description
The price component which shows the different pricing options across the form pages is too large and is distracting users from the form. There is an updated to reduce the size of this visually.

## Link to Ticket / Card:
https://trello.com/c/QOr2zuzp/1312-update-the-offer-price-component-in-next-subscribe

## Screenshots:
Before: 
![image](https://user-images.githubusercontent.com/6513313/60198024-906a8000-9838-11e9-9212-c87adf29000d.png)

After:
![image](https://user-images.githubusercontent.com/6513313/60198071-af691200-9838-11e9-857a-a369ed65624b.png)


## Has the necessary documentation been created / updated?
- [ ] Yes
- [ ] Not required for this ticket

## Has this been given a review by Design/UX?
- [ ] Yes
- [ ] Not required for this ticket
