### PR TITLE
Remove grid from package change into next-subscribe

### DIFF
--- a/partials/package-change.html
+++ b/partials/package-change.html
@@ -1,75 +1,69 @@
 <div class="ncf__package-change">
-	<div class="o-grid-container o-grid-container--bleed">
-		<div class="o-grid-row">
-			<div data-o-grid-colspan="12 S10 M8 L6 XL5 center">
-				<div class="ncf__package-change__package">
-					<p class="ncf__package-change__content">You have chosen <span class="ncf__strong">{{currentPackage}}</span></p>
-					<div class="ncf__package-change__actions">
-						<a href="{{changePackageUrl}}" class="ncf__button ncf__button--mono ncf__button--baseline" data-trackable="change">Change</a>
-					</div>
-				</div>
-				{{#if terms}}
-				<div class="ncf__package-change__terms">
-					{{#each terms}}
-					<div class="ncf__package-change__term{{#if this.discount}} ncf__package-change__term--discounted{{/if}}">
-						{{#ifEquals this.name 'trial'}}
-						<span class="ncf__package-change__title">Try the FT</span>
-						{{#if this.discount}}
-						<span class="ncf__package-change__discount">Save {{this.discount}}</span>
-						{{/if}}
-						<div class="ncf__package-change__description">
-							4 weeks for <span class="ncf__package-change__trial-price">{{trialPrice}}</span>
-						</div>
-						{{/ifEquals}}
-
-						{{#ifEquals this.name 'annual'}}
-						<span class="ncf__package-change__title">Annually</span>
-						{{#if this.discount}}
-						<span class="ncf__package-change__discount">Save {{this.discount}}</span>
-						{{/if}}
-						<div class="ncf__package-change__description">
-							Single <span class="ncf__package-change__price">{{price}}</span> payment*
-						</div>
-						{{#if weeklyPrice}}
-						<div class="ncf__package-change__weekly-price">
-							Just <span class="ncf__package-change__price">{{weeklyPrice}}</span> per week
-						</div>
-						{{/if}}
-						{{/ifEquals}}
-
-						{{#ifEquals this.name 'quarterly'}}
-						<span class="ncf__package-change__title">Quarterly</span>
-						{{#if this.discount}}
-						<span class="ncf__package-change__discount">Save {{this.discount}}</span>
-						{{/if}}
-						<div class="ncf__package-change__description">
-							<span class="ncf__package-change__price">{{price}}</span> per quarter
-						</div>
-						{{/ifEquals}}
-
-						{{#ifEquals this.name 'monthly'}}
-						<span class="ncf__package-change__title">Monthly</span>
-						{{#if this.discount}}
-						<span class="ncf__package-change__discount">Save {{this.discount}}</span>
-						{{/if}}
-						<div class="ncf__package-change__description">
-							<span class="ncf__package-change__price">{{price}}</span> per month
-						</div>
-						{{/ifEquals}}
-					</div>
-					{{/each}}
-					{{#each terms}}
-					{{#unless this.discount}}
-					{{#ifEquals this.name 'annual'}}
-					<div class="ncf__package-change__annual-copy">
-						* Save up to 25% when you pay annually. Discount varies across member states and across our subscription packages.
-					</div>
-					{{/ifEquals}}
-					{{/unless}}
-					{{/each}}
-				</div>
-				{{/if}}
-			</div>
+	<div class="ncf__package-change__package">
+		<p class="ncf__package-change__content">You have chosen <span class="ncf__strong">{{currentPackage}}</span></p>
+		<div class="ncf__package-change__actions">
+			<a href="{{changePackageUrl}}" class="ncf__button ncf__button--mono ncf__button--baseline" data-trackable="change">Change</a>
 		</div>
 	</div>
+	{{#if terms}}
+	<div class="ncf__package-change__terms">
+		{{#each terms}}
+		<div class="ncf__package-change__term{{#if this.discount}} ncf__package-change__term--discounted{{/if}}">
+			{{#ifEquals this.name 'trial'}}
+			<span class="ncf__package-change__title">Try the FT</span>
+			{{#if this.discount}}
+			<span class="ncf__package-change__discount">Save {{this.discount}}</span>
+			{{/if}}
+			<div class="ncf__package-change__description">
+				4 weeks for <span class="ncf__package-change__trial-price">{{trialPrice}}</span>
+			</div>
+			{{/ifEquals}}
+
+			{{#ifEquals this.name 'annual'}}
+			<span class="ncf__package-change__title">Annually</span>
+			{{#if this.discount}}
+			<span class="ncf__package-change__discount">Save {{this.discount}}</span>
+			{{/if}}
+			<div class="ncf__package-change__description">
+				Single <span class="ncf__package-change__price">{{price}}</span> payment*
+			</div>
+			{{#if weeklyPrice}}
+			<div class="ncf__package-change__weekly-price">
+				Just <span class="ncf__package-change__price">{{weeklyPrice}}</span> per week
+			</div>
+			{{/if}}
+			{{/ifEquals}}
+
+			{{#ifEquals this.name 'quarterly'}}
+			<span class="ncf__package-change__title">Quarterly</span>
+			{{#if this.discount}}
+			<span class="ncf__package-change__discount">Save {{this.discount}}</span>
+			{{/if}}
+			<div class="ncf__package-change__description">
+				<span class="ncf__package-change__price">{{price}}</span> per quarter
+			</div>
+			{{/ifEquals}}
+
+			{{#ifEquals this.name 'monthly'}}
+			<span class="ncf__package-change__title">Monthly</span>
+			{{#if this.discount}}
+			<span class="ncf__package-change__discount">Save {{this.discount}}</span>
+			{{/if}}
+			<div class="ncf__package-change__description">
+				<span class="ncf__package-change__price">{{price}}</span> per month
+			</div>
+			{{/ifEquals}}
+		</div>
+		{{/each}}
+		{{#each terms}}
+		{{#unless this.discount}}
+		{{#ifEquals this.name 'annual'}}
+		<div class="ncf__package-change__annual-copy">
+			* Save up to 25% when you pay annually. Discount varies across member states and across our subscription packages.
+		</div>
+		{{/ifEquals}}
+		{{/unless}}
+		{{/each}}
+	</div>
+	{{/if}}
 </div>

--- a/styles/package-change.scss
+++ b/styles/package-change.scss
@@ -3,7 +3,6 @@
 @mixin ncfPackageChange() {
 	&__package-change {
 		@include oTypographySans($scale: 0);
-		background-color: oColorsGetPaletteColor('wheat');
 		padding: 0 20px;
 
 		@include oGridRespondTo($from: S) {


### PR DESCRIPTION
### Description

The grid not being in next-subscribe meant that changes to the grid size had to be done in two repositories. Moving this to next-subscribe means that it has better control of the component.

[Ticket](https://trello.com/c/bHHabGTX/1521-gride-width-tcs)
