### PR TITLE
use separate deliveryAddress lines rather than array

### DIFF
--- a/demos/data.json
+++ b/demos/data.json
@@ -69,7 +69,8 @@
   },
   "delivery-address": {
     "params": {
-      "values": ["10 Elm Street", "Apartment 1"]
+      "line1": "20 Elm Street",
+      "line2": "Apartment 2"
     }
   },
   "delivery-city-town": {

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -145,7 +145,7 @@ Renders an inline yes / no radio group for users to enter if they are a decision
 Renders the 3 delivery address fields (line 1/2/3).
 
 ```handlebars
-{{> n-conversion-forms/partials/delivery-address values="['10 Elm Street', 'Apartment 1']" hasError=true isDisabled=true }}
+{{> n-conversion-forms/partials/delivery-address line1="10 Elm Street" line2="Apartment 1" hasError=true isDisabled=true }}
 ```
 
 ### Options

--- a/partials/delivery-address.html
+++ b/partials/delivery-address.html
@@ -6,7 +6,7 @@
 
 	<p>
 		<label for="deliveryAddressLine1" class="o-forms__label">Address line 1</label>
-		<input type="text" id="deliveryAddressLine1" name="deliveryAddressLine1" value="{{values.[0]}}"
+		<input type="text" id="deliveryAddressLine1" name="deliveryAddressLine1" value="{{line1}}"
 				class="o-forms__text js-field__input js-item__value"
 				data-trackable="field-deliveryAddressLine1"
 				autocomplete="address-line1"
@@ -16,7 +16,7 @@
 	</p>
 	<p>
 		<label for="deliveryAddressLine2" class="o-forms__label">Address line 2 <small>(optional)</small></label>
-		<input type="text" id="deliveryAddressLine2" name="deliveryAddressLine2" value="{{values.[1]}}"
+		<input type="text" id="deliveryAddressLine2" name="deliveryAddressLine2" value="{{line2}}"
 					class="o-forms__text js-field__input js-item__value"
 					data-trackable="field-deliveryAddressLine2"
 					autocomplete="address-line2"
@@ -25,7 +25,7 @@
 	</p>
 	<p>
 		<label for="deliveryAddressLine3" class="o-forms__label">Address line 3 <small>(optional)</small></label>
-		<input type="text" id="deliveryAddressLine3" name="deliveryAddressLine3" value="{{values.[2]}}"
+		<input type="text" id="deliveryAddressLine3" name="deliveryAddressLine3" value="{{line3}}"
 					class="o-forms__text js-field__input js-item__value"
 					data-trackable="field-deliveryAddressLine3"
 					autocomplete="address-line3"

--- a/tests/partials/delivery-address.spec.js
+++ b/tests/partials/delivery-address.spec.js
@@ -22,14 +22,16 @@ describe('delivery-address template', () => {
 	});
 
 	it('should populate the correct value', () => {
-		const values = ['line 1', 'line 2', 'line 3'];
+		const line1 = 'line1';
+		const line2 = 'line2';
+		const line3 = 'line3';
 		const $ = context.template({
-			values
+			line1, line2, line3
 		});
 
-		expect($('#deliveryAddressLine1').val()).to.equal(values[0]);
-		expect($('#deliveryAddressLine2').val()).to.equal(values[1]);
-		expect($('#deliveryAddressLine3').val()).to.equal(values[2]);
+		expect($('#deliveryAddressLine1').val()).to.equal(line1);
+		expect($('#deliveryAddressLine2').val()).to.equal(line2);
+		expect($('#deliveryAddressLine3').val()).to.equal(line3);
 	});
 
 	shouldBeRequired(context, '#deliveryAddressLine1');


### PR DESCRIPTION
 🐿 v2.12.3

## Feature Description
use separate deliveryAddress lines rather than array

## Link to Ticket / Card:
https://trello.com/c/dxgP3IRA/1328-5-submit-delivery-step

## Screenshots:
n/a

## Has the necessary documentation been created / updated?
- [x] Yes
- [ ] Not required for this ticket

## Has this been given a review by Design/UX?
- [ ] Yes
- [x] Not required for this ticket
