### PR TITLE
Add print delivery related fields

### DIFF
--- a/demos/app.js
+++ b/demos/app.js
@@ -77,14 +77,24 @@ function fetchPartials (dir) {
 function compilePartial (partial) {
 	let parameters = '';
 	let examplePartials = '';
+	let exampleVars = '';
+
 	const partialData = data[partial] || {};
 	const handlebars = Handlebars();
 
 	if (partialData) {
 		if (partialData.params) {
 			parameters = Object.keys(partialData.params).map(key => {
+				let value = partialData.params[key];
+
+				if (typeof value !== 'string') {
+					exampleVars = `let ${key} = ${JSON.stringify(value, null, 2)};\n`;
+					value = `${key}`;
+				} else {
+					value = `"${value}"`;
+				}
 				// Use the key of the param as this will available on the template scope
-				return `${key}=${key}`;
+				return `${key}=${value}`;
 			}).join(' ');
 		}
 		if (partialData.partials) {
@@ -128,7 +138,7 @@ function compilePartial (partial) {
 			${rendered}
 		</div>
 
-		<textarea id="example-code" style="width:100%" readonly>${template}</textarea>
+		<textarea id="example-code" style="width:100%" readonly>${exampleVars}${template}</textarea>
 
 		<script type="text/javascript" src="/public/main.js"></script>
 	</body>

--- a/demos/data.json
+++ b/demos/data.json
@@ -1,8 +1,38 @@
 {
+  "city-town": {
+    "params": {
+      "value": "Bath"
+    }
+  },
+  "county": {
+    "params": {
+      "value": "Somerset"
+    }
+  },
   "country": {
     "params": {
       "filterList": ["GBR", "JPN", "USA", "FRA"],
       "value": "USA"
+    }
+  },
+  "delivery-address": {
+    "params": {
+      "values": ["10 Elm Street", "Apartment 1"]
+    }
+  },
+  "delivery-instructions": {
+    "params": {
+      "maxlength": "200",
+      "rows": "5",
+      "value": "Foo bar baz"
+    }
+  },
+  "delivery-start-date": {
+    "params": {
+      "date": "16th February 2019",
+      "min": "2019-02-16",
+      "max": "2019-04-13",
+      "value": "2019-02-16"
     }
   },
   "fieldset": {

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -3,8 +3,13 @@
 ## Content
 
 * [App Banner](#app-banner)
+* [City/town](#city-town)
 * [Continue Reading](#continue-reading)
+* [County](#county)
 * [Decision Maker](#decision-maker)
+* [Delivery Address](#delivery-address)
+* [Delivery Information](#delivery-information)
+* [Delivery Start Date](#delivery-start-date)
 * [Fieldset](#fieldset)
 * [Firstname](#firstname)
 * [Lastname](#lastname)
@@ -23,6 +28,19 @@ Banner that appears on confirmation pages to inform the user of our App
 ```handlebars
 {{> n-conversion-forms/partials/app-banner }}
 ```
+## City/town
+
+Renders the city/town field.
+
+```handlebars
+{{> n-conversion-forms/partials/city-town value="Bath" hasError=true isDisabled=true }}
+```
+
+### Options
+
++ `value`: string - The name of the city or town.
++ `isDisabled`: boolean - Whether the field is disabled or not.
++ `hasError`: boolean - If true it adds `o-forms--error` class to display error.
 
 ## Continue Reading
 
@@ -37,6 +55,20 @@ A message to inform the user they can read an article once they've subscribed.
 + `quote`: string - Title displayed between the quote marks.
 + `link`: string - Location of the continue reading button.
 
+## County
+
+Renders the county field.
+
+```handlebars
+{{> n-conversion-forms/partials/county value="Somerset" hasError=true isDisabled=true }}
+```
+
+### Options
+
++ `value`: string - The name of the county.
++ `isDisabled`: boolean - Whether the field is disabled or not.
++ `hasError`: boolean - If true it adds `o-forms--error` class to display error.
+
 ## Decision Maker
 
 Renders an inline yes / no radio group for users to enter if they are a decision maker in their company.
@@ -48,6 +80,53 @@ Renders an inline yes / no radio group for users to enter if they are a decision
 ### Options
 + `value`: string - Pass 'yes' or 'no' to check an option, default is unchecked.
 + `hasError`: boolean - if true it adds `o-forms--error` class to display error.
+
+## Delivery Address
+
+Renders the 3 delivery address fields (line 1/2/3).
+
+```handlebars
+{{> n-conversion-forms/partials/delivery-address values="['10 Elm Street', 'Apartment 1']" hasError=true isDisabled=true }}
+```
+
+### Options
+
++ `values`: Array - An array containing the 3 lines of the address.
++ `isDisabled`: boolean - Whether the field is disabled or not.
++ `hasError`: boolean - If true it adds `o-forms--error` class to display error.
+
+## Delivery Instructions
+
+Renders the delivery instructions text area.
+
+```handlebars
+{{> n-conversion-forms/partials/delivery-instructions value="Leave on the front porch." hasError=true isDisabled=true }}
+```
+
+### Options
+
++ `maxlength`: string - The maximum number of characters to allow in this field.
++ `rows`: string - The number of rows to render this textarea with.
++ `value`: string - The delivery instructions.
++ `isDisabled`: boolean - Whether the field is disabled or not.
++ `hasError`: boolean - If true it adds `o-forms--error` class to display error.
+
+## Delivery Start Date
+
+Renders a date field with a given start date (and accompanying copy).
+
+```handlebars
+{{> n-conversion-forms/partials/delivery-start-date value="2019-02-16" date="Saturday 16th February 2019" hasError=true isDisabled=true }}
+```
+
+### Options
+
++ `value`: string - The date in `YYYY-MM-DD` format.
++ `min`: string - The earliest start date in `YYYY-MM-DD` format.
++ `max`: string - The latest start date in `YYYY-MM-DD` format.
++ `date`: string - The date in `dddd Do MMMM YYYY` format.
++ `isDisabled`: boolean - Whether the field is disabled or not.
++ `hasError`: boolean - If true it adds `o-forms--error` class to display error.
 
 ## Fieldset
 

--- a/main.scss
+++ b/main.scss
@@ -92,6 +92,11 @@
 		&--min-content {
 			grid-template-columns: 1fr min-content min-content;
 		}
+
+		label small {
+			color: oColorsMix(black, white, 50);
+			font-weight: normal;
+		}
 	}
 
 	&__terms {

--- a/partials/city-town.html
+++ b/partials/city-town.html
@@ -1,0 +1,16 @@
+<div id="cityTownField"
+		class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}"
+		data-ui-item="form-field"
+		data-ui-item-name="cityTown"
+		data-validate="required">
+
+	<label for="cityTown" class="o-forms__label">City/town</label>
+	<input type="text" id="cityTown" name="cityTown" value="{{value}}"
+				class="o-forms__text js-field__input js-item__value"
+				data-trackable="field-cityTown"
+				autocomplete="address-level2"
+				placeholder="e.g. Bath"
+				aria-required="true" required
+				{{#if isDisabled}}disabled{{/if}}>
+
+</div>

--- a/partials/county.html
+++ b/partials/county.html
@@ -1,0 +1,15 @@
+<div id="countyField"
+		class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}"
+		data-ui-item="form-field"
+		data-ui-item-name="county"
+		data-validate="required">
+
+	<label for="county" class="o-forms__label">County <small>(optional)</small></label>
+	<input type="text" id="county" name="county" value="{{value}}"
+				class="o-forms__text js-field__input js-item__value"
+				data-trackable="field-county"
+				autocomplete="address-level3"
+				placeholder="e.g. Somerset"
+				{{#if isDisabled}}disabled{{/if}}>
+
+</div>

--- a/partials/delivery-address.html
+++ b/partials/delivery-address.html
@@ -1,0 +1,35 @@
+<div id="deliveryAddressFields"
+		class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}"
+		data-ui-item="form-field"
+		data-ui-item-name="deliveryAddress"
+		data-validate="required">
+
+	<p>
+		<label for="addressLine1" class="o-forms__label">Address line 1</label>
+		<input type="text" id="addressLine1" name="addressLine1" value="{{values.[0]}}"
+					class="o-forms__text js-field__input js-item__value"
+					data-trackable="field-addressLine1"
+					autocomplete="address-line1"
+					placeholder="e.g. 10 Elm Street"
+					aria-required="true" required
+					{{#if isDisabled}}disabled{{/if}}>
+	</p>
+	<p>
+		<label for="addressLine2" class="o-forms__label">Address line 2 <small>(optional)</small></label>
+		<input type="text" id="addressLine2" name="addressLine2" value="{{values.[1]}}"
+					class="o-forms__text js-field__input js-item__value"
+					data-trackable="field-addressLine2"
+					autocomplete="address-line2"
+					placeholder="e.g. Apartment 1"
+					{{#if isDisabled}}disabled{{/if}}>
+	</p>
+	<p>
+		<label for="addressLine3" class="o-forms__label">Address line 3 <small>(optional)</small></label>
+		<input type="text" id="addressLine3" name="addressLine3" value="{{values.[2]}}"
+					class="o-forms__text js-field__input js-item__value"
+					data-trackable="field-addressLine3"
+					autocomplete="address-line3"
+					placeholder="Enter address line 3"
+					{{#if isDisabled}}disabled{{/if}}>
+	</p>
+</div>

--- a/partials/delivery-instructions.html
+++ b/partials/delivery-instructions.html
@@ -1,0 +1,19 @@
+<div id="deliveryInstructionsField"
+		class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}"
+		data-ui-item="form-field"
+		data-ui-item-name="deliveryInstructions"
+		data-validate="required">
+
+	<label for="deliveryInstructions" class="o-forms__label">
+		Delivery instructions <small>(optional)</small><br />
+		{{#if maxlength}}<small>Max. {{maxlength}} characters</small>{{/if}}
+	</label>
+	<textarea type="text" id="deliveryInstructions" name="deliveryInstructions"
+				{{#if maxlength}}maxlength="{{maxlength}}"{{/if}}
+				{{#if rows}}rows="{{rows}}"{{/if}}
+				class="o-forms__text js-field__input js-item__value"
+				data-trackable="field-deliveryInstructions"
+				placeholder="Enter your delivery instructions"
+				{{#if isDisabled}}disabled{{/if}}>{{value}}</textarea>
+
+</div>

--- a/partials/delivery-start-date.html
+++ b/partials/delivery-start-date.html
@@ -1,0 +1,29 @@
+<div id="deliveryStartDateField"
+		class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}"
+		data-ui-item="form-field"
+		data-ui-item-name="deliveryStartDate"
+		data-validate="required">
+
+	<label for="deliveryStartDate" class="o-forms__label">
+		Delivery start date<br />
+		<small>Earliest available delivery date: {{date}}</small>
+	</label>
+
+	<input type="date" id="deliveryStartDate" name="deliveryStartDate" value="{{value}}"
+				{{#if min}}min={{min}}{{/if}}
+				{{#if max}}max={{max}}{{/if}}
+				class="o-forms__text js-field__input js-item__value"
+				data-trackable="field-deliveryStartDate"
+				aria-required="true" required
+				{{#if isDisabled}}disabled{{/if}}>
+
+	<div class="o-forms__errortext">Please select a valid start date</div>
+
+	<p>Your subscription will start from: <strong>{{date}}</strong></p>
+
+	<p>
+		NB. This will  be the closest date we can supply your newspaper based on your selected
+		date e.g. if you select a Sunday then we can start your supply on the Monday.
+	</p>
+
+</div>

--- a/tests/partials/city-town.spec.js
+++ b/tests/partials/city-town.spec.js
@@ -1,0 +1,23 @@
+const {
+	fetchPartial,
+	shouldBeDisableable,
+	shouldBeRequired,
+	shouldPopulateValue,
+	shouldError
+} = require('../helpers');
+
+let context = {};
+
+describe('city-town template', () => {
+	before(async () => {
+		context.template = await fetchPartial('city-town.html');
+	});
+
+	shouldPopulateValue(context);
+
+	shouldBeRequired(context, 'input');
+
+	shouldError(context);
+
+	shouldBeDisableable(context, 'input');
+});

--- a/tests/partials/county.spec.js
+++ b/tests/partials/county.spec.js
@@ -1,0 +1,20 @@
+const {
+	fetchPartial,
+	shouldBeDisableable,
+	shouldPopulateValue,
+	shouldError
+} = require('../helpers');
+
+let context = {};
+
+describe('county template', () => {
+	before(async () => {
+		context.template = await fetchPartial('county.html');
+	});
+
+	shouldPopulateValue(context);
+
+	shouldError(context);
+
+	shouldBeDisableable(context, 'input');
+});

--- a/tests/partials/delivery-address.spec.js
+++ b/tests/partials/delivery-address.spec.js
@@ -1,0 +1,40 @@
+const expect = require('chai').expect;
+const {
+	fetchPartial,
+	shouldBeDisableable,
+	shouldBeRequired,
+	shouldError
+} = require('../helpers');
+
+let context = {};
+
+describe('delivery-address template', () => {
+	before(async () => {
+		context.template = await fetchPartial('delivery-address.html');
+	});
+
+	it('should have a blank value if one isnt passed in', () => {
+		const $ = context.template({});
+
+		expect($('#addressLine1').val()).to.equal('');
+		expect($('#addressLine2').val()).to.equal('');
+		expect($('#addressLine3').val()).to.equal('');
+	});
+
+	it('should populate the correct value', () => {
+		const values = ['line 1', 'line 2', 'line 3'];
+		const $ = context.template({
+			values
+		});
+
+		expect($('#addressLine1').val()).to.equal(values[0]);
+		expect($('#addressLine2').val()).to.equal(values[1]);
+		expect($('#addressLine3').val()).to.equal(values[2]);
+	});
+
+	shouldBeRequired(context, '#addressLine1');
+
+	shouldError(context);
+
+	shouldBeDisableable(context, 'input');
+});

--- a/tests/partials/delivery-instructions.spec.js
+++ b/tests/partials/delivery-instructions.spec.js
@@ -1,0 +1,41 @@
+const expect = require('chai').expect;
+const {
+	fetchPartial,
+	shouldBeDisableable,
+	shouldError
+} = require('../helpers');
+
+let context = {};
+
+describe('delivery-instructions template', () => {
+	before(async () => {
+		context.template = await fetchPartial('delivery-instructions.html');
+	});
+
+	it('should set a maxlength if set', () => {
+		const $ = context.template({
+			maxlength: '200'
+		});
+
+		expect($('textarea').attr('maxlength')).to.equal('200');
+	});
+
+	it('should have a blank value if one isnt passed in', () => {
+		const $ = context.template({});
+
+		expect($('textarea').text().trim()).to.equal('');
+	});
+
+	it('should populate the correct value', () => {
+		const value = 'ThisIsAValue';
+		const $ = context.template({
+			value
+		});
+
+		expect($('textarea').text().trim()).to.equal(value);
+	});
+
+	shouldError(context);
+
+	shouldBeDisableable(context, 'textarea');
+});

--- a/tests/partials/delivery-start-date.spec.js
+++ b/tests/partials/delivery-start-date.spec.js
@@ -1,0 +1,31 @@
+const expect = require('chai').expect;
+const {
+	fetchPartial,
+	shouldBeDisableable,
+	shouldPopulateValue,
+	shouldError
+} = require('../helpers');
+
+let context = {};
+
+describe('delivery-start-date template', () => {
+	before(async () => {
+		context.template = await fetchPartial('delivery-start-date.html');
+	});
+
+	it('should set a min and max value if set', () => {
+		const $ = context.template({
+			max: '2019-04-13',
+			min: '2019-02-16'
+		});
+
+		expect($('input').attr('max')).to.equal('2019-04-13');
+		expect($('input').attr('min')).to.equal('2019-02-16');
+	});
+
+	shouldPopulateValue(context);
+
+	shouldError(context);
+
+	shouldBeDisableable(context, 'input');
+});


### PR DESCRIPTION
🐿 v2.12.4

## Feature Description

This adds various partials we need for print delivery forms with the exception of the fulfilment options (coming up next).

Also fixed the broken demo examples again (not showing the values of the parameters properly). Not sure where my previous fix for that went ¯\\\_(ツ)\_/¯

## Link to Ticket / Card:

https://trello.com/c/N460ES43/1018-3-delivery-page-render-page-with-address-section

## Screenshots:

<details><summary>City/town</summary>
<img src="https://user-images.githubusercontent.com/708296/60674441-122e5f00-9e72-11e9-9956-d60232a0f9fd.png">
</details>

<details><summary>County</summary>
<img src="https://user-images.githubusercontent.com/708296/60674453-1b1f3080-9e72-11e9-8d79-dda0836a8389.png">
</details>

<details><summary>Delivery address</summary>
<img src="https://user-images.githubusercontent.com/708296/60674470-21ada800-9e72-11e9-880a-99ca50c4e73e.png">
</details>

<details><summary>Delivery instructions</summary>
<img src="https://user-images.githubusercontent.com/708296/60674484-27a38900-9e72-11e9-8d85-eb2f4443ba04.png">
</details>

<details><summary>Delivery start date</summary>
<img src="https://user-images.githubusercontent.com/708296/60674497-2eca9700-9e72-11e9-8ce2-e111bae85118.png">
</details>

## Has the necessary documentation been created / updated?
- [x] Yes

## Has this been given a review by Design/UX?
- [ ] Yes
- [ ] Not required for this ticket
