### PR TITLE
Make delivery option input name singular

### DIFF
--- a/partials/delivery-option.html
+++ b/partials/delivery-option.html
@@ -1,7 +1,7 @@
-<div id="deliveryOptionsField" class="o-forms__group ncf__delivery-option{{#if isSingle}} ncf__delivery-option--single{{/if}}">
+<div id="deliveryOptionField" class="o-forms__group ncf__delivery-option{{#if isSingle}} ncf__delivery-option--single{{/if}}">
 	{{#each options}}
 	<div class="ncf__delivery-option__item">
-		<input type="radio" id="{{this.value}}" name="deliveryOptions" value="{{this.value}}" class="o-forms__radio o-forms__radio--right ncf__delivery-option__input o-forms__radio-button--my-custom-theme"{{#if this.isSelected}} checked="checked"{{/if}}>
+		<input type="radio" id="{{this.value}}" name="deliveryOption" value="{{this.value}}" class="o-forms__radio o-forms__radio--right ncf__delivery-option__input o-forms__radio-button--my-custom-theme"{{#if this.isSelected}} checked="checked"{{/if}}>
 		<label for="{{this.value}}" class="o-forms__label ncf__delivery-option__label">
 			{{#ifEquals this.value 'PV'}}
 			<span class="ncf__delivery-option__title">Paper vouchers</span>


### PR DESCRIPTION
 🐿 v2.12.4

## Feature Description

Just realised I had named this in a plural fashion but it should actually be singular.
