### PR TITLE
JSX POC: Phone field

### DIFF
--- a/components/__snapshots__/phone.spec.js.snap
+++ b/components/__snapshots__/phone.spec.js.snap
@@ -1,0 +1,323 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Phone render a disabled phone input 1`] = `
+<div id="primaryTelephoneField"
+     class="o-forms o-forms--wide ncf__field js-field"
+     data-ui-item="form-field"
+     data-ui-item-name="primaryTelephone"
+     data-validate="required,number"
+>
+  <label for="primaryTelephone"
+         class="o-forms__label"
+  >
+    Phone number
+  </label>
+  <small class="o-forms__additional-info"
+         id="phone-description"
+  >
+    5 to 15 characters (numbers only)
+  </small>
+  <input type="tel"
+         id="primaryTelephone"
+         name="primaryTelephone"
+         placeholder="Enter your phone number"
+         autocomplete="tel"
+         class="o-forms__text js-field__input js-item__value"
+         data-min="5"
+         data-max="15"
+         minlength="5"
+         maxlength="15"
+         data-trackable="field-phone"
+         aria-describedby="phone-description"
+         aria-required="true"
+         required
+         pattern="whatever"
+         disabled
+         value
+  >
+  <div class="o-forms__errortext">
+    This phone number is not valid
+  </div>
+</div>
+`;
+
+exports[`Phone render a disabled phone input 2`] = `
+<div id="primaryTelephoneField"
+     class="o-forms o-forms--wide ncf__field js-field"
+     data-ui-item="form-field"
+     data-ui-item-name="primaryTelephone"
+     data-validate="required,number"
+>
+  <label for="primaryTelephone"
+         class="o-forms__label"
+  >
+    Phone number
+  </label>
+  <small class="o-forms__additional-info"
+         id="phone-description"
+  >
+    5 to 15 characters (numbers only)
+  </small>
+  <input type="tel"
+         id="primaryTelephone"
+         name="primaryTelephone"
+         placeholder="Enter your phone number"
+         autocomplete="tel"
+         class="o-forms__text js-field__input js-item__value"
+         data-min="5"
+         data-max="15"
+         minlength="5"
+         maxlength="15"
+         data-trackable="field-phone"
+         aria-describedby="phone-description"
+         aria-required="true"
+         required
+         pattern="whatever"
+         disabled
+         value
+  >
+  <div class="o-forms__errortext">
+    This phone number is not valid
+  </div>
+</div>
+`;
+
+exports[`Phone render a phone input with a label 1`] = `
+<div id="primaryTelephoneField"
+     class="o-forms o-forms--wide ncf__field js-field"
+     data-ui-item="form-field"
+     data-ui-item-name="primaryTelephone"
+     data-validate="required,number"
+>
+  <label for="primaryTelephone"
+         class="o-forms__label"
+  >
+    Phone number
+  </label>
+  <small class="o-forms__additional-info"
+         id="phone-description"
+  >
+    5 to 15 characters (numbers only)
+  </small>
+  <input type="tel"
+         id="primaryTelephone"
+         name="primaryTelephone"
+         placeholder="Enter your phone number"
+         autocomplete="tel"
+         class="o-forms__text js-field__input js-item__value"
+         data-min="5"
+         data-max="15"
+         minlength="5"
+         maxlength="15"
+         data-trackable="field-phone"
+         aria-describedby="phone-description"
+         aria-required="true"
+         required
+         pattern="whatever"
+         value
+  >
+  <div class="o-forms__errortext">
+    This phone number is not valid
+  </div>
+</div>
+`;
+
+exports[`Phone render a phone input with a label 2`] = `
+<div id="primaryTelephoneField"
+     class="o-forms o-forms--wide ncf__field js-field"
+     data-ui-item="form-field"
+     data-ui-item-name="primaryTelephone"
+     data-validate="required,number"
+>
+  <label for="primaryTelephone"
+         class="o-forms__label"
+  >
+    Phone number
+  </label>
+  <small class="o-forms__additional-info"
+         id="phone-description"
+  >
+    5 to 15 characters (numbers only)
+  </small>
+  <input type="tel"
+         id="primaryTelephone"
+         name="primaryTelephone"
+         placeholder="Enter your phone number"
+         autocomplete="tel"
+         class="o-forms__text js-field__input js-item__value"
+         data-min="5"
+         data-max="15"
+         minlength="5"
+         maxlength="15"
+         data-trackable="field-phone"
+         aria-describedby="phone-description"
+         aria-required="true"
+         required
+         pattern="whatever"
+         value
+  >
+  <div class="o-forms__errortext">
+    This phone number is not valid
+  </div>
+</div>
+`;
+
+exports[`Phone render a phone input with a label for B2B 1`] = `
+<div id="primaryTelephoneField"
+     class="o-forms o-forms--wide ncf__field js-field"
+     data-ui-item="form-field"
+     data-ui-item-name="primaryTelephone"
+     data-validate="required,number"
+>
+  <label for="primaryTelephone"
+         class="o-forms__label"
+  >
+    Work phone number
+  </label>
+  <small class="o-forms__additional-info"
+         id="phone-description"
+  >
+    5 to 15 characters (numbers only)
+  </small>
+  <input type="tel"
+         id="primaryTelephone"
+         name="primaryTelephone"
+         placeholder="Enter your phone number"
+         autocomplete="tel"
+         class="o-forms__text js-field__input js-item__value"
+         data-min="5"
+         data-max="15"
+         minlength="5"
+         maxlength="15"
+         data-trackable="field-phone"
+         aria-describedby="phone-description"
+         aria-required="true"
+         required
+         pattern="whatever"
+         value
+  >
+  <div class="o-forms__errortext">
+    This phone number is not valid
+  </div>
+</div>
+`;
+
+exports[`Phone render a phone input with a label for B2B 2`] = `
+<div id="primaryTelephoneField"
+     class="o-forms o-forms--wide ncf__field js-field"
+     data-ui-item="form-field"
+     data-ui-item-name="primaryTelephone"
+     data-validate="required,number"
+>
+  <label for="primaryTelephone"
+         class="o-forms__label"
+  >
+    Work phone number
+  </label>
+  <small class="o-forms__additional-info"
+         id="phone-description"
+  >
+    5 to 15 characters (numbers only)
+  </small>
+  <input type="tel"
+         id="primaryTelephone"
+         name="primaryTelephone"
+         placeholder="Enter your phone number"
+         autocomplete="tel"
+         class="o-forms__text js-field__input js-item__value"
+         data-min="5"
+         data-max="15"
+         minlength="5"
+         maxlength="15"
+         data-trackable="field-phone"
+         aria-describedby="phone-description"
+         aria-required="true"
+         required
+         pattern="whatever"
+         value
+  >
+  <div class="o-forms__errortext">
+    This phone number is not valid
+  </div>
+</div>
+`;
+
+exports[`Phone render a phone input with error styling 1`] = `
+<div id="primaryTelephoneField"
+     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
+     data-ui-item="form-field"
+     data-ui-item-name="primaryTelephone"
+     data-validate="required,number"
+>
+  <label for="primaryTelephone"
+         class="o-forms__label"
+  >
+    Phone number
+  </label>
+  <small class="o-forms__additional-info"
+         id="phone-description"
+  >
+    5 to 15 characters (numbers only)
+  </small>
+  <input type="tel"
+         id="primaryTelephone"
+         name="primaryTelephone"
+         placeholder="Enter your phone number"
+         autocomplete="tel"
+         class="o-forms__text js-field__input js-item__value"
+         data-min="5"
+         data-max="15"
+         minlength="5"
+         maxlength="15"
+         data-trackable="field-phone"
+         aria-describedby="phone-description"
+         aria-required="true"
+         required
+         pattern="whatever"
+         value
+  >
+  <div class="o-forms__errortext">
+    This phone number is not valid
+  </div>
+</div>
+`;
+
+exports[`Phone render a phone input with error styling 2`] = `
+<div id="primaryTelephoneField"
+     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
+     data-ui-item="form-field"
+     data-ui-item-name="primaryTelephone"
+     data-validate="required,number"
+>
+  <label for="primaryTelephone"
+         class="o-forms__label"
+  >
+    Phone number
+  </label>
+  <small class="o-forms__additional-info"
+         id="phone-description"
+  >
+    5 to 15 characters (numbers only)
+  </small>
+  <input type="tel"
+         id="primaryTelephone"
+         name="primaryTelephone"
+         placeholder="Enter your phone number"
+         autocomplete="tel"
+         class="o-forms__text js-field__input js-item__value"
+         data-min="5"
+         data-max="15"
+         minlength="5"
+         maxlength="15"
+         data-trackable="field-phone"
+         aria-describedby="phone-description"
+         aria-required="true"
+         required
+         pattern="whatever"
+         value
+  >
+  <div class="o-forms__errortext">
+    This phone number is not valid
+  </div>
+</div>
+`;

--- a/components/phone.jsx
+++ b/components/phone.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import propTypes from 'prop-types';
+
+export default function Phone ({
+	hasError = false,
+	isB2b = false,
+	isDisabled = false,
+	value = '',
+	pattern = '',
+	fieldId = 'primaryTelephoneField',
+	fieldName = 'primaryTelephone',
+	inputId = 'primaryTelephone',
+	inputName = 'primaryTelephone',
+	dataTrackable = 'field-phone',
+}) {
+	const labelText = isB2b ? 'Work phone number' : 'Phone number';
+	const descriptionId = 'phone-description';
+	let className = 'o-forms o-forms--wide ncf__field js-field';
+
+	if (hasError) {
+		className += ' o-forms--error';
+	}
+
+	return (
+		<div
+			id={fieldId}
+			className={className}
+			data-ui-item="form-field"
+			data-ui-item-name={fieldName}
+			data-validate="required,number"
+		>
+			<label htmlFor={inputId} className="o-forms__label">{labelText}</label>
+			<small className="o-forms__additional-info" id={descriptionId}>
+				5 to 15 characters (numbers only)
+			</small>
+
+			<input
+				type="tel"
+				id={inputId}
+				name={inputName}
+				placeholder="Enter your phone number"
+				autoComplete="tel"
+				className="o-forms__text js-field__input js-item__value"
+				data-min="5" /* Used by o-forms validation */
+				data-max="15" /* Used by o-forms validation */
+				minLength="5"
+				maxLength="15"
+				data-trackable={dataTrackable}
+				aria-describedby={descriptionId}
+				aria-required="true"
+				required
+				pattern={pattern}
+				disabled={isDisabled}
+				defaultValue={value}
+			/>
+
+			<div className="o-forms__errortext">This phone number is not valid</div>
+		</div>
+	);
+};
+
+Phone.propTypes = {
+	hasError: propTypes.bool,
+	isB2b: propTypes.bool,
+	isDisabled: propTypes.bool,
+	value: propTypes.string,
+	pattern: propTypes.string,
+	fieldId: propTypes.string,
+	fieldName: propTypes.string,
+	inputId: propTypes.string.isRequired,
+	inputName: propTypes.string.isRequired,
+	dataTrackable: propTypes.string.isRequired,
+};

--- a/components/phone.spec.js
+++ b/components/phone.spec.js
@@ -1,0 +1,49 @@
+import Phone from './phone';
+import { expectToRenderAs } from '../test-jest/helpers/expect-to-render-as';
+import { fetchPartialAsString } from '../test-jest/helpers/fetch-hbs-as-string';
+
+const context = {
+};
+
+expect.extend(expectToRenderAs);
+
+describe('Phone', () => {
+	beforeAll(async () => {
+		context.template = await fetchPartialAsString('phone.html');
+	});
+
+	it('render a phone input with a label', () => {
+		const props = {
+			pattern: 'whatever',
+		};
+
+		expect(Phone).toRenderAs(context, props);
+	});
+
+	it('render a phone input with a label for B2B', () => {
+		const props = {
+			pattern: 'whatever',
+			isB2b: true,
+		};
+
+		expect(Phone).toRenderAs(context, props);
+	});
+
+	it('render a disabled phone input', () => {
+		const props = {
+			pattern: 'whatever',
+			isDisabled: true,
+		};
+
+		expect(Phone).toRenderAs(context, props);
+	});
+
+	it('render a phone input with error styling', () => {
+		const props = {
+			pattern: 'whatever',
+			hasError: true,
+		};
+
+		expect(Phone).toRenderAs(context, props);
+	});
+});

--- a/partials/phone.html
+++ b/partials/phone.html
@@ -11,7 +11,7 @@
 		5 to 15 characters (numbers only)
 	</small>
 
-	<input type="tel" id="primaryTelephone" name="primaryTelephone" value="{{value}}" placeholder="Enter your phone number"
+	<input type="tel" id="primaryTelephone" name="primaryTelephone" placeholder="Enter your phone number"
 				autocomplete="tel"
 				class="o-forms__text js-field__input js-item__value"
 				data-min="5" {{!-- Used by o-forms validation --}}
@@ -22,7 +22,8 @@
 				aria-describedby="phone-description"
 				aria-required="true" required
 				{{#if pattern}}pattern="{{pattern}}"{{/if}}
-				{{#if isDisabled}}disabled{{/if}}>
+				{{#if isDisabled}}disabled{{/if}}
+				value="{{value}}">
 
 	<div class="o-forms__errortext">This phone number is not valid</div>
 


### PR DESCRIPTION
### Description
JSX version of the phone field.

As well as converting the partials params into props, I have made other values such as the fields `id` and `name` attributes into props so that these can be configured. I have defaulted these values to those used in the Handlebars partial.

[Ticket](https://trello.com/c/Jha4GGCA/77-jsx-poc-phone-number)

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [X] **Tests** written for new or updated for existing functionality
- [X] **Accessibility** checked for screen readers and contrast
