### PR TITLE
Add js class to start date text

### DIFF
--- a/partials/delivery-start-date.html
+++ b/partials/delivery-start-date.html
@@ -19,7 +19,7 @@
 
 	<div class="o-forms__errortext">Please select a valid start date</div>
 
-	<p>Your subscription will start from: <strong>{{date}}</strong></p>
+	<p>Your subscription will start from: <strong class="js-start-date-text">{{date}}</strong></p>
 
 	<p>
 		NB. This will  be the closest date we can supply your newspaper based on your selected


### PR DESCRIPTION
🐿 v2.12.4

## Feature Description
When updating the start date, this needs to be selectable in the JS so it can be updated when the response from membership comes back.

## Link to Ticket / Card:

https://trello.com/c/m1k5q0pA/1320-8-delivery-page-delivery-start-date

## Has the necessary documentation been created / updated?
- [x] Not required for this ticket

## Has this been given a review by Design/UX?
- [x] Not required for this ticket
