### PR TITLE
Print confirmation

### DIFF
--- a/demos/data.json
+++ b/demos/data.json
@@ -4,6 +4,42 @@
       "value": "Bath"
     }
   },
+  "confirmation": {
+    "params": {
+      "isPrintOnly": false,
+      "offer": "Premium Digital & Print",
+      "email": "test@example.com",
+      "details": [
+        {
+          "title": "Trial charge",
+          "data": "£XXXX"
+        },
+        {
+          "title": "Trial end date",
+          "data": "June 11th, 2019",
+          "description": "You'll be billed per month from this date"
+        },
+        {
+          "title": "Annual payment",
+          "data": "£XXXX"
+        },
+        {
+          "title": "Renewal date",
+          "data": "June 11th, 2019"
+        },
+        {
+          "title": "Payment method",
+          "data": "Credit Card"
+        }
+      ]
+    }
+  },
+  "continue-reading": {
+    "params": {
+      "quote": "The quick brown fox jumped over the lazy hare",
+      "link": "https://google.com"
+    }
+  },
   "county": {
     "params": {
       "value": "Somerset"
@@ -13,6 +49,20 @@
     "params": {
       "filterList": ["GBR", "JPN", "USA", "FRA"],
       "value": "USA"
+    }
+  },
+  "debug": {
+    "params": {
+      "isTest": true,
+      "showHelpers": true,
+      "links": {
+        "Google": "https://www.google.com"
+      }
+    }
+  },
+  "decision-maker": {
+    "params": {
+      "value": "yes"
     }
   },
   "delivery-address": {
@@ -46,6 +96,19 @@
   "form": {
     "partials": {
       "fields": "Inline content here."
+    }
+  },
+  "licence-confirmation": {
+    "params": {
+      "isTrial": true,
+      "duration": "30 day"
+    }
+  },
+  "licence-header": {
+    "params": {
+      "displayName": "Company",
+      "isTrial": true,
+      "welcomeText": "The quick brown fox jumped over the lazy hare"
     }
   },
   "loader": {
@@ -150,68 +213,6 @@
         "name": "Payment",
         "url": "#payment"
       }]
-    }
-  },
-  "confirmation": {
-    "params": {
-      "offer": "Premium Digital & Print",
-      "email": "test@example.com",
-      "details": [
-        {
-          "title": "Trial charge",
-          "data": "£XXXX"
-        },
-        {
-          "title": "Trial end date",
-          "data": "June 11th, 2019",
-          "description": "You'll be billed per month from this date"
-        },
-        {
-          "title": "Annual payment",
-          "data": "£XXXX"
-        },
-        {
-          "title": "Renewal date",
-          "data": "June 11th, 2019"
-        },
-        {
-          "title": "Payment method",
-          "data": "Credit Card"
-        }
-      ]
-    }
-  },
-  "debug": {
-    "params": {
-      "isTest": true,
-      "showHelpers": true,
-      "links": {
-        "Google": "https://www.google.com"
-      }
-    }
-  },
-  "decision-maker": {
-    "params": {
-      "value": "yes"
-    }
-  },
-  "licence-confirmation": {
-    "params": {
-      "isTrial": true,
-      "duration": "30 day"
-    }
-  },
-  "licence-header": {
-    "params": {
-      "displayName": "Company",
-      "isTrial": true,
-      "welcomeText": "The quick brown fox jumped over the lazy hare"
-    }
-  },
-  "continue-reading": {
-    "params": {
-      "quote": "The quick brown fox jumped over the lazy hare",
-      "link": "https://google.com"
     }
   }
 }

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -4,6 +4,7 @@
 
 * [App Banner](#app-banner)
 * [City/town](#city-town)
+* [Confirmation](#confirmation)
 * [Continue Reading](#continue-reading)
 * [County](#county)
 * [Decision Maker](#decision-maker)
@@ -42,6 +43,25 @@ Renders the city/town field.
 + `value`: string - The name of the city or town.
 + `isDisabled`: boolean - Whether the field is disabled or not.
 + `hasError`: boolean - If true it adds `o-forms--error` class to display error.
+
+## Confirmation
+
+Renders the subscription confirmation page.
+Displayed cta and link are different for print only offers.
+
+```handlebars
+{{> n-conversion-forms/partials/confirmation isPrintOnly=true offer="Premium Digital & Print" email="test@example.com" details=details }}
+```
+
+### Options
+
++ `isPrintOnly`: boolean - is this offer a print only offer or not.
++ `offer`: string - offer display name.
++ `email`: email - user email.
++ `details`: array - objects with the following properties.
+  + `title`: string
+  + `data`: string
+  + `description`: string
 
 ## Continue Reading
 

--- a/partials/confirmation.html
+++ b/partials/confirmation.html
@@ -43,6 +43,10 @@
 		See our <a class="ncf__link ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="_top" rel="noopener">Terms &amp; Conditions</a> for details on how to cancel.
 	</p>
 	<p class="ncf__center">
+	{{#if isPrintOnly}}
+		<a href="/todaysnewspaper " class="ncf__button ncf__button--submit">Explore our E-Paper</a>
+	{{else}}
 		<a href="/signup/newsletters" class="ncf__button ncf__button--submit">Start exploring</a>
+	{{/if}}
 	</p>
 </div>

--- a/tests/partials/confirmation.spec.js
+++ b/tests/partials/confirmation.spec.js
@@ -76,4 +76,24 @@ describe('confirmation template', () => {
 		expect($('dl dt').length).to.equal(0);
 		expect(Array.from($('a')).filter(elem => elem.attribs['data-trackable'] && elem.attribs['data-trackable'].includes('yourAccount')).length).to.equal(1);
 	});
+
+	it('should display correct button label for print only offer', () => {
+		const isPrintOnly = true;
+		const $ = context.template({
+			isPrintOnly
+		});
+
+		const buttonText = 'Explore our E-Paper';
+		expect($.text()).to.contain(buttonText);
+	});
+
+	it('should display correct button label for non print only offer', () => {
+		const isPrintOnly = false;
+		const $ = context.template({
+			isPrintOnly
+		});
+
+		const buttonText = 'Start exploring';
+		expect($.text()).to.contain(buttonText);
+	});
 });


### PR DESCRIPTION
## Feature Description
for users who have bought a print only product (not for Bundle) we should remove the"Start Exploring" button and have something else : ie "Thank you"or a link to direct them to the Epaper

## Link to Ticket / Card:
https://trello.com/c/sPiPtd8t/736-1-delivery-journey-different-cta-on-the-confirmation-page

## Screenshots:
![image](https://user-images.githubusercontent.com/6513313/60881137-f4c80f00-a23c-11e9-9d46-0910a49d56a0.png)


## Has the necessary documentation been created / updated?
- [x] Yes
- [ ] Not required for this ticket

## Has this been given a review by Design/UX?
- [ ] Yes
- [x] Not required for this ticket
