### PR TITLE
change delivery option copy

### DIFF
--- a/partials/delivery-instructions.html
+++ b/partials/delivery-instructions.html
@@ -6,7 +6,7 @@
 
 	<label for="deliveryInstructions" class="o-forms__label">
 		Delivery instructions <small>(optional)</small><br />
-		<small>Any instructions which will help us deliver your newspaper; door colour, letterbox location, access code etc</small><br />
+		<small>Any instructions which will help us deliver your newspaper, i.e. door colour, letterbox location, as well as information on how you want us to deliver it i.e. post through the letter box, place in plastic bag etc</small><br />
 		{{#if maxlength}}<small>Max. {{maxlength}} characters</small>{{/if}}
 	</label>
 	<textarea type="text" id="deliveryInstructions" name="deliveryInstructions"


### PR DESCRIPTION
 🐿 v2.12.3

## Feature Description
Richard Quinto mentioned that we should add more information to help avoid customer service issues down the line.

Copy to be added is below:
"Any instructions which will help us deliver your newspaper, i.e. door colour, letterbox location, as well as information on how you want us to deliver it i.e. post through the letter box, place in plastic bag etc"

## Link to Ticket / Card:
https://trello.com/c/x19PJx5l/1379-1-add-extra-delivery-instructions-copy

