### PR TITLE
Add data-signup-is-trial attribute for floodlight pixel tracking

### DIFF
--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -71,12 +71,13 @@ Renders the subscription confirmation page.
 Displayed cta and link are different for print only offers.
 
 ```handlebars
-{{> n-conversion-forms/partials/confirmation isPrintOnly=true offer="Premium Digital & Print" email="test@example.com" details=details }}
+{{> n-conversion-forms/partials/confirmation isPrintOnly=true isTrial=true offer="Premium Digital & Print" email="test@example.com" details=details }}
 ```
 
 ### Options
 
-+ `isPrintOnly`: boolean - is this offer a print only offer or not.
++ `isPrintOnly`: boolean - whether or not this is a print only offer.
++ `isTrial`: boolean - whether or not this is a trial offer.
 + `offer`: string - offer display name.
 + `email`: email - user email.
 + `details`: array - objects with the following properties.

--- a/partials/confirmation.html
+++ b/partials/confirmation.html
@@ -1,4 +1,5 @@
-<div class="ncf ncf__wrapper">
+{{!-- the isTrial bit is needed for the floodlight pixel tracking. --}}
+<div class="ncf ncf__wrapper"{{#if isTrial}} data-signup-is-trial="true"{{/if}}>
 	<div class="ncf__center">
 		<div class="ncf__icon ncf__icon--tick ncf__icon--large"></div>
 		<p class="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">You are now subscribed to:</p>

--- a/tests/partials/confirmation.spec.js
+++ b/tests/partials/confirmation.spec.js
@@ -96,4 +96,18 @@ describe('confirmation template', () => {
 		const buttonText = 'Start exploring';
 		expect($.text()).to.contain(buttonText);
 	});
+
+	it('should add a data-signup-is-trial="true" attribute for floodlight pixel tracking', () => {
+		const $ = context.template({
+			isTrial: true
+		});
+
+		expect($.html()).to.contain('data-signup-is-trial="true"');
+	});
+
+	it('should not add a data-signup-is-trial="true" attribute if isTrial not passed in', () => {
+		const $ = context.template();
+
+		expect($.html()).to.not.contain('data-signup-is-trial="true"');
+	});
 });


### PR DESCRIPTION
🐿 v2.12.4

## Feature Description

The floodlight tracking was thrown off because trial subscriptions that were shown this confirmation template were being lumped together with the normal ones. See tracking code here: https://github.com/Financial-Times/n-ui/blob/master/components/n-ui/tracking/third-party/floodlight.js#L9-L14

## Link to Ticket / Card:

https://trello.com/c/4hH7LRlP/1448-bau-bug-pixels

## Has the necessary documentation been created / updated?
- [x] Yes
