### PR TITLE
fix: disable default empty country option

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "cheerio": "^1.0.0-rc.2",
     "fetch-mock": "^7.2.0",
     "jsdom": "15.1.0",
-    "jsdom-global": "3.0.2",
     "mocha": "^5.1.1",
     "node-sass": "^4.9.4",
     "nodemon": "^1.17.5",

--- a/partials/billing-country.html
+++ b/partials/billing-country.html
@@ -8,7 +8,7 @@
 			data-trackable="field-billing-country"
 			{{#if isDisabled}}disabled{{/if}}>
 
-		<option value>Please select a country</option>
+		<option value disabled>Please select a country</option>
 		{{#each countries as |country|}}
 			{{#if this.label}}
 			<optgroup label="{{country.label}}">

--- a/tests/utils/validation.spec.js
+++ b/tests/utils/validation.spec.js
@@ -1,6 +1,8 @@
 const expect = require('chai').expect;
 const proxyquire = require('proxyquire').noCallThru();
 const sinon = require('sinon');
+const jsdom = require('jsdom');
+const { JSDOM } = jsdom;
 
 const DomHelper = require('../helpers/dom');
 
@@ -15,12 +17,10 @@ const Validation = proxyquire('../../utils/validation', {
 	'o-forms': OFormsStub
 });
 
-global.window = {};
 
 let $form;
 let checkboxAddEventListener;
 let checkValidityStub;
-let cleanupJSDom;
 let insertBeforeStub;
 let removeChildStub;
 let requiredElListener;
@@ -40,8 +40,18 @@ const createElement = (config) => {
 
 describe('Validation', () => {
 
+	before(() => {
+		const dom = new JSDOM();
+		global.window = dom.window;
+		global.document = dom.window.document;
+	});
+
+	after(() => {
+		delete global.window;
+		delete global.document;
+	});
+
 	beforeEach(() => {
-		cleanupJSDom = require('jsdom-global')();
 		$form = document.createElement('form');
 		sandbox = sinon.createSandbox();
 
@@ -72,7 +82,6 @@ describe('Validation', () => {
 	});
 
 	afterEach(() => {
-		cleanupJSDom();
 		sandbox.restore();
 	});
 


### PR DESCRIPTION
## Feature Description

When selecting the "Please select a country" option, the change handler was being executed with a blank countryCode, leading to issues when attempting to retrieve the gateway details. This disables the default option so its unavailable for selection.

## Link to Ticket / Card:

https://trello.com/c/keOttSIW/1363-payment-page-config-call-is-throwing-errors

## Screenshots: N/A

## Has the necessary documentation been created / updated?
- [ ] Yes
- [x] Not required for this ticket

## Has this been given a review by Design/UX?
- [ ] Yes
- [x] Not required for this ticket
