### PR TITLE
Add licence-header partial

### DIFF
--- a/demos/data.json
+++ b/demos/data.json
@@ -171,6 +171,13 @@
       "duration": "30 day"
     }
   },
+  "licence-header": {
+    "params": {
+      "displayName": "Company",
+      "isTrial": true,
+      "welcomeText": "The quick brown fox jumped over the lazy hare"
+    }
+  },
   "continue-reading": {
     "params": {
       "quote": "The quick brown fox jumped over the lazy hare",

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -8,7 +8,8 @@
 * [Fieldset](#fieldset)
 * [Firstname](#firstname)
 * [Lastname](#lastname)
-* [Header](#header)
+* [Licence Confirmation](#licence-confirmation)
+* [Licence Header](#licence-header)
 * [Loader](#loader)
 * [Message](#message)
 * [Package Change](#package-change)
@@ -129,6 +130,20 @@ Confirmation page for subscribing to a company licence.
 
 ```handlebars
 {{> n-conversion-forms/partials/licence-confirmation isTrial=true }}
+```
+
+## licence-header
+
+Header copy for licence pages.
+
+### Options
+
++ `isTrial`: boolean - Is the licence a trial or not
++ `displayName`: string - Name of the company licence is for
++ `welcomeText`: string - Form welcome text
+
+```handlebars
+{{> n-conversion-forms/partials/licence-header isTrial=false displayName="IBM" welcomeText="Join our FT.com licence" }}
 ```
 
 ## Loader

--- a/partials/licence-header.html
+++ b/partials/licence-header.html
@@ -1,0 +1,13 @@
+<h1 class="ncf__header">
+{{#if displayName }}
+	{{displayName}} |
+{{/if}}
+{{#if isTrial}}
+	Start your free trial
+{{else}}
+	Join your FT.com subscription
+{{/if}}
+</h1>
+{{#if welcomeText}}
+<p>{{{ welcomeText }}}</p>
+{{/if}}

--- a/tests/partials/licence-header.spec.js
+++ b/tests/partials/licence-header.spec.js
@@ -1,0 +1,60 @@
+const { expect } = require('chai');
+const { fetchPartial } = require('../helpers');
+
+let context = {};
+
+describe('licence-header template', () => {
+	before(async () => {
+		context.template = await fetchPartial('licence-header.html');
+	});
+
+	it('should not mention trial by default', () => {
+		const $ = context.template({});
+
+		expect($.text()).not.to.contain('trial');
+	});
+
+	it('should mention trial when isTrial is set', () => {
+		const $ = context.template({
+			isTrial: true
+		});
+
+		expect($.text()).to.contain('trial');
+	});
+
+	it('should add a display name when set', () => {
+		const displayName = 'Company Test Name';
+		const $ = context.template({
+			displayName
+		});
+
+		expect($.text()).to.contain(displayName);
+	});
+
+	it('should show welcome test when set', () => {
+		const welcomeText = 'The quick brown fox jumped over the lazy hare';
+		const $ = context.template({
+			welcomeText
+		});
+
+		expect($.text()).to.contain(welcomeText);
+	});
+
+	it('should show welcome test when set', () => {
+		const welcomeText = 'The quick brown fox jumped over the lazy hare';
+		const $ = context.template({
+			welcomeText
+		});
+
+		expect($.text()).to.contain(welcomeText);
+	});
+
+	it('should allow html in the welcome text', () => {
+		const welcomeText = 'The quick <strong id="strong">brown</strong> fox jumped over the lazy hare';
+		const $ = context.template({
+			welcomeText
+		});
+
+		expect($('#strong').length).to.equal(1);
+	});
+});


### PR DESCRIPTION
## Feature Description
This is used across trial and company licence forms, centralising in n-conversion-forms

## Screenshots:
<img width="509" alt="Screenshot 2019-07-04 at 15 33 14" src="https://user-images.githubusercontent.com/1721150/60674013-10b06700-9e71-11e9-8e4e-1138d9e4d943.png">

## Has the necessary documentation been created / updated?
- [X] Yes
- [ ] Not required for this ticket

## Has this been given a review by Design/UX?
- [X] Yes
- [ ] Not required for this ticket
