### PR TITLE
Postcode lowercase

### DIFF
--- a/partials/billing-postcode.html
+++ b/partials/billing-postcode.html
@@ -1,28 +1,28 @@
-{{#*inline "postCodeLabel"}}
+{{#*inline "postcodeLabel"}}
 {{#if isZipCode}}Zip code{{else}}Post code{{/if}}
 {{/inline}}
-<div id="billingPostCodeField"
+<div id="billingPostcodeField"
 		class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}{{#if isHidden}} n-ui-hide{{/if}}"
 		data-ui-item="form-field"
-		data-ui-item-name="deliveryPostCode"
+		data-ui-item-name="deliveryPostcode"
 		data-validate="required">
 
-	<label for="billingPostCode" class="o-forms__label">
-		Billing {{> postCodeLabel }}
+	<label for="billingPostcode" class="o-forms__label">
+		Billing {{> postcodeLabel }}
 	</label>
 
 	<input type="text"
-			id="billingPostCode"
-			name="billingPostCode"
+			id="billingPostcode"
+			name="billingPostcode"
 			value="{{value}}"
-			placeholder="{{> postCodeLabel }}"
+			placeholder="{{> postcodeLabel }}"
 			autocomplete="postal-code"
 			class="o-forms__text js-field__input js-item__value"
-			data-trackable="billing-post-code"
+			data-trackable="billing-postcode"
 			aria-required="true" required
 			{{#if pattern}}pattern="{{pattern}}"{{/if}}
 			{{#if isDisabled}}disabled{{/if}}>
 
-	<div class="o-forms__errortext">Please enter a valid {{> postCodeLabel }}.</div>
+	<div class="o-forms__errortext">Please enter a valid {{> postcodeLabel }}.</div>
 
 </div>

--- a/partials/debug.html
+++ b/partials/debug.html
@@ -32,14 +32,14 @@
 	var FORM_SELECTOR = 'form.ncf';
 	var debugData = {
 		billingCountry: 'GBR',
-		billingPostCode: 'EC4M9BT',
+		billingPostcode: 'EC4M9BT',
 		country: 'GBR',
 		deliveryAddressLine1: 'delivery test1',
 		deliveryAddressLine2: 'delivery test2',
 		deliveryAddressLine3: 'delivery test3',
 		deliveryCityTown: 'delivery city',
 		deliveryCounty: 'delivery county',
-		deliveryPostCode: 'EC4M9BT',
+		deliveryPostcode: 'EC4M9BT',
 		email: Date.now() + '@ftqa.org',
 		firstName: 'Test',
 		industry: 'DEF',

--- a/partials/delivery-postcode.html
+++ b/partials/delivery-postcode.html
@@ -1,28 +1,28 @@
-{{#*inline "postCodeLabel"}}
+{{#*inline "postcodeLabel"}}
 {{#if isZipCode}}Zip code{{else}}Post code{{/if}}
 {{/inline}}
-<div id="deliveryPostCodeField"
+<div id="deliveryPostcodeField"
 		class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}{{#if isHidden}} n-ui-hide{{/if}}"
 		data-ui-item="form-field"
-		data-ui-item-name="deliveryPostCode"
+		data-ui-item-name="deliveryPostcode"
 		data-validate="required">
 
-	<label for="deliveryPostCode" class="o-forms__label">
-		Delivery {{> postCodeLabel }}
+	<label for="deliveryPostcode" class="o-forms__label">
+		Delivery {{> postcodeLabel }}
 	</label>
 
 	<input type="text"
-			id="deliveryPostCode"
-			name="deliveryPostCode"
+			id="deliveryPostcode"
+			name="deliveryPostcode"
 			value="{{value}}"
-			placeholder="{{> postCodeLabel }}"
+			placeholder="{{> postcodeLabel }}"
 			autocomplete="postal-code"
 			class="o-forms__text js-field__input js-item__value"
-			data-trackable="delivery-post-code"
+			data-trackable="delivery-postcode"
 			aria-required="true" required
 			{{#if pattern}}pattern="{{pattern}}"{{/if}}
 			{{#if isDisabled}}disabled{{/if}}>
 
-	<div class="o-forms__errortext">Please enter a valid {{> postCodeLabel }}.</div>
+	<div class="o-forms__errortext">Please enter a valid {{> postcodeLabel }}.</div>
 
 </div>

--- a/tests/partials/billing-postcode.spec.js
+++ b/tests/partials/billing-postcode.spec.js
@@ -42,5 +42,5 @@ describe('billing postcode template', () => {
 
 	shouldBeDisableable(context, 'input');
 
-	shouldBeHiddable(context, '#billingPostCodeField');
+	shouldBeHiddable(context, '#billingPostcodeField');
 });

--- a/tests/partials/delivery-postcode.spec.js
+++ b/tests/partials/delivery-postcode.spec.js
@@ -36,5 +36,5 @@ describe('delivery postcode template', () => {
 
 	shouldBeDisableable(context, 'input');
 
-	shouldBeHiddable(context, '#deliveryPostCodeField');
+	shouldBeHiddable(context, '#deliveryPostcodeField');
 });

--- a/utils/billing-postcode.js
+++ b/utils/billing-postcode.js
@@ -1,9 +1,9 @@
 const FormElement = require('./form-element');
 
-class BillingPostCode extends FormElement {
+class BillingPostcode extends FormElement {
 	constructor (document) {
-		super(document, '.ncf #billingPostCodeField');
+		super(document, '.ncf #billingPostcodeField');
 	}
 }
 
-module.exports = BillingPostCode;
+module.exports = BillingPostcode;


### PR DESCRIPTION
## Feature Description
- use consistent `postcode` naming for postal codes
- keep postcode.html template unchanged for backward compatibility (it has a mixture of postcode/postCode), it is marked as deprecated

## Link to Ticket / Card:
n/a

## Screenshots:
n/a

## Has the necessary documentation been created / updated?
- [x] Yes
- [ ] Not required for this ticket

## Has this been given a review by Design/UX?
- [ ] Yes
- [x] Not required for this ticket
