### PR TITLE
Use app name from html element for debug email

### DIFF
--- a/partials/debug.html
+++ b/partials/debug.html
@@ -36,7 +36,7 @@
 	var RADIO_SELECTOR = FORM_SELECTOR + ' input[type="radio"]';
 	// This env var gets set in production. We use this when creating email addresses in case any
 	// get into production so Membership know who to come to about deleting them.
-	var SYSTEM_CODE = '{{process.env.SYSTEM_CODE}}' || 'n-conversion-forms';
+	var SYSTEM_CODE = document.documentElement.getAttribute('data-next-app') || 'n-conversion-forms';
 
 	var debugData = {
 		billingCountry: 'GBR',


### PR DESCRIPTION
 🐿 v2.12.4

### Description

Handlebars can't access env variables 🤦‍♂ so using the `data-next-app` property that's present on the `html` element. Side benefit to this is that it will work locally too \o/