### PR TITLE
Adds category to the constructor

### DIFF
--- a/tests/utils/tracking.spec.js
+++ b/tests/utils/tracking.spec.js
@@ -11,7 +11,7 @@ describe('Tracking', () => {
 	beforeEach(() => {
 		element = { dispatchEvent: () => {} };
 		window = { CustomEvent: function () {}, Image: function () {}, Date: function () {} };
-		tracking = new Tracking(window, element);
+		tracking = new Tracking(window, element, 'test');
 
 		sandbox = sinon.createSandbox();
 		sandbox.spy(tracking, 'dispatchCustomEvent');
@@ -44,17 +44,11 @@ describe('Tracking', () => {
 					tracking.dispatch();
 				}).to.throw();
 			});
-
-			it('should throw an error if action is missing', () => {
-				expect(() => {
-					tracking.dispatch('test');
-				}).to.throw();
-			});
 		});
 
 		describe('dispatch events', () => {
 			it('should call dispatchEvent', () => {
-				tracking.dispatch('test', 'test');
+				tracking.dispatch('test');
 				expect(tracking.dispatchCustomEvent.calledOnce).to.be.true;
 			});
 
@@ -71,13 +65,13 @@ describe('Tracking', () => {
 		describe('extra data', () => {
 			it('should merge extra tracking data', () => {
 				const data = { extra: 'data' };
-				tracking.dispatch('test', 'test', data);
+				tracking.dispatch('test', data);
 				expect(tracking.dispatchCustomEvent.getCall(0).args[0]).to.include(data);
 			});
 
 			it('should not overwrite the given action and test', () => {
 				const data = { action: 'bad', category: 'bad' };
-				tracking.dispatch('test', 'test', data);
+				tracking.dispatch('test', data);
 				expect(tracking.dispatchCustomEvent.getCall(0).args[0]).to.not.include({ action: 'bad', category: 'bad' });
 			});
 		});
@@ -92,27 +86,27 @@ describe('Tracking', () => {
 			};
 
 			it('should not send undefined properties', () => {
-				tracking.dispatch('test', 'test', data);
+				tracking.dispatch('test', data);
 				expect(tracking.dispatchCustomEvent.getCall(0).args[0]).to.not.include({ testUndefined: undefined });
 			});
 
 			it('should not send null properties', () => {
-				tracking.dispatch('test', 'test', data);
+				tracking.dispatch('test', data);
 				expect(tracking.dispatchCustomEvent.getCall(0).args[0]).to.not.include({ testNull: null });
 			});
 
 			it('should not send empty string properties', () => {
-				tracking.dispatch('test', 'test', data);
+				tracking.dispatch('test', data);
 				expect(tracking.dispatchCustomEvent.getCall(0).args[0]).to.not.include({ testEmptyString: '' });
 			});
 
 			it('should send zero properties', () => {
-				tracking.dispatch('test', 'test', data);
+				tracking.dispatch('test', data);
 				expect(tracking.dispatchCustomEvent.getCall(0).args[0]).to.include({ testZero: 0 });
 			});
 
 			it('should send false properties', () => {
-				tracking.dispatch('test', 'test', data);
+				tracking.dispatch('test', data);
 				expect(tracking.dispatchCustomEvent.getCall(0).args[0]).to.include({ testFalse: false });
 			});
 		});

--- a/utils/tracking.js
+++ b/utils/tracking.js
@@ -11,30 +11,30 @@ class Tracking {
 	 * @param {Element} element HTML element to dispatch event on, normally document.body
 	 * @throws If the window or element is not supplied
 	 */
-	constructor (window, element) {
+	constructor (window, element, category) {
 		if (!window || !element) {
-			throw new Error('Please supply a window and element');
+			throw new Error('Please supply a window, element and category');
 		}
 
 		this.window = window;
 		this.element = element;
+		this.category = category;
 		this.initDebugData();
 	}
 
 	/**
 	 * Dispatch a standard tracking event, falls back to dispacting tracking pixel
-	 * @param {String} category
 	 * @param {String} action
 	 * @param {Object} data
 	 * @returns {Number} Amount of events dispatched
-	 * @throws If the category or action is not supplied
+	 * @throws If the action is not supplied
 	 */
-	dispatch (category, action, data = {}) {
-		if (!category || !action) {
-			throw new Error('Please supply a category and action');
+	dispatch (action, data = {}) {
+		if (!action) {
+			throw new Error('Please supply an action');
 		}
 
-		const eventData = Object.assign({}, data, { action, category });
+		const eventData = Object.assign({}, data, { action, category: this.category });
 
 		// Clean eventData of empty properties
 		for (const property in eventData) {


### PR DESCRIPTION
 🐿 v2.12.3

## Feature Description
I am facing a problem in next-subscribe where the category is different for B2C and B2B forms. I could just make the change [here](https://github.com/Financial-Times/next-subscribe/blob/master/client/controller.js#L136) but this would require making the `trackAction` call include category and having to include this value, i.e `signup`, every time we call  `trackAction` which we do multiple times. This does not seem like the best solution as the category only needs to change twice in next-subscribe, unlike action which changes depending on the event being fired. 

I could also just create a function that sets the category name. 

Thoughts?

## Link to Ticket / Card:
https://trello.com/c/1sHS28LF/1311-3-tracking-names-for-b2b-form




## Has the necessary documentation been created / updated?
- [ ] Yes
- [ ] Not required for this ticket

## Has this been given a review by Design/UX?
- [ ] Yes
- [ ] Not required for this ticket
