### PR TITLE
Fix payment type misalignment issue

### DIFF
--- a/styles/payment-type.scss
+++ b/styles/payment-type.scss
@@ -26,6 +26,12 @@
 			width: 100%;
 		}
 
+		// Being overly specific to override a specific o-forms styles
+		// this fixes a 3px misalignment in the payment types
+		.o-forms__label:first-of-type {
+			margin: 3px 0 3px 3px;
+		}
+
 		&--paypal {
 			.o-forms__label {
 				@include buttonImageOverriding();


### PR DESCRIPTION
## Feature Description
There was a slight misalignment caused by some standard o-forms label styles. Using a very specific style to override this which is not the greatest but hopefully can be removed after o-forms v7.

_Ignore the missing secure payment badge, it does not show on local_

| Before | After |
| --- | --- |
| <img width="472" alt="Screenshot 2019-08-20 at 13 19 17" src="https://user-images.githubusercontent.com/1721150/63346595-3aecb400-c34d-11e9-9ee7-5bf58d77058d.png"> | <img width="482" alt="Screenshot 2019-08-20 at 13 19 45" src="https://user-images.githubusercontent.com/1721150/63346602-4049fe80-c34d-11e9-8b47-b84f662295dc.png"> |




