### PR TITLE
fix: typos in test

### DIFF
--- a/test/partials/accept-terms.spec.js
+++ b/test/partials/accept-terms.spec.js
@@ -129,19 +129,19 @@ describe('accept-terms template', () => {
 			isTransition: true
 		};
 
-		it('should have the default and transtion terms', () => {
+		it('should have the default and transition terms', () => {
 			const $ = context.template(params);
 			expectTerms($, { standard:1, transition: 3 });
 		});
 
-		it('should show immediate terms if transitionType immediate', () => {
-			const $ = context.template({...params, transitionType: 'immediate' });
-			expect($('label p.terms-transition--immediate').length).to.equal(1);
+		it('should show immediate terms if transitionType is immediate', () => {
+			const $ = context.template({ ...params, transitionType: 'immediate' });
+			expect($('.terms-transition--immediate').length).to.equal(1);
 		});
 
-		it('should show other terms if transitionType not immediate', () => {
-			const $ = context.template({...params, transitionType: 'endOfTerm' });
-			expect($('label p.terms-transition--other').length).to.equal(1);
+		it('should show other terms if transitionType is not immediate', () => {
+			const $ = context.template({ ...params, transitionType: 'endOfTerm' });
+			expect($('.terms-transition--other').length).to.equal(1);
 		});
 	});
 


### PR DESCRIPTION
 🐿 v2.12.4

## Feature Description

Fixes typos is accept-terms unit tests after work to include the transition specific terms.

## Link to Ticket / Card:

https://trello.com/c/YQYDZCon/1525-1-make-tcs-text-relevant-to-transitions

## Screenshots:

<summary>
End Of Term
<details>
<img src="https://user-images.githubusercontent.com/6599523/65229090-8ec0f900-dac3-11e9-9ceb-a4c2573c7e4e.png" />
</details>
</summary>

<summary>
Immediate
<details>
<img src="https://user-images.githubusercontent.com/6599523/65229127-a6987d00-dac3-11e9-98c5-26115f5dd3e7.png" />
</details>
</summary>


## Has the necessary documentation been created / updated?
- [ ] Yes
- [x] Not required for this ticket

## Has this been given a review by Design/UX?
- [x] Yes
- [ ] Not required for this ticket
