### PR TITLE
Add salesforce utility to convert country codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ import MyModule from 'n-conversion-forms/utils/my-module';
 * [Password](#password)
 * [Payment Term](#payment-term)
 * [Payment Type](#payment-type)
+* [Salesforce](#salesforce)
 * [Submit](#submit)
 * [Tracking](#tracking)
 * [Validation](#validation)
@@ -231,6 +232,19 @@ PaymentType.DIRECTDEBIT
 PaymentType.PAYPAL
 PaymentType.APPLEPAY
 ```
+
+### Salesforce
+
+Utility for converting salesforce country names to ISO country codes.
+
+```js
+// isoCode will equal GBR
+const isoCode = salesforceNameToIsoCode('United Kingdom');
+
+// salesfoceName will equal United Kingdom
+const salesforceName = isoCodeToSalesforceName('GBR');
+```
+
 ### Submit
 
 ```js

--- a/tests/utils/salesforce.spec.js
+++ b/tests/utils/salesforce.spec.js
@@ -1,0 +1,31 @@
+const {
+	isoCodeToSalesforceName,
+	salesforceNameToIsoCode
+} = require('../../utils/salesforce');
+const expect = require('chai').expect;
+
+describe('salesforce', () => {
+	describe('isoCodeToSalesforceName', () => {
+		it('should throw if a incorrect ISO code entered', () => {
+			expect(() => {
+				isoCodeToSalesforceName('test');
+			}).to.throw();
+		});
+
+		it('should return the salesforce name for a country', () => {
+			expect(isoCodeToSalesforceName('GBR')).to.equal('United Kingdom');
+		});
+	});
+
+	describe('salesforceCodeToIsoCode', () => {
+		it('should throw if a incorrect Salesforce name entered', () => {
+			expect(() => {
+				salesforceNameToIsoCode('test');
+			}).to.throw();
+		});
+
+		it('should return the ISO country code for Salesforce country', () => {
+			expect(salesforceNameToIsoCode('United Kingdom')).to.equal('GBR');
+		});
+	});
+});

--- a/utils/salesforce.js
+++ b/utils/salesforce.js
@@ -1,0 +1,32 @@
+const { countries } = require('n-common-static-data').billingCountries;
+
+/**
+ * Turn a ISO 3 character country code to a Salesforce country name
+ * @param {String} countryCode ISO 3 character country code
+ * @returns {String} Country name from Salesforce
+ */
+function isoCodeToSalesforceName (countryCode) {
+	const selectedCountry = countries.find(country => country.code === countryCode);
+	if (!selectedCountry) {
+		throw new Error(`ISO code ${countryCode} Salesforce equivalent not found`);
+	}
+	return selectedCountry.salesforceName;
+}
+
+/**
+ * Turn a country name from salesforce into a ISO 3 character country code
+ * @param {String} salesforceName Country name from Salesforce
+ * @returns {String} ISO 3 character country code
+ */
+function salesforceNameToIsoCode (salesforceName) {
+	const selectedCountry = countries.find(country => country.salesforceName === salesforceName);
+	if (!selectedCountry) {
+		throw new Error(`Salesforce Country ${salesforceName} ISO equivalent not found`);
+	}
+	return selectedCountry.code;
+}
+
+module.exports = {
+	isoCodeToSalesforceName,
+	salesforceNameToIsoCode
+};


### PR DESCRIPTION
## Feature Description
For Marketo we need to convert ISO country codes to Salesforce country names. Adding this utility here as it may be useful elsewhere and reduces the need to depend on `n-common-static-data` for our applications.

## Link to Ticket / Card:
https://trello.com/c/DGsVQQ0U/1291-8-add-marketo-api-request-to-next-subscribe

## Has the necessary documentation been created / updated?
- [X] Yes
- [ ] Not required for this ticket

## Has this been given a review by Design/UX?
- [ ] Yes
- [X] Not required for this ticket
