### PR TITLE
Adds a new method to the Email class for validating a valid email domain

### DIFF
--- a/tests/utils/email.spec.js
+++ b/tests/utils/email.spec.js
@@ -149,63 +149,77 @@ describe('Email', () => {
 
 				expect(typeof handler).to.equal('function');
 			});
-
-			it('should call the onNotFound callback if the email field has no value.', () => {
-				email.handleEmailValidatorChange(url, onSuccess, onFailure);
-				expect(onSuccess.called).to.be.false;
-				expect(onFailure.called).to.be.true;
-			});
-
-			it('should call the specified url with the correct params if the email field has a value', () => {
-				fetchMock.mock(url, 200);
-
-				emailElement.value = 'test@example.com';
-				email.handleEmailValidatorChange(url, onSuccess, onFailure);
-
-				expect(fetchMock.called(url)).to.be.true;
-				expect(fetchMock.lastOptions(url)).to.deep.equal({
-					method: 'POST',
-					credentials: 'include',
-					headers: {
-						'Content-Type': 'application/json'
-					},
-					body: JSON.stringify({
-						email: 'test@example.com',
-						csrfToken: '1234567890'
-					})
-				});
-			});
-
-			it('should call the onNotFound callback if the call to the url fails', async () => {
-				fetchMock.mock(url, 500);
-
-				emailElement.value = 'test@example.com';
-				await email.handleEmailValidatorChange(url, onSuccess, onFailure);
-
-				expect(onSuccess.called).to.be.false;
-				expect(onFailure.called).to.be.true;
-			});
-
-			it('should call the onFound callback if the user exists', async () => {
-				fetchMock.mock(url, 'true');
-
-				emailElement.value = 'test@example.com';
-				await email.handleEmailValidatorChange(url, onSuccess, onFailure);
-
-				expect(onSuccess.called).to.be.true;
-				expect(onFailure.called).to.be.false;
-			});
-
-			it('should call the onNotFound callback if the user doesn\'t exist', async () => {
-				fetchMock.mock(url, 'false');
-
-				emailElement.value = 'test@example.com';
-				await email.handleEmailValidatorChange(url, onSuccess, onFailure);
-
-				expect(onSuccess.called).to.be.false;
-				expect(onFailure.called).to.be.true;
-			});
 		});
 	}
+
+	describe('handleEmailValidatorChange', () => {
+		const url = '/foo';
+		let email;
+		let onSuccess;
+		let onFailure;
+
+		beforeEach(() => {
+			onSuccess = sinon.stub();
+			onFailure = sinon.stub();
+
+			email = new Email(document);
+		});
+
+		it('should call the onNotFound callback if the email field has no value.', () => {
+			email.handleEmailValidatorChange(url, onSuccess, onFailure);
+			expect(onSuccess.called).to.be.false;
+			expect(onFailure.called).to.be.true;
+		});
+
+		it('should call the specified url with the correct params if the email field has a value', () => {
+			fetchMock.mock(url, 200);
+
+			emailElement.value = 'test@example.com';
+			email.handleEmailValidatorChange(url, onSuccess, onFailure);
+
+			expect(fetchMock.called(url)).to.be.true;
+			expect(fetchMock.lastOptions(url)).to.deep.equal({
+				method: 'POST',
+				credentials: 'include',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({
+					email: 'test@example.com',
+					csrfToken: '1234567890'
+				})
+			});
+		});
+
+		it('should call the onNotFound callback if the call to the url fails', async () => {
+			fetchMock.mock(url, 500);
+
+			emailElement.value = 'test@example.com';
+			await email.handleEmailValidatorChange(url, onSuccess, onFailure);
+
+			expect(onSuccess.called).to.be.false;
+			expect(onFailure.called).to.be.true;
+		});
+
+		it('should call the onFound callback if the user exists', async () => {
+			fetchMock.mock(url, 'true');
+
+			emailElement.value = 'test@example.com';
+			await email.handleEmailValidatorChange(url, onSuccess, onFailure);
+
+			expect(onSuccess.called).to.be.true;
+			expect(onFailure.called).to.be.false;
+		});
+
+		it('should call the onNotFound callback if the user doesn\'t exist', async () => {
+			fetchMock.mock(url, 'false');
+
+			emailElement.value = 'test@example.com';
+			await email.handleEmailValidatorChange(url, onSuccess, onFailure);
+
+			expect(onSuccess.called).to.be.false;
+			expect(onFailure.called).to.be.true;
+		});
+	});
 
 });

--- a/utils/email.js
+++ b/utils/email.js
@@ -56,7 +56,7 @@ class Email {
 	 */
 	registerEmailExistsCheck (url, onFound, onNotFound) {
 		const handler = () => {
-			this.handleEmailExistsChange(url, onFound, onNotFound);
+			this.handleEmailValidatorChange(url, onFound, onNotFound);
 		};
 
 		this.$email.addEventListener('change', handler);
@@ -65,13 +65,31 @@ class Email {
 	}
 
 	/**
-	 * Calls the membership service to check the email
+	 * Register the email domain allowed call.
+	 * **NB** It's recommended you have a hidden #csrfToken input element that you validate the request with in your backend service.
+	 *
+	 * @param {String} url URL to the email domain allowed endpoint
+	 * @param {Function} onAllowed Callback function to run if the email is allowed
+	 * @param {Function} onNotAllowed Callback function to run if the email is not allowed
+	 */
+	emailDomainAllowedCheck (url, onAllowed, onNotAllowed) {
+		const handler = () => {
+			this.handleEmailValidatorChange(url, onAllowed, onNotAllowed);
+		};
+
+		this.$email.addEventListener('change', handler);
+
+		return handler;
+	}
+
+	/**
+	 * Calls the membership service to check the email against an endpoint
 	 * @param {String} url URL of email checking service
-	 * @param {Function} onFound Function to call when email found
-	 * @param {Function} onNotFound Function to call when not found
+	 * @param {Function} success Function to call when returns true
+	 * @param {Function} failure Function to call when returns false
 	 * @return {Promise}
 	 */
-	handleEmailExistsChange (url, onFound, onNotFound) {
+	handleEmailValidatorChange (url, success, failure) {
 		if (this.$email.value) {
 			return fetch(url, {
 				method: 'POST',
@@ -87,14 +105,14 @@ class Email {
 				.then(fetchres.json)
 				.then(response => {
 					if (response === true) {
-						onFound();
+						success();
 					} else {
-						onNotFound();
+						failure();
 					}
 				})
-				.catch(onNotFound);
+				.catch(failure);
 		} else {
-			onNotFound();
+			failure();
 		}
 	};
 


### PR DESCRIPTION
 🐿 v2.12.4

## Feature Description
Required as part of the work in https://github.com/Financial-Times/next-subscribe/pull/475

Adds a new method to the `Email` class to run change validation to check if an email domain is valid or not.

## Link to Ticket / Card:
https://trello.com/c/4rS4MI18/1346-3-client-side-details-controller

## Has the necessary documentation been created / updated?
- [ ] Yes
- [x] Not required for this ticket

## Has this been given a review by Design/UX?
- [ ] Yes
- [x] Not required for this ticket
