### PR TITLE
Revert "Fix logout debug button by directly clearing cookie"

### DIFF
--- a/partials/debug.html
+++ b/partials/debug.html
@@ -64,9 +64,13 @@
 	};
 
 	function logout () {
-		document.cookie = 'FTSession=; path=/;';
-		document.cookie = 'FTSession_s=; path=/;';
-		window.location.reload();
+		const options = {
+			mode: 'no-cors',
+			credentials: 'include'
+		};
+		fetch('https://www.ft.com/logout', options).then(function () {
+			window.location.reload();
+		});
 	}
 
 	function fillForm () {


### PR DESCRIPTION
Reverts Financial-Times/n-conversion-forms#259

It turns out that if we don't use the `.ft.com` domain for our local development environment cookies we get cookie issues when transitioning between ft.com and local.ft.com. `next-subscribe` now lays cookies with the `.ft.com` domain so we can revert this change and `/logout` will successfully remove them for both local.ft.com and ft.com.