### PR TITLE
Adds functionality to get and change postcode reference based on country

### DIFF
--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -15,6 +15,7 @@
 * [Delivey City/town](#delivery-city-town)
 * [Delivery Information](#delivery-information)
 * [Delivery Option](#delivery-option)
+* [Delivery Postcode](#delivery-postcode)
 * [Delivery Start Date](#delivery-start-date)
 * [Fieldset](#fieldset)
 * [Firstname](#firstname)
@@ -56,8 +57,11 @@ Renders the billing country field.
 Displays a billing postal code field with o-forms styling.
 
 ```handlebars
-{{> n-conversion-forms/partials/billing-postcode value="EC4M9BT" isZipCode=true }}
+{{> n-conversion-forms/partials/billing-postcode value="EC4M9BT" postcodeReference='postcode' }}
 ```
+### Required
+
++ `postcodeReference`: required - string - this value should be determined by the country code. Use BillingPostcode.getPostcodeReferenceByCountry which extends [Postcode](../utils/postcode.js)
 
 ### Options
 
@@ -213,17 +217,21 @@ Display delivery options with radio buttons for users to choose between.
   + `value`: string - Value to send when selected.
   + `isSelected`: boolean - Set to true for the term to be selected.
 
-## Delivery postcode
+## Delivery Postcode
 
 Displays a post code field with o-forms styling.
 
 ```handlebars
-{{> n-conversion-forms/partials/delivery-postcode value="EC4M9BT" isZipCode=true }}
+{{> n-conversion-forms/partials/delivery-postcode value="EC4M9BT" postcodeReference="postcode" }}
 ```
+
+### Required
+
++ `postcodeReference`: required - string - this value should be determined by the country code. Use DeliveryPostcode.getPostcodeReferenceByCountry which extends [Postcode](../utils/postcode.js)
+
 ### Options
 
 + `isDisabled`: boolean - true - disables the field.
-+ `isZipCode`: boolean - true - `zip code` label - false - `post code`.
 + `pattern`: string - Pattern to be used for validation.
 + `value`: string - Text to pre-populate the field.
 

--- a/docs/UTILS.md/POSTCODE.md
+++ b/docs/UTILS.md/POSTCODE.md
@@ -1,0 +1,57 @@
+# Postcode
+
+Adds functionality to the [delivery postcode partial](../PARTIALS.md#delivery-postcode) and [billing postcode partial](../PARTIALS.md#billing-postcode).
+
+It allows for the retrieval of the correct terminology of postcode based on the country of the user and also updates any reference to postcode to the correct terminology when the user changes their country.
+
+## Contents
+
+* [Implementation](#implementation)
+* [Methods](#methods)
+
+
+## Implementation
+
+```javascript
+	const postcode = new Postcode(document, query);
+```
+
+| Parameter | Required | Description                   |
+| --------- | -------- | ----------------------------- |
+| document  | yes      | property of the window object |
+| query     | no       | id of the field. Defaults to `.ncf #postCodeField` |
+
+## Methods
+
+* [changePostcodeReferenceForCountry](#changePostcodeReferenceForCountry)
+* [getPostcodeReferenceByCountry](#getPostcodeReferenceByCountry)
+
+### changePostcodeReferenceForCountry
+
+Changes the delivery post code field label, placeholder and error message so that the correct terminology is used for the given country.
+
+```javascript
+	postcode.changePostcodeReferenceForCountry = 'USA';
+```
+
+| Parameter | Required | Example                   |
+| --------- | -------- | ----------------------------- |
+| Three letter ISO 3166-1 country code | yes | 'USA' -> 'Enter your zip code' |
+
+### getPostcodeReferenceByCountry
+
+Returns the correct terminology for the word postcode of the given country.
+
+```javascript
+	const postcode = postcode.getPostcodeReferenceByCountry('USA');
+```
+
+| Parameter   | Required | Description |
+| ----------- | -------- | ----------- |
+| countryCode | yes      | Three letter ISO 3166-1 country code |
+
+#### Possible Responses:
+
+* USA -> zip code
+* CAN -> postal code
+* Default -> post code

--- a/partials/billing-postcode.html
+++ b/partials/billing-postcode.html
@@ -1,6 +1,3 @@
-{{#*inline "postcodeLabel"}}
-{{#if isZipCode}}Zip code{{else}}Post code{{/if}}
-{{/inline}}
 <div id="billingPostcodeField"
 		class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}{{#if isHidden}} n-ui-hide{{/if}}"
 		data-ui-item="form-field"
@@ -8,14 +5,14 @@
 		data-validate="required">
 
 	<label for="billingPostcode" class="o-forms__label">
-		Billing {{> postcodeLabel }}
+		Billing <span data-reference="postcode">{{postcodeReference}}<span>
 	</label>
 
 	<input type="text"
 			id="billingPostcode"
 			name="billingPostcode"
 			value="{{value}}"
-			placeholder="{{> postcodeLabel }}"
+			placeholder="Enter your {{postcodeReference}}"
 			autocomplete="postal-code"
 			class="o-forms__text js-field__input js-item__value"
 			data-trackable="billing-postcode"
@@ -23,6 +20,6 @@
 			{{#if pattern}}pattern="{{pattern}}"{{/if}}
 			{{#if isDisabled}}disabled{{/if}}>
 
-	<div class="o-forms__errortext">Please enter a valid {{> postcodeLabel }}.</div>
+	<div class="o-forms__errortext">Please enter a valid <span data-reference="postcode">{{postcodeReference}}<span>.</div>
 
 </div>

--- a/partials/delivery-postcode.html
+++ b/partials/delivery-postcode.html
@@ -1,6 +1,3 @@
-{{#*inline "postcodeLabel"}}
-{{#if isZipCode}}Zip code{{else}}Post code{{/if}}
-{{/inline}}
 <div id="deliveryPostcodeField"
 		class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}{{#if isHidden}} n-ui-hide{{/if}}"
 		data-ui-item="form-field"
@@ -8,14 +5,14 @@
 		data-validate="required">
 
 	<label for="deliveryPostcode" class="o-forms__label">
-		Delivery {{> postcodeLabel }}
+		Delivery <span data-reference="postcode">{{postcodeReference}}<span>
 	</label>
 
 	<input type="text"
 			id="deliveryPostcode"
 			name="deliveryPostcode"
 			value="{{value}}"
-			placeholder="{{> postcodeLabel }}"
+			placeholder= "Enter your {{postcodeReference}}"
 			autocomplete="postal-code"
 			class="o-forms__text js-field__input js-item__value"
 			data-trackable="delivery-postcode"
@@ -23,6 +20,6 @@
 			{{#if pattern}}pattern="{{pattern}}"{{/if}}
 			{{#if isDisabled}}disabled{{/if}}>
 
-	<div class="o-forms__errortext">Please enter a valid {{> postcodeLabel }}.</div>
+	<div class="o-forms__errortext">Please enter a valid <span data-reference="postcode">{{postcodeReference}}<span>.</div>
 
 </div>

--- a/test/partials/billing-postcode.spec.js
+++ b/test/partials/billing-postcode.spec.js
@@ -22,17 +22,11 @@ describe('billing postcode template', () => {
 	});
 
 	it('should be post code by default', () => {
-		const $ = context.template({});
-		expect($.text()).to.contain('Post code');
-	});
-
-	it('should render zip code if asked', () => {
 		const $ = context.template({
-			isZipCode: true
+			postcodeReference: 'postcode'
 		});
-		expect($.text()).to.contain('Zip code');
+		expect($.text()).to.contain('postcode');
 	});
-
 
 	shouldPopulateValue(context);
 

--- a/test/partials/delivery-postcode.spec.js
+++ b/test/partials/delivery-postcode.spec.js
@@ -16,16 +16,16 @@ describe('delivery postcode template', () => {
 		context.template = await fetchPartial('delivery-postcode.html');
 	});
 
-	it('should be post code by default', () => {
+	it('should be Delivery', () => {
 		const $ = context.template({});
-		expect($.text()).to.contain('Post code');
+		expect($('label').text()).to.contain('Delivery');
 	});
 
-	it('should render zip code if asked', () => {
+	it('should be post code by default', () => {
 		const $ = context.template({
-			isZipCode: true
+			postcodeReference: 'postcode'
 		});
-		expect($.text()).to.contain('Zip code');
+		expect($.text()).to.contain('postcode');
 	});
 
 	shouldPopulateValue(context);

--- a/test/utils/billing-postcode.spec.js
+++ b/test/utils/billing-postcode.spec.js
@@ -1,0 +1,105 @@
+const { expect } = require('chai');
+const sandbox = require('sinon').createSandbox();
+
+const BillingPostcode = require('../../utils/billing-postcode');
+
+describe('BillingPostcode', () => {
+	let billingPostcode;
+	let querySelectorStub;
+	let querySelectorAllStub;
+
+	beforeEach(() => {
+		const document = {
+			querySelector: () => {
+				return {
+					querySelectorAll: () => {},
+					querySelector: () => {}
+				};
+			}
+		};
+		billingPostcode = new BillingPostcode(document, '.ncf #billingPostcodeField');
+		querySelectorStub = sandbox.stub(billingPostcode.$el, 'querySelector');
+		querySelectorAllStub = sandbox.stub(billingPostcode.$el, 'querySelectorAll');
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	it('should return an element', () => {
+		expect(billingPostcode.$el).to.exist;
+	});
+
+	describe('changePostcodeReferenceForCountry', () => {
+
+		beforeEach(() => {
+			querySelectorStub.returns({ innerHTML: '' });
+			querySelectorAllStub.returns([{ innerHTML: '' }, { innerHTML: '' }]);
+		});
+
+		context('postcode reference name', () => {
+			it('should call querySelector with [data-reference]', () => {
+				billingPostcode.changePostcodeReferenceForCountry = 'GBR';
+				expect(querySelectorAllStub.calledWith('[data-reference=postcode]')).to.be.true;
+			});
+
+			it('should set postcodeReference to post code by default', () => {
+				const expectedResponse = [{ innerHTML: 'postcode' }, { innerHTML: 'postcode' }];
+				billingPostcode.changePostcodeReferenceForCountry = 'GBR';
+				expect(billingPostcode.reference).to.eql(expectedResponse);
+			});
+
+			it('should set postcodeReference to zip code when country code is USA', () => {
+				const expectedResponse = [{ innerHTML: 'zip code' }, { innerHTML: 'zip code' }];
+				billingPostcode.changePostcodeReferenceForCountry = 'USA';
+				expect(billingPostcode.reference).to.eql(expectedResponse);
+			});
+
+			it('should set postcodeReference to postal code when country code is Canada', () => {
+				const expectedResponse = [{ innerHTML: 'postal code' }, { innerHTML: 'postal code' }];
+				billingPostcode.changePostcodeReferenceForCountry = 'CAN';
+				expect(billingPostcode.reference).to.eql(expectedResponse);
+			});
+		});
+
+		context('placeholder', () => {
+			it('should call querySelector with span input', () => {
+				querySelectorStub.returns({ placeholder: 'Enter your postcode' });
+				billingPostcode.changePostcodeReferenceForCountry = 'GBR';
+				expect(querySelectorStub.calledWith('input')).to.be.true;
+			});
+
+			it('should set postcode placeholder to `Enter your postcode` by default', () => {
+				querySelectorStub.returns({ placeholder: 'Enter your zip code' });
+				billingPostcode.changePostcodeReferenceForCountry = 'GBR';
+				expect(billingPostcode.postcodeInput.placeholder).to.equal('Enter your postcode');
+			});
+
+			it('should set postcode placeholder to `Enter your zip code` when country code is USA', () => {
+				querySelectorStub.returns({ placeholder: 'Enter your postcode' });
+				billingPostcode.changePostcodeReferenceForCountry = 'USA';
+				expect(billingPostcode.postcodeInput.placeholder).to.equal('Enter your zip code');
+			});
+
+			it('should set postcode placeholder to `Enter your postal code` when country code is Canada', () => {
+				querySelectorStub.returns({ placeholder: 'Enter your zip code' });
+				billingPostcode.changePostcodeReferenceForCountry = 'CAN';
+				expect(billingPostcode.postcodeInput.placeholder).to.equal('Enter your postal code');
+			});
+		});
+	});
+
+	describe('getPostcodeReferenceByCountry', () => {
+		it('should return post code by default ', () => {
+			expect(BillingPostcode.getPostcodeReferenceByCountry('ZAR')).to.equal('postcode');
+		});
+
+		it('should return postal code when country is Canada', () => {
+			expect(BillingPostcode.getPostcodeReferenceByCountry('CAN')).to.equal('postal code');
+		});
+
+		it('should return zip code when country is USA', () => {
+			expect(BillingPostcode.getPostcodeReferenceByCountry('USA')).to.equal('zip code');
+		});
+	});
+});

--- a/test/utils/delivery-postcode.spec.js
+++ b/test/utils/delivery-postcode.spec.js
@@ -1,0 +1,105 @@
+const { expect } = require('chai');
+const sandbox = require('sinon').createSandbox();
+
+const DeliveryPostcode = require('../../utils/delivery-postcode');
+
+describe('DeliveryPostcode', () => {
+	let deliveryPostcode;
+	let querySelectorStub;
+	let querySelectorAllStub;
+
+	beforeEach(() => {
+		const document = {
+			querySelector: () => {
+				return {
+					querySelectorAll: () => {},
+					querySelector: () => {}
+				};
+			}
+		};
+		deliveryPostcode = new DeliveryPostcode(document, '.ncf #deliveryPostcodeField');
+		querySelectorStub = sandbox.stub(deliveryPostcode.$el, 'querySelector');
+		querySelectorAllStub = sandbox.stub(deliveryPostcode.$el, 'querySelectorAll');
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	it('should return an element', () => {
+		expect(deliveryPostcode.$el).to.exist;
+	});
+
+	describe('changePostcodeReferenceForCountry', () => {
+
+		beforeEach(() => {
+			querySelectorStub.returns({ innerHTML: '' });
+			querySelectorAllStub.returns([{ innerHTML: '' }, { innerHTML: '' }]);
+		});
+
+		context('postcode reference name', () => {
+			it('should call querySelector with [data-reference]', () => {
+				deliveryPostcode.changePostcodeReferenceForCountry = 'GBR';
+				expect(querySelectorAllStub.calledWith('[data-reference=postcode]')).to.be.true;
+			});
+
+			it('should set postcodeReference to post code by default', () => {
+				const expectedResponse = [{ innerHTML: 'postcode' }, { innerHTML: 'postcode' }];
+				deliveryPostcode.changePostcodeReferenceForCountry = 'GBR';
+				expect(deliveryPostcode.reference).to.eql(expectedResponse);
+			});
+
+			it('should set postcodeReference to zip code when country code is USA', () => {
+				const expectedResponse = [{ innerHTML: 'zip code' }, { innerHTML: 'zip code' }];
+				deliveryPostcode.changePostcodeReferenceForCountry = 'USA';
+				expect(deliveryPostcode.reference).to.eql(expectedResponse);
+			});
+
+			it('should set postcodeReference to postal code when country code is Canada', () => {
+				const expectedResponse = [{ innerHTML: 'postal code' }, { innerHTML: 'postal code' }];
+				deliveryPostcode.changePostcodeReferenceForCountry = 'CAN';
+				expect(deliveryPostcode.reference).to.eql(expectedResponse);
+			});
+		});
+
+		context('placeholder', () => {
+			it('should call querySelector with span input', () => {
+				querySelectorStub.returns({ placeholder: 'Enter your postcode' });
+				deliveryPostcode.changePostcodeReferenceForCountry = 'GBR';
+				expect(querySelectorStub.calledWith('input')).to.be.true;
+			});
+
+			it('should set postcode placeholder to `Enter your postcode` by default', () => {
+				querySelectorStub.returns({ placeholder: 'Enter your zip code' });
+				deliveryPostcode.changePostcodeReferenceForCountry = 'GBR';
+				expect(deliveryPostcode.postcodeInput.placeholder).to.equal('Enter your postcode');
+			});
+
+			it('should set postcode placeholder to `Enter your zip code` when country code is USA', () => {
+				querySelectorStub.returns({ placeholder: 'Enter your postcode' });
+				deliveryPostcode.changePostcodeReferenceForCountry = 'USA';
+				expect(deliveryPostcode.postcodeInput.placeholder).to.equal('Enter your zip code');
+			});
+
+			it('should set postcode placeholder to `Enter your postal code` when country code is Canada', () => {
+				querySelectorStub.returns({ placeholder: 'Enter your zip code' });
+				deliveryPostcode.changePostcodeReferenceForCountry = 'CAN';
+				expect(deliveryPostcode.postcodeInput.placeholder).to.equal('Enter your postal code');
+			});
+		});
+	});
+
+	describe('getPostcodeReferenceByCountry', () => {
+		it('should return post code by default ', () => {
+			expect(DeliveryPostcode.getPostcodeReferenceByCountry('ZAR')).to.equal('postcode');
+		});
+
+		it('should return postal code when country is Canada', () => {
+			expect(DeliveryPostcode.getPostcodeReferenceByCountry('CAN')).to.equal('postal code');
+		});
+
+		it('should return zip code when country is USA', () => {
+			expect(DeliveryPostcode.getPostcodeReferenceByCountry('USA')).to.equal('zip code');
+		});
+	});
+});

--- a/test/utils/postcode.spec.js
+++ b/test/utils/postcode.spec.js
@@ -1,0 +1,106 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const Postcode = require('../../utils/postcode');
+
+describe('postcode', () => {
+	let postcode;
+	let querySelectorStub;
+	let querySelectorAllStub;
+
+	beforeEach(() => {
+		const document = {
+			querySelector: () => {
+				return {
+					querySelectorAll: () => {},
+					querySelector: () => {}
+				};
+			}
+		};
+		postcode = new Postcode(document);
+		querySelectorStub = sandbox.stub(postcode.$el, 'querySelector');
+		querySelectorAllStub = sandbox.stub(postcode.$el, 'querySelectorAll');
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	it('should return an element', () => {
+		expect(postcode.$el).to.exist;
+	});
+
+	describe('getPostcodeReferenceByCountry', () => {
+		it('return postcode by default', () => {
+			expect(Postcode.getPostcodeReferenceByCountry('GBR')).to.equal('postcode');
+		});
+
+		it('return zip code when country code is USA', () => {
+			expect(Postcode.getPostcodeReferenceByCountry('USA')).to.equal('zip code');
+		});
+
+		it('return postal when country code is CAN', () => {
+			expect(Postcode.getPostcodeReferenceByCountry('CAN')).to.equal('postal code');
+		});
+	});
+
+	describe('changePostcodeReferenceForCountry', () => {
+
+		beforeEach(() => {
+			querySelectorStub.returns({ innerHTML: '' });
+			querySelectorAllStub.returns([{ innerHTML: '' }, { innerHTML: '' }]);
+		});
+
+		context('postcode reference name', () => {
+			it('should call querySelector with [data-reference]', () => {
+				postcode.changePostcodeReferenceForCountry = 'GBR';
+				expect(querySelectorAllStub.calledWith('[data-reference=postcode]')).to.be.true;
+			});
+
+			it('should set postcodeReference to post code by default', () => {
+				const expectedResponse = [{ innerHTML: 'postcode' }, { innerHTML: 'postcode' }];
+				postcode.changePostcodeReferenceForCountry = 'GBR';
+				expect(postcode.reference).to.eql(expectedResponse);
+			});
+
+			it('should set postcodeReference to zip code when country code is USA', () => {
+				const expectedResponse = [{ innerHTML: 'zip code' }, { innerHTML: 'zip code' }];
+				postcode.changePostcodeReferenceForCountry = 'USA';
+				expect(postcode.reference).to.eql(expectedResponse);
+			});
+
+			it('should set postcodeReference to postal code when country code is Canada', () => {
+				const expectedResponse = [{ innerHTML: 'postal code' }, { innerHTML: 'postal code' }];
+				postcode.changePostcodeReferenceForCountry = 'CAN';
+				expect(postcode.reference).to.eql(expectedResponse);
+			});
+		});
+
+		context('placeholder', () => {
+			it('should call querySelector with span input', () => {
+				querySelectorStub.returns({ placeholder: 'Enter your postcode' });
+				postcode.changePostcodeReferenceForCountry = 'GBR';
+				expect(querySelectorStub.calledWith('input')).to.be.true;
+			});
+
+			it('should set postcode placeholder to `Enter your postcode` by default', () => {
+				querySelectorStub.returns({ placeholder: 'Enter your zip code' });
+				postcode.changePostcodeReferenceForCountry = 'GBR';
+				expect(postcode.postcodeInput.placeholder).to.equal('Enter your postcode');
+			});
+
+			it('should set postcode placeholder to `Enter your zip code` when country code is USA', () => {
+				querySelectorStub.returns({ placeholder: 'Enter your postcode' });
+				postcode.changePostcodeReferenceForCountry = 'USA';
+				expect(postcode.postcodeInput.placeholder).to.equal('Enter your zip code');
+			});
+
+			it('should set postcode placeholder to `Enter your postal code` when country code is Canada', () => {
+				querySelectorStub.returns({ placeholder: 'Enter your zip code' });
+				postcode.changePostcodeReferenceForCountry = 'CAN';
+				expect(postcode.postcodeInput.placeholder).to.equal('Enter your postal code');
+			});
+		});
+	});
+});

--- a/utils/billing-postcode.js
+++ b/utils/billing-postcode.js
@@ -1,6 +1,6 @@
-const FormElement = require('./form-element');
+const Postcode= require('./postcode');
 
-class BillingPostcode extends FormElement {
+class BillingPostcode extends Postcode {
 	constructor (document) {
 		super(document, '.ncf #billingPostcodeField');
 	}

--- a/utils/delivery-postcode.js
+++ b/utils/delivery-postcode.js
@@ -1,0 +1,9 @@
+const Postcode = require('./postcode');
+
+class DeliveryPostcode extends Postcode {
+	constructor (document) {
+		super(document, '.ncf #deliveryPostcodeField');
+	}
+}
+
+module.exports = DeliveryPostcode;

--- a/utils/postcode.js
+++ b/utils/postcode.js
@@ -1,9 +1,28 @@
 const FormElement = require('./form-element');
 
 class Postcode extends FormElement {
-	constructor (document) {
-		super(document, '.ncf #postCodeField');
+	constructor (document, query = '.ncf #postCodeField') {
+		super(document, query);
 	}
+
+	set changePostcodeReferenceForCountry (countryCode) {
+		const name = Postcode.getPostcodeReferenceByCountry(countryCode);
+		this.reference = this.$el.querySelectorAll('[data-reference=postcode]');
+		this.reference.forEach(reference => reference.innerHTML = name);
+		this.postcodeInput = this.$el.querySelector('input');
+		this.postcodeInput.placeholder = 'Enter your ' + name;
+	}
+
+	static getPostcodeReferenceByCountry (countryCode) {
+		if (countryCode === 'CAN') {
+			return 'postal code';
+		} else if (countryCode === 'USA') {
+			return 'zip code';
+		} else {
+			return 'postcode';
+		}
+	}
+
 }
 
 module.exports = Postcode;


### PR DESCRIPTION
🐿 v2.12.3

## Feature Description
This functionality allows for the retrieval of the correct terminology of postcode based on the country of the user.

USA -> zip code
Canada -> postal code
default -> postcode

This also updates any reference to postcode to the correct terminology when the user changes their country, i.e Canada to USA - postal code to zip code.

This work deals with both billing and delivery postcode.

## Link to Ticket / Card:
https://trello.com/c/w3jLsixQ/1476-3-postcode-logic-for-us-and-canada-migration

## Has the necessary documentation been created / updated?
- [x] Yes
- [ ] Not required for this ticket

## Has this been given a review by Design/UX?
- [ ] Yes
- [x] Not required for this ticket

