### PR TITLE
Update payment terms to display trial info for all payment options

### DIFF
--- a/partials/payment-term.html
+++ b/partials/payment-term.html
@@ -7,35 +7,42 @@
 			<span class="ncf__payment-term__discount">Save {{this.discount}}</span>
 			{{/if}}
 
-			{{#ifEquals this.name 'trial'}}
-			<span class="ncf__payment-term__title">Try the FT</span>
-			<div class="ncf__payment-term__description">
-				{{#if trialDuration}}{{trialDuration}}{{else}}4 weeks{{/if}} for <span class="ncf__payment-term__trial-price">{{trialPrice}}</span><br />
-				unless you cancel during your trial you will be billed <span class="ncf__payment-term__price">{{price}}</span> per month after the trial period
-			</div>
-			{{/ifEquals}}
-
 			{{#ifEquals this.name 'annual'}}
-			<span class="ncf__payment-term__title">Annual</span>
+			<span class="ncf__payment-term__title">{{#if isTrial}}Try the FT - {{/if}}Annual</span>
 			<div class="ncf__payment-term__description">
+				{{#if isTrial}}
+				{{#if trialDuration}}{{trialDuration}}{{else}}4 weeks{{/if}} for <span class="ncf__payment-term__trial-price">{{trialPrice}}</span><br />
+				Unless you cancel during your trial you will be billed <span class="ncf__payment-term__price">{{price}}</span> per year after the trial period
+				{{else}}
 				Single <span class="ncf__payment-term__price ncf__strong">{{price}}</span> payment
 				{{#if weeklyPrice}}<br /><span class="ncf__payment-term__weekly-price">That's just {{weeklyPrice}} per week</span>{{/if}}
 				{{!-- Remove this discount text temporarily in favour of weekly price --}}
 				<!-- {{#unless discount}}<br />Save up to 25% when you pay annually{{/unless}} -->
+				{{/if}}
 			</div>
 			{{/ifEquals}}
 
 			{{#ifEquals this.name 'quarterly'}}
-			<span class="ncf__payment-term__title">Quarterly</span>
+			<span class="ncf__payment-term__title">{{#if isTrial}}Try the FT - {{/if}}Quarterly</span>
 			<div class="ncf__payment-term__description">
+				{{#if isTrial}}
+				{{#if trialDuration}}{{trialDuration}}{{else}}4 weeks{{/if}} for <span class="ncf__payment-term__trial-price">{{trialPrice}}</span><br />
+				Unless you cancel during your trial you will be billed <span class="ncf__payment-term__price">{{price}}</span> per quarter after the trial period
+				{{else}}
 				<span class="ncf__payment-term__price">{{price}}</span> per quarter
+				{{/if}}
 			</div>
 			{{/ifEquals}}
 
 			{{#ifEquals this.name 'monthly'}}
-			<span class="ncf__payment-term__title">Monthly</span>
+			<span class="ncf__payment-term__title">{{#if isTrial}}Try the FT - {{/if}}Monthly</span>
 			<div class="ncf__payment-term__description">
+				{{#if isTrial}}
+				{{#if trialDuration}}{{trialDuration}}{{else}}4 weeks{{/if}} for <span class="ncf__payment-term__trial-price">{{trialPrice}}</span><br />
+				Unless you cancel during your trial you will be billed <span class="ncf__payment-term__price">{{price}}</span> per month after the trial period
+				{{else}}
 				<span class="ncf__payment-term__price">{{price}}</span> per month
+				{{/if}}
 			</div>
 			{{/ifEquals}}
 		</label>

--- a/test/partials/payment-term.spec.js
+++ b/test/partials/payment-term.spec.js
@@ -27,65 +27,6 @@ describe('payment-term', () => {
 		expect($('input').length).to.equal(3);
 	});
 
-	describe('trial', () => {
-		it('should show the correct title copy', () => {
-			const name = 'trial';
-			const $ = context.template({ options: [{
-				name
-			}]});
-			expect($(TITLE_SELECTOR).text()).to.equal('Try the FT');
-		});
-
-		it('should show the price', () => {
-			const name = 'trial';
-			const price = '£1.01';
-			const $ = context.template({ options: [{
-				name,
-				price
-			}]});
-			expect($(DESCRIPTION_SELECTOR).text()).to.contain(price);
-		});
-
-		it('should show the trial price', () => {
-			const name = 'trial';
-			const price = '£1.01';
-			const trialPrice = '£2.01';
-			const $ = context.template({ options: [{
-				name,
-				price,
-				trialPrice
-			}]});
-			expect($(DESCRIPTION_SELECTOR).text()).to.contain(trialPrice);
-		});
-
-		it('should show 4 weeks by default', () => {
-			const name = 'trial';
-			const price = '£1.01';
-			const trialPrice = '£2.01';
-			const $ = context.template({ options: [{
-				name,
-				price,
-				trialPrice
-			}]});
-			expect($(DESCRIPTION_SELECTOR).text()).to.contain('4 weeks');
-		});
-
-		it('should show the passed trialDuration', () => {
-			const name = 'trial';
-			const price = '£1.01';
-			const trialPrice = '£2.01';
-			const trialDuration = 'TEST DURATION';
-			const $ = context.template({ options: [{
-				name,
-				price,
-				trialPrice,
-				trialDuration
-			}]});
-			expect($(DESCRIPTION_SELECTOR).text()).to.not.contain('4 weeks');
-			expect($(DESCRIPTION_SELECTOR).text()).to.contain(trialDuration);
-		});
-	});
-
 	describe('annual', () => {
 		it('should show the correct title copy', () => {
 			const name = 'annual';
@@ -141,6 +82,10 @@ describe('payment-term', () => {
 			}]});
 			expect($('.ncf__payment-term__weekly-price').length).to.equal(1);
 		});
+
+		describe('trial', () => {
+			testTrial('annual');
+		});
 	});
 
 	describe('quarterly', () => {
@@ -161,6 +106,10 @@ describe('payment-term', () => {
 			}]});
 			expect($(DESCRIPTION_SELECTOR).text()).to.contain(price);
 		});
+
+		describe('trial', () => {
+			testTrial('quarterly');
+		});
 	});
 
 	describe('monthly', () => {
@@ -180,6 +129,10 @@ describe('payment-term', () => {
 				price
 			}]});
 			expect($(DESCRIPTION_SELECTOR).text()).to.contain(price);
+		});
+
+		describe('trial', () => {
+			testTrial('monthly');
 		});
 	});
 
@@ -211,4 +164,63 @@ describe('payment-term', () => {
 		const $ = context.template({ options: [option1, option2]});
 		expect($('.ncf__payment-term__discount').length).to.equal(1);
 	});
+
+	function testTrial (name) {
+		it('should show the correct title copy', () => {
+			const $ = context.template({ options: [{
+				name,
+				isTrial: true
+			}]});
+			expect($(TITLE_SELECTOR).text()).to.contain('Try the FT');
+		});
+
+		it('should show the price', () => {
+			const price = '£1.01';
+			const $ = context.template({ options: [{
+				name,
+				price,
+				isTrial: true
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.contain(price);
+		});
+
+		it('should show the trial price', () => {
+			const price = '£1.01';
+			const trialPrice = '£2.01';
+			const $ = context.template({ options: [{
+				name,
+				price,
+				trialPrice,
+				isTrial: true
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.contain(trialPrice);
+		});
+
+		it('should show 4 weeks by default', () => {
+			const price = '£1.01';
+			const trialPrice = '£2.01';
+			const $ = context.template({ options: [{
+				name,
+				price,
+				trialPrice,
+				isTrial: true
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.contain('4 weeks');
+		});
+
+		it('should show the passed trialDuration', () => {
+			const price = '£1.01';
+			const trialPrice = '£2.01';
+			const trialDuration = 'TEST DURATION';
+			const $ = context.template({ options: [{
+				name,
+				price,
+				trialPrice,
+				trialDuration,
+				isTrial: true
+			}]});
+			expect($(DESCRIPTION_SELECTOR).text()).to.not.contain('4 weeks');
+			expect($(DESCRIPTION_SELECTOR).text()).to.contain(trialDuration);
+		});
+	}
 });


### PR DESCRIPTION
### Description

**Breaking Change** Trials can contain multiple payment terms which was not handled in our existing forms. Instead of having the payment term name being `trial` we now pass the actual name of the term along with a `isTrial` flag which will mark the option as a trial payment term.

[Ticket](https://trello.com/c/DGCm7Xw1/1560-print-trial-payment-terms-issues)
