### PR TITLE
Add loader methods to show loader on specific element

### DIFF
--- a/styles/loader.scss
+++ b/styles/loader.scss
@@ -15,6 +15,13 @@
 		align-items: center;
 		justify-content: center;
 
+		&--element {
+			height: auto;
+			position: absolute;
+			// Hack to cover all input fields
+			right: -1px;
+		}
+
 		&.is-visible {
 			display: flex;
 		}

--- a/styles/loader.scss
+++ b/styles/loader.scss
@@ -35,8 +35,6 @@
 					'theme': 'light',
 					'size': 'large'
 				));
-
-
 				content: '';
 				position: relative;
 				top: 50%;
@@ -46,8 +44,7 @@
 
 			&__title {
 				@include oTypographySize($scale: 2);
-				// No semi-bold so doing it manually.
-				font-weight: 500;
+				font-weight: oFontsWeight('semibold');
 			}
 		}
 	}

--- a/styles/loader.scss
+++ b/styles/loader.scss
@@ -41,6 +41,7 @@
 				position: relative;
 				top: 50%;
 				transform: translateY(-50%);
+				margin-bottom: 20px;
 			}
 
 			&__title {

--- a/styles/payment-type.scss
+++ b/styles/payment-type.scss
@@ -76,6 +76,8 @@
 		margin-top: 15px;
 		position: relative;
 		z-index: 2;
+		// Minimum height of a payment iframe to stop page jumping
+		min-height: 385px;
 
 		&-overlay {
 			background-color: rgba(0, 0, 0, 0.15);

--- a/utils/loader.js
+++ b/utils/loader.js
@@ -107,6 +107,48 @@ class Loader {
 			event.preventDefault();
 		}
 	}
+
+	/**
+	 * Display a loader on top of the element passed
+	 * @param {DOMElement} element Show loader over this
+	 * @param {Object} content Content for the loader in standard format
+	 */
+	showOnElement (element, content) {
+		const loader = new DOMParser().parseFromString(this.template(content), 'text/html');
+		element.appendChild(loader.querySelector('.ncf__loader'));
+	}
+
+	/**
+	 * Remove loader from a given element
+	 * @param {DOMElement} element Loader inside
+	 */
+	removeFromElement (element) {
+		element.querySelector('.ncf__loader').remove();
+	}
+
+	/**
+	 * Return a string to be injected into the page
+	 * @param {String} title
+	 * @param {String} content
+	 */
+	template ({ title='Loading', content='' }) {
+		return `
+		<div class="ncf__loader is-visible ncf__loader--element"
+			role="dialog"
+			aria-labelledby="loader-aria-label"
+			aria-describedby="loader-aria-description"
+			aria-modal="true"
+			tabindex="1">
+			<div class="ncf__loader__content">
+				<div class="ncf__loader__content__title" id="loader-aria-label">
+					${title}
+				</div>
+				<div class="ncf__loader__content__main" id="loader-aria-description">
+					${content}
+				</div>
+			</div>
+		</div>`;
+	}
 };
 
 module.exports = Loader;


### PR DESCRIPTION
## Feature Description
Currently we can only show a loader across a whole page, but with payment type changes we don't have to block the whole page. This allows you to show a loader by passing in an element to the show function.

| Before | After |
| --- | --- |
| <img width="1232" alt="Screenshot 2019-08-20 at 15 19 17" src="https://user-images.githubusercontent.com/1721150/63355512-282eab00-c35e-11e9-8224-31c2e570430a.png"> | <img width="1233" alt="Screenshot 2019-08-20 at 15 21 10" src="https://user-images.githubusercontent.com/1721150/63355520-2bc23200-c35e-11e9-9c3b-42b31f94f93b.png"> |


