### PR TITLE
Disable globalsign security seal

### DIFF
--- a/partials/payment-type.html
+++ b/partials/payment-type.html
@@ -1,13 +1,14 @@
 <div class="ncf__security-seal">
 	<!-- NOTE: this won't display on local.ft.com (yet it will still take up space. I know.) -->
 	<!--- DO NOT EDIT - GlobalSign SSL Site Seal Code - DO NOT EDIT --->
-	<table width=125 border=0 cellspacing=0 cellpadding=0 title="CLICK TO VERIFY: This site uses a GlobalSign SSL Certificate to secure your personal information.">
+	<!-- Disabled until we can get a version from GlobalSign that works better than this one. Currently it doesn't always load correctly. -->
+	<!-- <table width=125 border=0 cellspacing=0 cellpadding=0 title="CLICK TO VERIFY: This site uses a GlobalSign SSL Certificate to secure your personal information.">
 		<tr>
 			<td><span id="ss_img_wrapper_gmogs_image_110-45_en_dblue"><a href="https://www.globalsign.com/" target=_blank title="GlobalSign Site Seal" rel="nofollow"><img alt="SSL" border=0 id="ss_img" src="//seal.globalsign.com/SiteSeal/images/gs_noscript_110-45_en.gif"></a></span>
 				<script type="text/javascript" src="//seal.globalsign.com/SiteSeal/gmogs_image_110-45_en_dblue.js"></script>
 			</td>
 		</tr>
-	</table>
+	</table> -->
 	<!--- DO NOT EDIT - GlobalSign SSL Site Seal Code - DO NOT EDIT --->
 </div>
 


### PR DESCRIPTION
🐿 v2.12.4

## Feature Description

The Global Sign SSL padlock image is not showing up correctly and makes the sign up form look broken sometimes. 

Removing until we can get a better solution from Global Sign.

[Ticket](https://trello.com/c/WIFoCaPC/1494-1-remove-the-global-sign-ssl-image-as-its-not-loading-correctly)