### PR TITLE
Remove border from globalsign link

### DIFF
--- a/styles/payment-type.scss
+++ b/styles/payment-type.scss
@@ -88,5 +88,8 @@
 		table {
 			margin: 0 auto;
 		}
+		a {
+			border: 0;
+		}
 	}
 }


### PR DESCRIPTION
 🐿 v2.12.4

## Feature Description

Because this wasn't working locally, I didn't see that the image was wrapped in an unstyled link with a bottom border.

[Ticket](https://trello.com/c/CCOKa66K/1447-add-security-seal-to-single-page-and-newspaper)

## Screenshots:

|Before|After|
|-|-|
|<img width="413" alt="1566223019" src="https://user-images.githubusercontent.com/708296/63271263-ad985980-c291-11e9-93f8-d0b5bb0b5105.png">|<img width="413" alt="1566223030" src="https://user-images.githubusercontent.com/708296/63271278-b4bf6780-c291-11e9-8dbb-b7e84857aca2.png">|
