### PR TITLE
Add GlobalSign badge to payment type partial

### DIFF
--- a/partials/payment-type.html
+++ b/partials/payment-type.html
@@ -1,8 +1,15 @@
-<!-- commenting out for now as some of this renders locally and some doesn't so it looks weird on the demo -->
-<!-- <div class="ncf__security-seal">
-	<p>Secure payment details</p>
-	<script type="text/javascript" src="https://seal.websecurity.norton.com/getseal?host_name=www.ft.com&amp;size=XS&amp;use_flash=NO&amp;use_transparent=Yes&amp;lang=en"></script> Secure payment details
-</div> -->
+<div class="ncf__security-seal">
+	<!-- NOTE: this won't display on local.ft.com (yet it will still take up space. I know.) -->
+	<!--- DO NOT EDIT - GlobalSign SSL Site Seal Code - DO NOT EDIT --->
+	<table width=125 border=0 cellspacing=0 cellpadding=0 title="CLICK TO VERIFY: This site uses a GlobalSign SSL Certificate to secure your personal information.">
+		<tr>
+			<td><span id="ss_img_wrapper_gmogs_image_110-45_en_dblue"><a href="https://www.globalsign.com/" target=_blank title="GlobalSign Site Seal" rel="nofollow"><img alt="SSL" border=0 id="ss_img" src="//seal.globalsign.com/SiteSeal/images/gs_noscript_110-45_en.gif"></a></span>
+				<script type="text/javascript" src="//seal.globalsign.com/SiteSeal/gmogs_image_110-45_en_dblue.js"></script>
+			</td>
+		</tr>
+	</table>
+	<!--- DO NOT EDIT - GlobalSign SSL Site Seal Code - DO NOT EDIT --->
+</div>
 
 <div id="paymentTypeField" class="o-forms o-forms--wide ncf__field">
 	<div class="ncf__payment-type-selector">

--- a/styles/payment-type.scss
+++ b/styles/payment-type.scss
@@ -81,4 +81,10 @@
 			z-index: 1;
 		}
 	}
+
+	&__security-seal {
+		table {
+			margin: 0 auto;
+		}
+	}
 }


### PR DESCRIPTION
🐿 v2.12.4

## Feature Description

Annoyingly, this thing doesn't show up on local.ft.com and _still takes up the space_. Don't really want to pollute the partial with an `isDev` flag so just leaving it as is ¯\\\_(ツ)\_/¯

[Ticket](https://trello.com/c/CCOKa66K/1447-add-security-seal-to-single-page-and-newspaper)

## Screenshots:

<img width="515" src="https://user-images.githubusercontent.com/708296/63264672-905c8e80-c283-11e9-9830-ac74dfcbecc6.png">

## Has this been given a review by Design/UX?
- [x] Yes
