### PR TITLE
Rename deliveryCityTown to deliveryCity

### DIFF
--- a/partials/debug.html
+++ b/partials/debug.html
@@ -41,7 +41,7 @@
 		deliveryAddressLine1: 'delivery test1',
 		deliveryAddressLine2: 'delivery test2',
 		deliveryAddressLine3: 'delivery test3',
-		deliveryCityTown: 'delivery city',
+		deliveryCity: 'delivery city',
 		deliveryCounty: 'delivery county',
 		deliveryPostcode: 'EC4M9BT',
 		email: Date.now() + '@ftqa.org',

--- a/partials/delivery-address.html
+++ b/partials/delivery-address.html
@@ -29,7 +29,7 @@
 					class="o-forms__text js-field__input js-item__value"
 					data-trackable="field-deliveryAddressLine3"
 					autocomplete="address-line3"
-					placeholder="Enter address line 3"
+					placeholder=""
 					{{#if isDisabled}}disabled{{/if}}>
 	</p>
 </div>

--- a/partials/delivery-city.html
+++ b/partials/delivery-city.html
@@ -1,13 +1,13 @@
-<div id="deliveryCityTownField"
+<div id="deliveryCityField"
 		class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}"
 		data-ui-item="form-field"
-		data-ui-item-name="deliveryCityTown"
+		data-ui-item-name="deliveryCity"
 		data-validate="required">
 
-	<label for="deliveryCityTown" class="o-forms__label">City/town</label>
-	<input type="text" id="deliveryCityTown" name="deliveryCityTown" value="{{value}}"
+	<label for="deliveryCity" class="o-forms__label">City/town</label>
+	<input type="text" id="deliveryCity" name="deliveryCity" value="{{value}}"
 				class="o-forms__text js-field__input js-item__value"
-				data-trackable="field-deliveryCityTown"
+				data-trackable="field-deliveryCity"
 				autocomplete="address-level2"
 				placeholder="e.g. Bath"
 				aria-required="true" required

--- a/test/partials/delivery-city.spec.js
+++ b/test/partials/delivery-city.spec.js
@@ -10,7 +10,7 @@ let context = {};
 
 describe('delivery-city-town template', () => {
 	before(async () => {
-		context.template = await fetchPartial('delivery-city-town.html');
+		context.template = await fetchPartial('delivery-city.html');
 	});
 
 	shouldPopulateValue(context);


### PR DESCRIPTION
## Feature Description
When we send the delivery data to membership we send this as field as `city` rather than `cityTown`.

## Link to Ticket / Card:
https://trello.com/c/npfV689n/1514-town-does-not-get-prepopulated-when-returning-to-the-delivery-step
