### PR TITLE
Fix logout debug button by directly clearing cookie

### DIFF
--- a/partials/debug.html
+++ b/partials/debug.html
@@ -64,13 +64,9 @@
 	};
 
 	function logout () {
-		const options = {
-			mode: 'no-cors',
-			credentials: 'include'
-		};
-		fetch('https://www.ft.com/logout', options).then(function () {
-			window.location.reload();
-		});
+		document.cookie = 'FTSession=; path=/;';
+		document.cookie = 'FTSession_s=; path=/;';
+		window.location.reload();
 	}
 
 	function fillForm () {


### PR DESCRIPTION
### Description

Recently removed the domain in cookies that were being set in environments other than production for our e2e tests. As `/logout` will only clear cookies with the domain of `.ft.com` this meant our session cookies were not being cleared. Instead remove cookies with the name `FTSession` and `FTSession_s` where ever they are from.