### PR TITLE
Fix a11y contrast ratio issue

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -94,7 +94,7 @@
 		}
 
 		label small {
-			color: oColorsMix(black, white, 50);
+			color: oColorsMix(black, white, 70);
 			font-weight: normal;
 		}
 	}


### PR DESCRIPTION
🐿 v2.12.4

## Feature Description

This was making the a11y tests fail here: https://circleci.com/gh/Financial-Times/next-subscribe/8455