### PR TITLE
Use weekly price instead of discount copy

### DIFF
--- a/partials/payment-term.html
+++ b/partials/payment-term.html
@@ -19,7 +19,9 @@
 			<span class="ncf__payment-term__title">Pay annually</span>
 			<div class="ncf__payment-term__description">
 				Single <span class="ncf__payment-term__price ncf__strong">{{price}}</span> payment
-				{{#unless discount}}<br />Save up to 25% when you pay annually{{/unless}}
+				{{#if weeklyPrice}}<br /><span class="ncf__payment-term__weekly-price">Just {{weeklyPrice}} per week</span>{{/if}}
+				{{!-- Remove this discount text temporarily in favour of weekly price --}}
+				<!-- {{#unless discount}}<br />Save up to 25% when you pay annually{{/unless}} -->
 			</div>
 			{{/ifEquals}}
 

--- a/test/partials/payment-term.spec.js
+++ b/test/partials/payment-term.spec.js
@@ -78,7 +78,8 @@ describe('payment-term', () => {
 			expect($(DESCRIPTION_SELECTOR).text()).to.contain(price);
 		});
 
-		it('should show discount copy if not discounted', () => {
+		// Removing in favour of weekly price for the time being
+		it.skip('should show discount copy if not discounted', () => {
 			const name = 'annual';
 			const $ = context.template({ options: [{
 				name
@@ -94,6 +95,24 @@ describe('payment-term', () => {
 				discount
 			}]});
 			expect($(DESCRIPTION_SELECTOR).text()).to.not.contain('Save up to');
+		});
+
+		it('should not have weekly price text by default', () => {
+			const name = 'annual';
+			const $ = context.template({ options: [{
+				name
+			}]});
+			expect($('.ncf__payment-term__weekly-price').length).to.equal(0);
+		});
+
+		it('should have weekly price text if passed', () => {
+			const name = 'annual';
+			const weeklyPrice = '£1.00';
+			const $ = context.template({ options: [{
+				name,
+				weeklyPrice
+			}]});
+			expect($('.ncf__payment-term__weekly-price').length).to.equal(1);
 		});
 	});
 


### PR DESCRIPTION
## Feature Description

Make the new forms more similar to the old to remove any chance of negatively impacting conversion.