### PR TITLE
Update sale colour on payment-term from black to claret

### DIFF
--- a/styles/payment-term.scss
+++ b/styles/payment-term.scss
@@ -4,7 +4,7 @@
 	@include bigRadioButton($className: '.ncf__payment-term');
 	&__payment-term {
 		&__discount {
-			background-color: oColorsGetPaletteColor('black');
+			background-color: oColorsGetPaletteColor('claret-60');
 			color: oColorsGetPaletteColor('white');
 			position: absolute;
 			padding: 6px 16px;
@@ -18,7 +18,7 @@
 				height: 0;
 				border-top: 6px solid transparent;
 				border-bottom: 6px solid transparent;
-				border-right: 6px solid oColorsGetPaletteColor('black-70');
+				border-right: 6px solid oColorsGetPaletteColor('claret-50');
 				transform: rotate(45deg);
 				position: absolute;
 				bottom: -8px;


### PR DESCRIPTION
## Feature Description
Updating the sale colour to be consistent with the barriers

| Before | After |
| --- | --- |
| <img width="180" alt="Screenshot 2019-08-19 at 15 18 09" src="https://user-images.githubusercontent.com/1721150/63272915-dbcb6880-c294-11e9-8df6-e98b15243549.png"> | <img width="260" alt="Screenshot 2019-08-19 at 15 14 00" src="https://user-images.githubusercontent.com/1721150/63272926-dff78600-c294-11e9-95e0-f21d2599e510.png"> |


