### PR TITLE
Add delivery option and start date utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ import MyModule from 'n-conversion-forms/utils/my-module';
 * [AppBanner](#app-banner)
 * [TrialBanner](#trial-banner)
 * [Country](#country)
+* [Delivery Option](#delivery-option)
+* [Delivery Start Date](#delivery-start-date)
 * [Email](#email)
 * [Event Notifier](#event-notifier)
 * [Loader](#loader)
@@ -103,6 +105,38 @@ country.onChange(() => {
 
 Adds listener for country changes and retrieve the currently selected value.
 
+### Delivery Option
+
+```js
+const deliveryOption = new DeliveryOption(document);
+```
+
+This utility provides the ability to bind a callback that gets fired when the delivery option gets changed by the user.
+
+```js
+deliveryOption.handleDeliveryOptionChange(() => {
+  // your code here.
+});
+```
+
+### Delivery Start Date
+
+This utility provides the ability to call a backend service that validates the selected start date and updates the UI accordingly with the new information returned<sup>†</sup>. The start date will be sent as a `POST` to the service as `startDate` in the body, along with any data returned by the given function (second parameter).
+
+```js
+deliveryStartDate.handleDeliveryStartDateChange('/api/path', () => {
+  // This function needs to return an object containing any extra data to send with the request.
+});
+```
+
+† This requires the result of the endpoint to look as follows:
+
+```js
+{
+  firstDeliveryDate: '2019-02-16',
+  firstDeliveryDateString: 'Saturday 16th of February 2019'
+}
+```
 
 ### Email
 

--- a/tests/utils/delivery-option.spec.js
+++ b/tests/utils/delivery-option.spec.js
@@ -1,0 +1,58 @@
+const DeliveryOption = require('../../utils/delivery-option');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+describe('DeliveryOption', () => {
+	let sandbox = sinon.createSandbox();
+
+	let document;
+	let formStub;
+	let deliveryOption1Listener;
+	let deliveryOption2Listener;
+
+	beforeEach(() => {
+		document = { querySelector: sandbox.stub().returns(false) };
+		deliveryOption1Listener = sandbox.stub();
+		deliveryOption2Listener = sandbox.stub();
+
+		formStub = {
+			deliveryOption: [
+				{ addEventListener: deliveryOption1Listener },
+				{ addEventListener: deliveryOption2Listener }
+			]
+		};
+
+		document.querySelector.withArgs('form.ncf').returns(formStub);
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	describe('constructor', () => {
+		it('should throw an error if document element isn\'t passed in.', () => {
+			expect(() => {
+				new DeliveryOption();
+			}).to.throw();
+		});
+
+		it('should throw an error if delivery option element does not exist on the page', () => {
+			expect(() => {
+				document.querySelector = () => { };
+				new DeliveryOption(document);
+			}).to.throw();
+		});
+	});
+
+	describe('handleDeliveryOptionChange', () => {
+		it('binds the given callback to the change event on the delivery option fields', async () => {
+			let deliveryOptionUtil = new DeliveryOption(document);
+			let callback = sinon.stub();
+			deliveryOptionUtil.handleDeliveryOptionChange(callback);
+
+			expect(deliveryOption1Listener.calledWith('change', callback)).to.be.true;
+			expect(deliveryOption2Listener.calledWith('change', callback)).to.be.true;
+		});
+	});
+
+});

--- a/tests/utils/delivery-start-date.spec.js
+++ b/tests/utils/delivery-start-date.spec.js
@@ -1,0 +1,104 @@
+const DeliveryStartDate = require('../../utils/delivery-start-date');
+const expect = require('chai').expect;
+const fetchMock = require('fetch-mock');
+const sinon = require('sinon');
+
+describe('DeliveryStartDate', () => {
+	let sandbox = sinon.createSandbox();
+
+	let document;
+	let startDateContainer;
+	let startDateFieldStub;
+	let startDateTextStub;
+
+	beforeEach(() => {
+		document = { querySelector: sandbox.stub().returns(false) };
+
+		startDateContainer = { classList: { add: sandbox.stub(), remove: sandbox.stub() } };
+		startDateFieldStub = { value: '2019-02-16' };
+		startDateTextStub = { innerHTML: 'Saturday 16th of February 2019' };
+
+		document.querySelector.withArgs('#deliveryStartDateField').returns(startDateContainer);
+		document.querySelector.withArgs('#deliveryStartDate').returns(startDateFieldStub);
+		document.querySelector.withArgs('.js-start-date-text').returns(startDateTextStub);
+	});
+
+	afterEach(() => {
+		fetchMock.restore();
+		sandbox.restore();
+	});
+
+	describe('constructor', () => {
+		it('should throw an error if document element isn\'t passed in.', () => {
+			expect(() => {
+				new DeliveryStartDate();
+			}).to.throw();
+		});
+
+		it('should throw an error if delivery start date element does not exist on the page', () => {
+			expect(() => {
+				document.querySelector = () => { };
+				new DeliveryStartDate(document);
+			}).to.throw();
+		});
+	});
+
+	describe('handleDeliveryStartDateChange', () => {
+		let startDateUtil;
+		let startDateChangeResult;
+
+		async function setup () {
+			fetchMock.mock('/api/path', {
+				firstDeliveryDate: '2019-04-13',
+				firstDeliveryDateString: 'Saturday 13th of April 2019'
+			});
+			startDateUtil = new DeliveryStartDate(document);
+			startDateChangeResult = await startDateUtil.handleDeliveryStartDateChange('/api/path', () => {
+				return { foo: 'bar' };
+			});
+		};
+
+		afterEach(() => {
+			fetchMock.restore();
+		});
+
+		it('should only call the api if the field has a value', async () => {
+			delete startDateFieldStub.value;
+			await setup();
+			expect(fetchMock.called()).to.be.false;
+		});
+
+		it('should make a call to the api for the start date', async () => {
+			await setup();
+			expect(fetchMock.called()).to.be.true;
+			expect(fetchMock.lastUrl()).to.equal('/api/path');
+			expect(fetchMock.lastOptions().body).to.equal(JSON.stringify({
+				foo: 'bar',
+				startDate: '2019-02-16'
+			}));
+		});
+
+		it('should update the page according to the response from the API call', async () => {
+			await setup();
+			expect(startDateFieldStub.value).to.equal('2019-04-13');
+			expect(startDateTextStub.innerHTML).to.equal('Saturday 13th of April 2019');
+		});
+
+		it('should clear errors and return true if the fetch call succeeds', async () => {
+			await setup();
+			expect(startDateContainer.classList.remove.calledWith('o-forms--error')).to.be.true;
+			expect(startDateChangeResult).to.be.true;
+		});
+
+		it('should display an error and return false if the fetch call errors', async () => {
+			fetchMock.mock('/api/path', 500);
+			startDateUtil = new DeliveryStartDate(document);
+
+			let startDateChangeResult = await startDateUtil.handleDeliveryStartDateChange('/api/path', () => {});
+
+			expect(startDateContainer.classList.add.calledWith('o-forms--error')).to.be.true;
+			expect(startDateChangeResult).to.be.false;
+		});
+	});
+
+});

--- a/tests/utils/validation.spec.js
+++ b/tests/utils/validation.spec.js
@@ -209,7 +209,7 @@ describe('Validation', () => {
 				}).to.throw();
 			});
 
-			it('should store a custom validation function that will show a custom validation message when validation fails', () => {
+			it('should store a custom validation function that will show a custom validation message when validation fails', async () => {
 				sandbox.stub(validation, 'showCustomFieldValidationError');
 				sandbox.stub(validation, 'clearCustomFieldValidationError');
 
@@ -220,13 +220,13 @@ describe('Validation', () => {
 				});
 
 				// Run the stored custom validation function
-				validation.customValidation.get('foo')();
+				await validation.customValidation.get('foo')();
 
 				expect(validation.showCustomFieldValidationError.called).to.be.true;
 				expect(validation.clearCustomFieldValidationError.called).to.be.false;
 			});
 
-			it('should store a custom validation function that will clear a custom validation message when validation passes', () => {
+			it('should store a custom validation function that will clear a custom validation message when validation passes', async () => {
 				sandbox.stub(validation, 'showCustomFieldValidationError');
 				sandbox.stub(validation, 'clearCustomFieldValidationError');
 
@@ -237,7 +237,7 @@ describe('Validation', () => {
 				});
 
 				// Run the stored custom validation function
-				validation.customValidation.get('foo')();
+				await validation.customValidation.get('foo')();
 
 				expect(validation.clearCustomFieldValidationError.called).to.be.true;
 			});

--- a/utils/delivery-option.js
+++ b/utils/delivery-option.js
@@ -1,0 +1,36 @@
+/**
+ * Utility for the `n-conversion-forms/partial/delivery-option.html` partial
+ * @example
+ * const deliveryOption = new DeliveryOption(document);
+ */
+class DeliveryOption {
+	/**
+	 * Initalise the Delivery Option utility
+	 * @param {Element} element Usually the window.document
+	 * @throws If the element not passed
+	 */
+	constructor (element) {
+		if (!element) {
+			throw new Error('Please supply the DOM element');
+		}
+
+		this.$form = element.querySelector('form.ncf');
+
+		if (!this.$form.deliveryOption) {
+			throw new Error('Please include the delivery option partial on the page.');
+		}
+	}
+
+	/**
+	 * Binds the given callback to the field's onchange event.
+	 * @param {Function} callback The callback function to call when a change event occurs.
+	 */
+	handleDeliveryOptionChange (callback) {
+		for (let option of [...this.$form.deliveryOption]) {
+			option.addEventListener('change', callback);
+		}
+	}
+
+};
+
+module.exports = DeliveryOption;

--- a/utils/delivery-start-date.js
+++ b/utils/delivery-start-date.js
@@ -1,0 +1,64 @@
+const fetchres = require('fetchres');
+
+/**
+ * Utility for the `n-conversion-forms/partial/delivery-start-date.html` partial
+ * @example
+ * const deliveryStartDate = new DeliveryStartDate(document);
+ */
+class DeliveryStartDate {
+	/**
+	 * Initalise the DeliveryStartDate utility
+	 * @param {Element} element Usually the window.document
+	 * @throws If the element not passed
+	 */
+	constructor (element) {
+		if (!element) {
+			throw new Error('Please supply the DOM element');
+		}
+
+		this.$container = element.querySelector('#deliveryStartDateField');
+		this.$deliveryStartDate = element.querySelector('#deliveryStartDate');
+		this.$deliveryStartDateText = element.querySelector('.js-start-date-text');
+
+		if (!this.$deliveryStartDate) {
+			throw new Error('Please include the delivery start date partial on the page.');
+		}
+	}
+
+	/**
+	 * Calls the membership service to check the delivery start date
+	 * @param {String} url URL of delivery start date checking service
+	 * @param {Function} getData A function to allow fetching updated form data from the page.
+	 * @returns {boolean} Whether or not the start date is valid.
+	 * @throws If there was an error calling the endpoint to check this.
+	 */
+	async handleDeliveryStartDateChange (url, getData) {
+		if (this.$deliveryStartDate.value) {
+			try {
+				this.$container.classList.remove('o-forms--error');
+				const result = await fetch(url, {
+					method: 'POST',
+					credentials: 'include',
+					headers: {
+						'Content-Type': 'application/json'
+					},
+					body: JSON.stringify(Object.assign({}, getData(), {
+						startDate: this.$deliveryStartDate.value
+					}))
+				})
+					.then(fetchres.json);
+
+				this.$deliveryStartDate.value = result.firstDeliveryDate;
+				this.$deliveryStartDateText.innerHTML = result.firstDeliveryDateString;
+
+				return true;
+			} catch (error) {
+				this.$container.classList.add('o-forms--error');
+				return false;
+			}
+		}
+	};
+
+};
+
+module.exports = DeliveryStartDate;

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -68,15 +68,15 @@ class Validation {
 			throw new Error(`Custom validation for ${field.name} already exists.`);
 		}
 
-		this.customValidation.set(field.name, () => {
+		this.customValidation.set(field.name, async () => {
 			const id = `custom-validation-for-${field.name}`;
 			const $message = document.createElement('div');
 
 			$message.id = id;
 			$message.className = 'o-forms__errortext ncf__custom-validation-error';
-			$message.innerText = errorMessage;
+			$message.innerHTML = errorMessage;
 
-			const isValid = validator();
+			const isValid = await validator();
 			if (!isValid) {
 				this.showCustomFieldValidationError(field, $message);
 			} else {
@@ -137,11 +137,11 @@ class Validation {
 	checkCustomValidation () {
 		// Debounce this to prevent custom validation running again straight away
 		// through the checkFormValidity function below.
-		if (!this.debounceCustomValidation) {
+		if (this.customValidation.size > 0 && !this.debounceCustomValidation) {
 			this.debounceCustomValidation = true;
 
-			this.customValidation.forEach((validator) => {
-				validator();
+			this.customValidation.forEach(async (validator) => {
+				await validator();
 			});
 
 			setTimeout(() => {


### PR DESCRIPTION
🐿 v2.12.4

## Feature Description

Adds delivery option and delivery start date utils as well as fixing up the custom validation stuff to work with async/await and allow markup in error messages.

## Link to Ticket / Card:

https://trello.com/c/m1k5q0pA/1320-8-delivery-page-delivery-start-date

## Has the necessary documentation been created / updated?
- [x] Yes

## Has this been given a review by Design/UX?
- [x] Not required for this ticket
