### PR TITLE
feat: error page template

### DIFF
--- a/demos/data.json
+++ b/demos/data.json
@@ -53,6 +53,12 @@
       "value": "USA"
     }
   },
+  "customer-care": {
+    "params": {
+      "header": "We don't know what happened",
+      "message": "You should probably call us."
+    }
+  },
   "debug": {
     "params": {
       "isTest": true,
@@ -119,6 +125,15 @@
       "min": "2019-02-16",
       "max": "2019-04-13",
       "value": "2019-02-16"
+    }
+  },
+  "error-page": {
+    "params": {
+      "header": "Something went wrong",
+      "message": "Please call us and we can help."
+    },
+    "partials": {
+      "@partial-block": "<p>FIRE THE LIVECHAT CANNON!<div><img alt=\"Cannon GIF\" src=\"https://media.giphy.com/media/PisLH7dWInIs0/giphy.gif\" /></div></p>"
     }
   },
   "email": {

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -142,7 +142,6 @@ Renders a "contact customer support" page.
 + `header`: string - Custom header text. Defaults to "Sorry, this is not available online".
 + `message`: string - Custom message text, defaults to "Speak now to our Customer Care team to discuss your options".
 
-
 ## Decision Maker
 
 Renders an inline yes / no radio group for users to enter if they are a decision maker in their company.
@@ -244,6 +243,30 @@ Renders a date field with a given start date (and accompanying copy).
 + `date`: string - The date in `dddd Do MMMM YYYY` format.
 + `isDisabled`: boolean - Whether the field is disabled or not.
 + `hasError`: boolean - If true it adds `o-forms--error` class to display error.
+
+## Error Page
+
+Renders a generic "error" page.
+
+```handlebars
+{{#> n-conversion-forms/partials/error-page header="Some header text" message="Contact us for something" }}
+	Some content to be placed in the middle
+{{/ n-conversion-forms/partials/error-page}}
+```
+
+### Options
++ `header`: string - Custom header text. Defaults to "Sorry, this is not available online".
++ `message`: string - Custom message text, defaults to "Speak now to our Customer Care team to discuss your options".
+
+### Inline Partials
+
+You can pass in HTML using [partial block syntax](https://handlebarsjs.com/partials.html#partial-block) as follows:
+
+```handlebars
+{{> n-conversion-forms/partials/error-page}}
+  <p>Some additional content<p>
+{{/ n-conversion-forms/partials/error-page}}
+```
 
 ## Fieldset
 

--- a/main.scss
+++ b/main.scss
@@ -232,6 +232,16 @@
 		}
 	}
 
