### PR TITLE
Add the ability to override the trial duration in payment term

### DIFF
--- a/partials/payment-term.html
+++ b/partials/payment-term.html
@@ -10,7 +10,7 @@
 			{{#ifEquals this.name 'trial'}}
 			<span class="ncf__payment-term__title">Try the FT</span>
 			<div class="ncf__payment-term__description">
-				4 weeks for <span class="ncf__payment-term__trial-price">{{trialPrice}}</span><br />
+				{{#if trialDuration}}{{trialDuration}}{{else}}4 weeks{{/if}} for <span class="ncf__payment-term__trial-price">{{trialPrice}}</span><br />
 				unless you cancel during your trial you will be billed <span class="ncf__payment-term__price">{{price}}</span> per month after the trial period
 			</div>
 			{{/ifEquals}}

--- a/test/partials/payment-term.spec.js
+++ b/test/partials/payment-term.spec.js
@@ -57,6 +57,33 @@ describe('payment-term', () => {
 			}]});
 			expect($(DESCRIPTION_SELECTOR).text()).to.contain(trialPrice);
 		});
+
+		it('should show 4 weeks by default', () => {
+			const name = 'trial';
+			const price = '£1.01';
+			const trialPrice = '£2.01';
+			const $ = context.template({ options: [{
+				name,
+				price,
+				trialPrice
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.contain('4 weeks');
+		});
+
+		it('should show the passed trialDuration', () => {
+			const name = 'trial';
+			const price = '£1.01';
+			const trialPrice = '£2.01';
+			const trialDuration = 'TEST DURATION';
+			const $ = context.template({ options: [{
+				name,
+				price,
+				trialPrice,
+				trialDuration
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.not.contain('4 weeks');
+			expect($(DESCRIPTION_SELECTOR).text()).to.contain(trialDuration);
+		});
 	});
 
 	describe('annual', () => {


### PR DESCRIPTION
## Feature Description

Currently we are only showing 4 weeks for the trial duration. We can have trials of different durations so we need the ability to override this.

## Link to Ticket / Card:

https://trello.com/c/sor7sqad/1159-3-month-trials-are-displaying-as-only-1-month
