### PR TITLE
feat: Port partial component

### DIFF
--- a/components/__snapshots__/message.spec.jsx.snap
+++ b/components/__snapshots__/message.spec.jsx.snap
@@ -1,0 +1,435 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Message can add a data attribute name 1`] = `
+<div class="ncf__message o-forms o-forms--wide"
+     data-message-name="The Police best album ever"
+>
+  <div class="o-message o-message--alert-inner o-message--neutral"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can add a data attribute name 2`] = `
+<div class="ncf__message o-forms o-forms--wide"
+     data-message-name="The Police best album ever"
+>
+  <div class="o-message o-message--alert-inner o-message--neutral"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can render a message as a Notice 1`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--notice-inner o-message--neutral"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can render a message as a Notice 2`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--notice-inner o-message--neutral"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can render a message as a Success 1`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--alert-inner o-message--success"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can render a message as a Success 2`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--alert-inner o-message--success"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can render a message as an Error 1`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--alert-inner o-message--error"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can render a message as an Error 2`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--alert-inner o-message--error"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can render a message as an Inform 1`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--alert-inner o-message--inform"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can render a message as an Inform 2`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--alert-inner o-message--inform"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can render a title 1`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--alert-inner o-message--neutral"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-highlight">
+            Reggatta de Blanc
+          </span>
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can render a title 2`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--alert-inner o-message--neutral"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-highlight">
+            Reggatta de Blanc
+          </span>
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can render additional information 1`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--alert-inner o-message--neutral"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-highlight">
+            Reggatta de Blanc
+          </span>
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+        <p class="o-message__content--additional">
+          Sting
+        </p>
+        <p class="o-message__content--additional">
+          Steward Copeland
+        </p>
+        <p class="o-message__content--additional">
+          Andy Summers
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can render additional information 2`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--alert-inner o-message--neutral"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-highlight">
+            Reggatta de Blanc
+          </span>
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+        <p class="o-message__content--additional">
+          Sting
+        </p>
+        <p class="o-message__content--additional">
+          Steward Copeland
+        </p>
+        <p class="o-message__content--additional">
+          Andy Summers
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can render some actions as primary 1`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--alert-inner o-message--neutral"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-highlight">
+            Reggatta de Blanc
+          </span>
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+        <div class="o-message__actions">
+          <a href="https://open.spotify.com/album/2EpuND32cO7CX0gXZl2NB6"
+             class="o-message__actions__primary"
+          >
+            Listen on Spotify
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can render some actions as primary 2`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--alert-inner o-message--neutral"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-highlight">
+            Reggatta de Blanc
+          </span>
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+        <div class="o-message__actions">
+          <a href="https://open.spotify.com/album/2EpuND32cO7CX0gXZl2NB6"
+             class="o-message__actions__primary"
+          >
+            Listen on Spotify
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can render some actions as secondary 1`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--alert-inner o-message--neutral"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-highlight">
+            Reggatta de Blanc
+          </span>
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+        <div class="o-message__actions">
+          <a href="https://open.spotify.com/album/2EpuND32cO7CX0gXZl2NB6"
+             class="o-message__actions__secondary"
+          >
+            Listen on Spotify
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message can render some actions as secondary 2`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--alert-inner o-message--neutral"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-highlight">
+            Reggatta de Blanc
+          </span>
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+        <div class="o-message__actions">
+          <a href="https://open.spotify.com/album/2EpuND32cO7CX0gXZl2NB6"
+             class="o-message__actions__secondary"
+          >
+            Listen on Spotify
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message render a message 1`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--alert-inner o-message--neutral"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Message render a message 2`] = `
+<div class="ncf__message o-forms o-forms--wide">
+  <div class="o-message o-message--alert-inner o-message--neutral"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-detail">
+            My message in a bottle
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/components/message.jsx
+++ b/components/message.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+function Message({ title, message, additional = [], actions = null, name, isNotice, isError, isSuccess, isInform, isHidden }) {
+
+	const additionalMessages = additional.map((text, index) => {
+		return <p className="o-message__content--additional" key={index}>{text}</p>
+	})
+
+	const oMessageClassNames = classNames({
+		'o-message': true,
+		'o-message--notice-inner': isNotice,
+		'o-message--alert-inner': !isNotice,
+		'o-message--error': isError,
+		'o-message--success': !isError && isSuccess,
+		'o-message--inform': !isError && isSuccess,
+		'o-message--inform': !isError && !isSuccess && isInform,
+		'o-message--neutral': !isError && !isSuccess && !isInform,
+	});
+
+	const ncfClassNames = classNames(
+		'ncf__message', 'o-forms', 'o-forms--wide', { ' n-ui-hide': isHidden }
+	)
+
+	let callToActionsList = null;
+	if (actions) {
+		const callToActionElements = actions.map(({ link, isSecondary, text }, index) => {
+			return <a href={link} key={index} className={isSecondary ? 'o-message__actions__secondary' : 'o-message__actions__primary'}>{text}</a>
+		});
+		callToActionsList = <div className="o-message__actions">{callToActionElements}</div>;
+	}
+
+	return (
+		<div className={ncfClassNames} data-message-name={name}>
+			<div className={oMessageClassNames} data-o-component="o-message">
+				<div className="o-message__container" >
+					<div className="o-message__content">
+						<p className="o-message__content-main">
+							{title ? <span className="o-message__content-highlight">{title}</span> : null}
+							<span className="o-message__content-detail">{message}</span>
+						</p>
+						{additionalMessages}
+						{callToActionsList}
+					</div>
+				</div >
+			</div >
+		</div >
+	);
+}
+
+Message.propTypes = {
+	title: PropTypes.string,
+	message: PropTypes.string.isRequired,
+	additional: PropTypes.arrayOf(PropTypes.string),
+	actions: PropTypes.arrayOf({
+		link: PropTypes.string.isRequired,
+		isSecondary: PropTypes.bool,
+		text: PropTypes.string
+	}),
+	name: PropTypes.string,
+	isNotice: PropTypes.bool,
+	isError: PropTypes.bool,
+	isSuccess: PropTypes.bool,
+	isInform: PropTypes.bool,
+	isHidden: PropTypes.bool,
+};
+
+export default Message;

