### PR TITLE
feat: add transition-terms

### DIFF
--- a/demos/data.json
+++ b/demos/data.json
@@ -1,4 +1,10 @@
 {
+  "accept-terms": {
+    "params": {
+      "isTransition": true,
+      "transitionType": "endOfTerm"
+    }
+  },
   "billing-country": {
     "params": {
       "filterList": ["GBR", "JPN", "USA", "FRA"],

--- a/partials/accept-terms.html
+++ b/partials/accept-terms.html
@@ -24,6 +24,18 @@
 			{{/if}}
 		{{/if}}
 
+		{{#if isTransition}}
+
+		<p class="terms-transition">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="_blank" rel="noopener">customer service through chat, phone or email</a>.</p>
+		{{#ifEquals transitionType 'immediate'}}
+		<p class="terms-transition terms-transition--immediate">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</p>
+		{{else}}
+		<p class="terms-transition  terms-transition--other">By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.</p>
+		{{/ifEquals}}
+		<p class="terms-transition">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="_blank" rel="noopener">Terms &amp; Conditions</a>.</p>
+
+		{{/if}}
+
 		{{#if isSignup}}
 			{{#if isPrintProduct}}
 		<p class="terms-print">Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).</p>

--- a/test/partials/accept-terms.spec.js
+++ b/test/partials/accept-terms.spec.js
@@ -10,6 +10,7 @@ const SELECTOR_SIGNUP_TERMS = 'label p.terms-signup';
 const SELECTOR_SPECIAL_TERMS = 'label p#terms-special';
 const SELECTOR_B2B_TERMS = 'label p#terms-b2b';
 const SELECTOR_CORP_TERMS = 'label p.terms-corp-signup';
+const SELECTOR_TRANSITION_TERMS = 'label p.terms-transition';
 const SELECTOR_ACCEPT_TERMS_FIELD = '#acceptTermsField';
 const SELECTOR_CHECKBOX = 'input';
 const SELECTOR_ANCHOR = 'a';
@@ -123,6 +124,27 @@ describe('accept-terms template', () => {
 		});
 	});
 
+	describe('transition', () => {
+		const params = {
+			isTransition: true
+		};
+
+		it('should have the default and transtion terms', () => {
+			const $ = context.template(params);
+			expectTerms($, { standard:1, transition: 3 });
+		});
+
+		it('should show immediate terms if transitionType immediate', () => {
+			const $ = context.template({...params, transitionType: 'immediate' });
+			expect($('label p.terms-transition--immediate').length).to.equal(1);
+		});
+
+		it('should show other terms if transitionType not immediate', () => {
+			const $ = context.template({...params, transitionType: 'endOfTerm' });
+			expect($('label p.terms-transition--other').length).to.equal(1);
+		});
+	});
+
 	describe('Corp Signup', () => {
 		const params = {
 			isCorpSignup: true
@@ -189,11 +211,12 @@ describe('accept-terms template', () => {
 	shouldError(context);
 });
 
-function expectTerms ($, { standard=0, print=0, signup=0, special=0, b2b=0, corp=0 }) {
+function expectTerms ($, { standard=0, print=0, signup=0, special=0, b2b=0, corp=0, transition=0 }) {
 	expect($(SELECTOR_STANDARD_TERMS).length).to.equal(standard);
 	expect($(SELECTOR_PRINT_TERMS).length).to.equal(print);
 	expect($(SELECTOR_SIGNUP_TERMS).length).to.equal(signup);
 	expect($(SELECTOR_SPECIAL_TERMS).length).to.equal(special);
 	expect($(SELECTOR_B2B_TERMS).length).to.equal(b2b);
 	expect($(SELECTOR_CORP_TERMS).length).to.equal(corp);
+	expect($(SELECTOR_TRANSITION_TERMS).length).to.equal(transition);
 }


### PR DESCRIPTION
## Feature Description

Adds transition specific terms into the accept-terms partial
 🐿 v2.12.4

## Link to Ticket / Card:

https://trello.com/c/YQYDZCon/1525-1-make-tcs-text-relevant-to-transitions


## Screenshots:

N/A


## Has the necessary documentation been created / updated?
- [x] Yes
- [ ] Not required for this ticket

## Has this been given a review by Design/UX?
- [ ] Yes
- [x] Not required for this ticket