+	&__icon--error {
+		background: oColorsGetPaletteColor('crimson');
+		border-color: oColorsGetPaletteColor('crimson');
+		&::before {
+			@include oIconsGetIcon('warning', oColorsGetPaletteColor('white'), 20);
+			content: '';
+			color: oColorsGetPaletteColor('white');
+		}
+	}
+
 	&__icon--inline-edit {
 		@include oIconsGetIcon('edit', oColorsGetPaletteColor('black'), 20);
 		border: 0;

--- a/partials/customer-care.html
+++ b/partials/customer-care.html
@@ -6,11 +6,9 @@
 	</div>
 
 	<div class="ncf__paragraph ncf__customer-care">
-		<div class="ncf__paragraph">
-			<div class="ncf__icon ncf__icon--phone ncf__icon--large"></div>
-		</div>
+		<div class="ncf__icon ncf__icon--phone ncf__icon--large"></div>
 		<p>International Toll Free Number</p>
-		<a id="customer-care-internation-number" class="ncf__header ncf__link" href="tel:+80007056477">+ 800 0705 6477</a>
+		<a id="customer-care-international-number" class="ncf__header ncf__link" href="tel:+80007056477">+ 800 0705 6477</a>
 	</div>
 
 	<div class="ncf__paragraph">

--- a/partials/error-page.html
+++ b/partials/error-page.html
@@ -1,0 +1,20 @@
+<div class="ncf__wrapper ncf__center ncf__error-page">
+	<div class="ncf__icon ncf__icon--error ncf__icon--large"></div>
+	<div class="ncf__paragraph">
+		<h1 class="ncf__header">{{#if header}}{{header}}{{else}}Sorry, something went wrong{{/if}}</h1>
+		<p id="error-message">{{#if message}}{{message}}{{else}}Speak to our Customer Care team now so we can help.{{/if}}</p>
+	</div>
+	{{#if @partial-block}}
+		<div class="ncf__error-page__content">
+				{{> @partial-block }}
+		</div>
+
+	{{/if}}
+	<div class="ncf__paragraph">
+		<p>International Toll Free Number</p>
+		<a id="error-international-number" class="ncf__header ncf__link" href="tel:+80007056477">+ 800 0705 6477</a>
+	</div>
+	<div class="ncf__paragraph">
+		<a class="ncf__link" href="https://help.ft.com/help/contact-us/">Find a local phone number</a>
+	</div>
+</div>

--- a/test/partials/customer-care.spec.js
+++ b/test/partials/customer-care.spec.js
@@ -36,12 +36,12 @@ describe('customer care template', () => {
 
 	it('should display the international customer care number', () => {
 		const $ = context.template({});
-		expect($('a#customer-care-internation-number').text()).to.equal('+ 800 0705 6477');
+		expect($('a#customer-care-international-number').text()).to.equal('+ 800 0705 6477');
 	});
 
 	it('should set the international customer care number on the link', () => {
 		const $ = context.template({});
-		expect($('a#customer-care-internation-number').attr('href')).to.equal('tel:+80007056477');
+		expect($('a#customer-care-international-number').attr('href')).to.equal('tel:+80007056477');
 	});
 
 });

--- a/test/partials/error-page.spec.js
+++ b/test/partials/error-page.spec.js
@@ -1,0 +1,67 @@
+const { expect } = require('chai');
+const {
+	registerPartial,
+	unregisterPartial,
+	fetchPartial,
+} = require('../helpers');
+
+let context = {};
+
+describe('error page template', () => {
+
+	before(async () => {
+		registerPartial('@partial-block', '<div>Foo Bar</div>');
+		context.template = await fetchPartial('error-page.html');
+	});
+
+	after(() => {
+		unregisterPartial('@partial-block');
+	});
+
+	it('should display an error icon', () => {
+		const $ = context.template({});
+		expect($('.ncf__icon--error').length).to.equal(1);
+	});
+
+	it('should set the header text if provided', () => {
+		const sampleHeaderText = 'hello my unit tests!';
+		const $ = context.template({
+			header: sampleHeaderText
+		});
+		expect($('h1.ncf__header').text()).to.equal(sampleHeaderText);
+	});
+
+	it('should default the header text if not provided', () => {
+		const $ = context.template({});
+		expect($('h1.ncf__header').text()).to.equal('Sorry, something went wrong');
+	});
+
+	it('should set the message text if provided', () => {
+		const sampleMessage = 'Call now and receive a 98.56% discount!';
+		const $ = context.template({
+			message: sampleMessage
+		});
+		expect($('#error-message').text()).to.equal(sampleMessage);
+	});
+
+	it('should default the message text if not provided', () => {
+		const $ = context.template({});
+		expect($('#error-message').text()).to.equal('Speak to our Customer Care team now so we can help.');
+	});
+
+	it('should display the international customer care number', () => {
+		const $ = context.template({});
+		expect($('a#error-international-number').text()).to.equal('+ 800 0705 6477');
+	});
+
+	it('should set the international customer care number on the link', () => {
+		const $ = context.template({});
+		expect($('a#error-international-number').attr('href')).to.equal('tel:+80007056477');
+	});
+
+	it('should allow content in the partial', () => {
+		const $ = context.template();
+		expect($('.ncf__error-page__content').html().trim()).to.equal('<div>Foo Bar</div>');
+	});
+
+});


### PR DESCRIPTION
## Feature Description

Due to the custom responsive behaviour on the customer-care page and the different ordering of content and the additional requirement to embed external markup in the error page component, I thought it prudent to make it a separate partial.

## Link to Ticket / Card:

https://trello.com/c/wd9l2S8D/1439-1-build-failed-transaction-error-template

## Screenshots:

![Screenshot 2019-09-09 at 15 07 58](https://user-images.githubusercontent.com/6599523/64537937-a5bd5980-d313-11e9-9a64-098ae1ae8d77.png)

The livechat content is included via `@partial-block` functionality (embedded from next-retention)

## Has the necessary documentation been created / updated?
- [x] Yes
- [ ] Not required for this ticket

## Has this been given a review by Design/UX?
- [ ] Yes
- [ ] Not required for this ticket