--- a/components/message.spec.jsx
+++ b/components/message.spec.jsx
@@ -1,0 +1,115 @@
+import Message from './message';
+import { expectToRenderAs } from '../test-jest/helpers/expect-to-render-as';
+import { fetchPartialAsString } from '../test-jest/helpers/fetch-hbs-as-string';
+
+const context = {
+};
+
+expect.extend(expectToRenderAs);
+
+describe('Message', () => {
+	beforeAll(async () => {
+		context.template = await fetchPartialAsString('message.html');
+	});
+
+	it('render a message', () => {
+		const props = {
+			message: 'My message in a bottle',
+		};
+
+		expect(Message).toRenderAs(context, props);
+	});
+
+	it('can render a title', () => {
+		const props = {
+			title: 'Reggatta de Blanc',
+			message: 'My message in a bottle'
+		};
+
+		expect(Message).toRenderAs(context, props);
+	});
+
+	it('can render additional information', () => {
+		const props = {
+			title: 'Reggatta de Blanc',
+			message: 'My message in a bottle',
+			additional: ['Sting', 'Steward Copeland', 'Andy Summers']
+		};
+
+		expect(Message).toRenderAs(context, props);
+	});
+
+	it('can render some actions as primary', () => {
+		const props = {
+			title: 'Reggatta de Blanc',
+			message: 'My message in a bottle',
+			actions: [{
+				text: 'Listen on Spotify',
+				link: 'https://open.spotify.com/album/2EpuND32cO7CX0gXZl2NB6'
+			}]
+		};
+
+		expect(Message).toRenderAs(context, props);
+	});
+
+	it('can render some actions as secondary', () => {
+		const props = {
+			title: 'Reggatta de Blanc',
+			message: 'My message in a bottle',
+			actions: [{
+				text: 'Listen on Spotify',
+				link: 'https://open.spotify.com/album/2EpuND32cO7CX0gXZl2NB6',
+				isSecondary: true
+			}]
+		};
+
+		expect(Message).toRenderAs(context, props);
+	});
+
+	it('can render a message as a Notice', () => {
+		const props = {
+			message: 'My message in a bottle',
+			isNotice: true
+		};
+
+		expect(Message).toRenderAs(context, props);
+	});
+
+	it('can render a message as an Error', () => {
+		const props = {
+			message: 'My message in a bottle',
+			isError: true
+		};
+
+		expect(Message).toRenderAs(context, props);
+	});
+
+	it('can render a message as a Success', () => {
+		const props = {
+			message: 'My message in a bottle',
+			isSuccess: true
+		};
+
+		expect(Message).toRenderAs(context, props);
+	});
+
+	it('can render a message as an Inform', () => {
+		const props = {
+			message: 'My message in a bottle',
+			isInform: true
+		};
+
+		expect(Message).toRenderAs(context, props);
+	});
+
+	it('can add a data attribute name', () => {
+		const props = {
+			message: 'My message in a bottle',
+			name: 'The Police best album ever'
+		};
+
+		expect(Message).toRenderAs(context, props);
+	});
+
+
+});

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "bower-resolve-webpack-plugin": "^1.0.4",
     "chai": "^4.2.0",
     "cheerio": "^1.0.0-rc.2",
+    "classnames": "^2.2.6",
     "eslint-plugin-jest": "^22.17.0",
     "eslint-plugin-react": "^7.16.0",
     "fetch-mock": "^7.2.0",


### PR DESCRIPTION
This port the message component.
It looks me roughly 1.5 hours to port this component.
The average of the components seems to be simpler than this one. Few are more complex than this.
There are currently 47 partials to be ported minus 4 already ported, so 43.
Very likely we won't need all of them so let say 35.
35 x 1.5 hours is around 1 week and a half for 1 Engineer. I don't think it should take so long but let's discuss it together before we proceed further. 

In addition to the context, the following are the partials required just for the current /profile:

n-conversion-forms/partials/message [DONE]
n-conversion-forms/partials/email
n-conversion-forms/partials/firstname
n-conversion-forms/partials/lastname
n-conversion-forms/partials/phone [DONE]
n-conversion-forms/partials/fieldset
n-conversion-forms/partials/industry
n-conversion-forms/partials/responsibility
n-conversion-forms/partials/position
n-profile-ui/templates/consent <<< This can be a problem
n-conversion-forms/partials/submit