### PR TITLE
Add delivery-options partial

### DIFF
--- a/demos/data.json
+++ b/demos/data.json
@@ -27,6 +27,23 @@
       "value": "Foo bar baz"
     }
   },
+  "delivery-option": {
+    "params": {
+      "isSingle": true,
+      "options": [
+        {
+          "value": "PV"
+        },
+        {
+          "value": "HD",
+          "isSelected": true
+        },
+        {
+          "value": "EV"
+        }
+      ]
+    }
+  },
   "delivery-start-date": {
     "params": {
       "date": "16th February 2019",
@@ -98,19 +115,23 @@
     "params": {
       "options": [
         {
-          "name": "Test",
+          "name": "trial",
           "value": "Test",
           "description": "The quick brown fox jumped over the lazy hare."
         }, {
-          "name": "Test 1",
+          "name": "annual",
           "value": "Test 1",
           "description": "The <strong>quick</strong> brown fox<br />jumped over the lazy <a href=\"#\">hare</a>.",
           "selected": true
         }, {
-          "name": "Test 2",
+          "name": "quarterly",
           "value": "Test 2",
           "description": "The <strong>quick</strong> brown fox<br />jumped over the lazy <a href=\"#\">hare</a>.",
           "discount": "25%"
+        }, {
+          "name": "monthly",
+          "value": "Test 3",
+          "description": "The <strong>quick</strong> brown fox<br />jumped over the lazy <a href=\"#\">hare</a>."
         }
       ]
     }

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -9,6 +9,7 @@
 * [Decision Maker](#decision-maker)
 * [Delivery Address](#delivery-address)
 * [Delivery Information](#delivery-information)
+* [Delivery Option](#delivery-option)
 * [Delivery Start Date](#delivery-start-date)
 * [Fieldset](#fieldset)
 * [Firstname](#firstname)
@@ -110,6 +111,21 @@ Renders the delivery instructions text area.
 + `value`: string - The delivery instructions.
 + `isDisabled`: boolean - Whether the field is disabled or not.
 + `hasError`: boolean - If true it adds `o-forms--error` class to display error.
+
+## Delivery Option
+
+Display delivery options with radio buttons for users to choose between.
+
+```handlebars
+{{> n-conversion-forms/partials/delivery-option options=options }}
+```
+
+### Options
+
++ `isSingle`: boolean - Whether there is only one single option being presented.
++ `options`: array - An array of objects that can have the following properties.
+  + `value`: string - Value to send when selected.
+  + `isSelected`: boolean - Set to true for the term to be selected.
 
 ## Delivery Start Date
 

--- a/main.scss
+++ b/main.scss
@@ -261,6 +261,17 @@
 		}
 	}
 
+	@include bigRadioButton($className: '.ncf__delivery-option');
+	&__delivery-option--single {
+		.ncf__delivery-option__label {
+			// We need to hide the radio button if this the sole delivery option
+			&::after,
+			&::before {
+				display: none;
+			}
+		}
+	}
+
 	@include ncfMessage();
 	@include ncfPackageChange();
 	@include ncfPaymentTerm();

--- a/partials/debug.html
+++ b/partials/debug.html
@@ -41,6 +41,7 @@
 		primaryTelephone: '0987654321',
 		country: 'GBR',
 		billingCountry: 'GBR',
+		postCode: 'EC4M 9JA',
 		industry: 'DEF',
 		responsibility: 'ADL',
 		position: 'AS'

--- a/partials/delivery-option.html
+++ b/partials/delivery-option.html
@@ -1,0 +1,29 @@
+<div id="deliveryOptionsField" class="o-forms__group ncf__delivery-option{{#if isSingle}} ncf__delivery-option--single{{/if}}">
+	{{#each options}}
+	<div class="ncf__delivery-option__item">
+		<input type="radio" id="{{this.value}}" name="deliveryOptions" value="{{this.value}}" class="o-forms__radio o-forms__radio--right ncf__delivery-option__input o-forms__radio-button--my-custom-theme"{{#if this.isSelected}} checked="checked"{{/if}}>
+		<label for="{{this.value}}" class="o-forms__label ncf__delivery-option__label">
+			{{#ifEquals this.value 'PV'}}
+			<span class="ncf__delivery-option__title">Paper vouchers</span>
+			<div class="ncf__delivery-option__description">
+				13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
+			</div>
+			{{/ifEquals}}
+
+			{{#ifEquals this.value 'HD'}}
+			<span class="ncf__delivery-option__title">Home delivery</span>
+			<div class="ncf__delivery-option__description">
+				Free delivery to your home or office before 7am.
+			</div>
+			{{/ifEquals}}
+
+			{{#ifEquals this.value 'EV'}}
+			<span class="ncf__delivery-option__title">Electronic vouchers</span>
+			<div class="ncf__delivery-option__description">
+				Delivered via email and card, redeemable at retailers nationwide.
+			</div>
+			{{/ifEquals}}
+		</label>
+	</div>
+	{{/each}}
+</div>

--- a/styles/_shared.scss
+++ b/styles/_shared.scss
@@ -1,0 +1,52 @@
+@mixin bigRadioButton($className) {
+	.o-forms__radio + .o-forms__label {
+		padding: 14px 20px;
+		min-height: 110px;
+		border: 2px solid oColorsGetPaletteColor('teal');
+		text-align: left;
+		margin: 8px 0;
+
+		// radio button styling
+		&::before {
+			border: 2px solid oColorsGetPaletteColor('teal');
+			top: 43px;
+			right: 14px;
+		}
+
+		&::after {
+			top: 43px;
+			right: 14px;
+		}
+	}
+
+	.o-forms__radio:checked + .o-forms__label {
+		background-color: oColorsGetPaletteColor('teal');
+		color: oColorsGetPaletteColor('white');
+
+		// radio button styling
+		&::before {
+			border: 2px solid oColorsGetPaletteColor('white');
+		}
+
+		&::after {
+			background-color: oColorsGetPaletteColor('white');
+		}
+	}
+
+	#{$className}__item {
+		margin-bottom: 10px;
+
+		&--discount {
+			margin-top: 26px;
+		}
+	}
+
+	#{$className}__title {
+		font-weight: oFontsWeight('semibold');
+		@include oTypographySans($scale: 2);
+	}
+
+	#{$className}__description {
+		padding-top: 14px;
+	}
+}

--- a/styles/payment-term.scss
+++ b/styles/payment-term.scss
@@ -1,57 +1,8 @@
+@import './shared';
+
 @mixin ncfPaymentTerm() {
+	@include bigRadioButton($className: '.ncf__payment-term');
 	&__payment-term {
-
-		.o-forms__radio + .o-forms__label {
-			padding: 14px 20px;
-			min-height: 110px;
-			border: 2px solid oColorsGetPaletteColor('teal');
-			text-align: left;
-			margin: 8px 0;
-
-			// radio button styling
-			&::before {
-				border: 2px solid oColorsGetPaletteColor('teal');
-				top: 43px;
-				right: 14px;
-			}
-
-			&::after {
-				top: 43px;
-				right: 14px;
-			}
-		}
-
-		.o-forms__radio:checked + .o-forms__label {
-			background-color: oColorsGetPaletteColor('teal');
-			color: oColorsGetPaletteColor('white');
-
-			// radio button styling
-			&::before {
-				border: 2px solid oColorsGetPaletteColor('white');
-			}
-
-			&::after {
-				background-color: oColorsGetPaletteColor('white');
-			}
-		}
-
-		&__item {
-			margin-bottom: 10px;
-
-			&--discount {
-				margin-top: 26px;
-			}
-		}
-
-		&__title {
-			font-weight: oFontsWeight('semibold');
-			@include oTypographySans($scale: 2);
-		}
-
-		&__description {
-			padding-top: 14px;
-		}
-
 		&__discount {
 			background-color: oColorsGetPaletteColor('black');
 			color: oColorsGetPaletteColor('white');

--- a/tests/partials/delivery-option.spec.js
+++ b/tests/partials/delivery-option.spec.js
@@ -1,0 +1,79 @@
+const { expect } = require('chai');
+const {
+	fetchPartial,
+} = require('../helpers');
+
+let context = {};
+const TITLE_SELECTOR = '.ncf__delivery-option__title';
+
+describe('delivery-option', () => {
+	before(async () => {
+		context.template = await fetchPartial('delivery-option.html');
+	});
+
+	it('should show no options by default', () => {
+		const $ = context.template({});
+		expect($('input').length).to.equal(0);
+	});
+
+	it('should draw a single option', () => {
+		const $ = context.template({ options: [{}]});
+		expect($('input').length).to.equal(1);
+	});
+
+	it('should draw multiple options', () => {
+		const $ = context.template({ options: [{}, {}, {}]});
+		expect($('input').length).to.equal(3);
+	});
+
+	it('should hide the radio button if isSingle is passed', () => {
+		const $ = context.template({ isSingle: true });
+		expect($('.ncf__delivery-option--single').length).to.equal(1);
+	});
+
+	describe('Paper vouchers', () => {
+		it('should show the correct title copy', () => {
+			const value = 'PV';
+			const $ = context.template({ options: [{
+				value
+			}]});
+			expect($(TITLE_SELECTOR).text()).to.equal('Paper vouchers');
+		});
+	});
+
+	describe('Home delivery', () => {
+		it('should show the correct title copy', () => {
+			const value = 'HD';
+			const $ = context.template({ options: [{
+				value
+			}]});
+			expect($(TITLE_SELECTOR).text()).to.contain('Home delivery');
+		});
+	});
+
+	describe('EV', () => {
+		it('should show the correct title copy', () => {
+			const value = 'EV';
+			const $ = context.template({ options: [{
+				value
+			}]});
+			expect($(TITLE_SELECTOR).text()).to.contain('Electronic vouchers');
+		});
+	});
+
+	it('should populate the value', () => {
+		const value = 'PV';
+		const $ = context.template({ options: [{ value }]});
+		expect($('input').attr('id')).to.equal(value);
+		expect($('input').attr('value')).to.equal(value);
+		expect($('label').attr('for')).to.equal(value);
+	});
+
+	it('should select the correct radio button', () => {
+		const option1 = { value: 'PV' };
+		const option2 = { value: 'HD', isSelected: true };
+		const $ = context.template({ options: [option1, option2]});
+		expect($('input[checked]').attr('value')).to.equal(option2.value);
+	});
+
+});


### PR DESCRIPTION
🐿 v2.12.4

## Feature Description

Also fixed up the `payment-terms` in the demo.

## Link to Ticket / Card:

https://trello.com/c/Za8rkwXw/1321-5-delivery-page-fulfilment-options

## Screenshots:

<img src="https://user-images.githubusercontent.com/708296/60817983-9c3d3700-a194-11e9-82bf-057794f946cc.png">

## Has the necessary documentation been created / updated?
- [x] Yes

## Has this been given a review by Design/UX?
- [x] Yes
