### PR TITLE
compile jsx and add demo

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"],
+  "plugins": ["@babel/plugin-transform-runtime"]
+}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,9 @@ jobs:
           name: shared-helper / generate-build-state-artifacts
           command: .circleci/shared-helpers/helper-generate-build-state-artifacts
           when: always
+      - run:
+          name: Build dist files
+          command: make build
       - *cache_npm_cache
       - store_artifacts:
           path: build-state

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ package-lock.json
 .eslintrc.js
 .pa11yci.js
 .stylelintrc
+dist

--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,21 @@ node_modules/@financial-times/n-gage/index.mk:
 -include node_modules/@financial-times/n-gage/index.mk
 
 build:
+	node-sass main.scss dist/component.css --include-path bower_components
+	postcss dist/component.css -u autoprefixer -r
+	npm run transpile
+
+build-demo:
+	make build
 	webpack --config demos/webpack.config.js
-	node-sass demos/main.scss public/main.css --include-path bower_components
-	node-sass main.scss public/component.css --include-path bower_components
-	postcss public/component.css -u autoprefixer -r
+	node-sass demos/main.scss public/demo.css --include-path bower_components
+	webpack -d --config demos/webpack.jsx.config.js
 	@$(DONE)
 
-run: build
+run: build-demo
 	@DEMO_MODE=true nodemon --ext html,css --watch public --watch views demos/app.js
 
-a11y: build
+a11y: build-demo
 	@PA11Y=true node demos/app
 	@$(DONE)
 

--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,15 @@ node_modules/@financial-times/n-gage/index.mk:
 -include node_modules/@financial-times/n-gage/index.mk
 
 build:
-	node-sass main.scss dist/component.css --include-path bower_components
-	postcss dist/component.css -u autoprefixer -r
 	npm run transpile
 
 build-demo:
 	make build
 	webpack --config demos/webpack.config.js
-	node-sass demos/main.scss public/demo.css --include-path bower_components
-	webpack -d --config demos/webpack.jsx.config.js
+	webpack --config demos/webpack.jsx.config.js
+	node-sass demos/main.scss public/main.css --include-path bower_components
+	node-sass main.scss public/component.css --include-path bower_components
+	postcss public/component.css -u autoprefixer -r
 	@$(DONE)
 
 run: build-demo

--- a/components/index.jsx
+++ b/components/index.jsx
@@ -1,0 +1,19 @@
+import BillingPostcode from './billing-postcode';
+import DeliveryPostcode from './delivery-postcode';
+import Email from './email';
+import FirstName from './first-name';
+import LastName from './last-name';
+import Message from './message';
+import Password from './password';
+import Phone from './phone';
+
+export {
+	BillingPostcode,
+	DeliveryPostcode,
+	Email,
+	FirstName,
+	LastName,
+	Message,
+	Password,
+	Phone,
+};

--- a/components/phone.jsx
+++ b/components/phone.jsx
@@ -67,7 +67,7 @@ Phone.propTypes = {
 	pattern: propTypes.string,
 	fieldId: propTypes.string,
 	fieldName: propTypes.string,
-	inputId: propTypes.string.isRequired,
-	inputName: propTypes.string.isRequired,
-	dataTrackable: propTypes.string.isRequired,
+	inputId: propTypes.string,
+	inputName: propTypes.string,
+	dataTrackable: propTypes.string,
 };

--- a/demos/app-jsx.js
+++ b/demos/app-jsx.js
@@ -1,0 +1,20 @@
+/* eslint no-console:0 */
+const express = require('express');
+const jsxTemplate = require('./views/jsx');
+
+const PORT = process.env.PORT || 5005;
+const app = express();
+
+app.use('/public', express.static('public'));
+app.use('/dist', express.static('dist'));
+
+app.get('/', (req, res) => {
+	res.send(jsxTemplate({
+		title: 'n-conversion-forms-jsx-demo'
+	}));
+});
+
+app.listen(PORT, () => {
+	/* eslint-disable-next-line no-console */
+	console.log(`demo server running on port ${PORT}`);
+});

--- a/demos/app.js
+++ b/demos/app.js
@@ -140,7 +140,7 @@ function compilePartial (partial) {
 	<head>
 		<title>${partial}</title>
 		<link rel="stylesheet" href="/public/demo.css">
-		<link rel="stylesheet" href="/dist/component.css">
+		<link rel="stylesheet" href="/public/main.css">
 	</head>
 	<body style="background-color:#fff1e5;" id="demo-page-${partial}">
 

--- a/demos/app.js
+++ b/demos/app.js
@@ -5,6 +5,7 @@ const chalk = require('chalk');
 const express = require('@financial-times/n-internal-tool');
 const Handlebars = require('@financial-times/n-handlebars').handlebars;
 const data = require('./data.json');
+const jsxTemplate = require('./views/jsx');
 
 const PORT = process.env.PORT || 5005;
 const PARTIALS_DIR = resolve(__dirname, '../partials');
@@ -39,6 +40,15 @@ app.get('/partial/:name', (req, res) => {
 	const partial = `${req.params.name}`;
 	const template = compilePartial(partial);
 	res.send(template);
+});
+
+// add demo for jsx components
+app.use('/public', express.static('public'));
+app.use('/dist', express.static('dist'));
+app.get('/jsx', (req, res) => {
+	res.send(jsxTemplate({
+		title: 'n-conversion-forms-jsx-demo'
+	}));
 });
 
 app.listen(PORT, () => {
@@ -129,9 +139,8 @@ function compilePartial (partial) {
 <html lang="en">
 	<head>
 		<title>${partial}</title>
-		<link rel="stylesheet" href="/public/main.css">
-		<link rel="stylesheet" href="/public/component.css">
-		<link rel="stylesheet" href="/public/main.css">
+		<link rel="stylesheet" href="/public/demo.css">
+		<link rel="stylesheet" href="/dist/component.css">
 	</head>
 	<body style="background-color:#fff1e5;" id="demo-page-${partial}">
 

--- a/demos/init-jsx.js
+++ b/demos/init-jsx.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import * as ncf from '../dist/index';
+import ReactDOM from 'react-dom';
+import fixture from './data.json';
+
+function initDemo () {
+	const container = document.querySelector('#demoContent');
+
+	const element =
+		<React.Fragment>
+			<ncf.BillingPostcode postcodeReference={'billing postcode'}/>
+			<ncf.DeliveryPostcode postcodeReference={'delivery postcode'}/>
+			<ncf.Email />
+			<ncf.FirstName />
+			<ncf.LastName />
+			<ncf.Message {...fixture['message'].params}/>
+			<ncf.Password />
+			<ncf.Phone />
+		</React.Fragment>
+	;
+	ReactDOM.render(element, container);
+}
+
+initDemo();

--- a/demos/views/jsx.js
+++ b/demos/views/jsx.js
@@ -4,8 +4,8 @@ function main ({title}) {
 <html>
 	<head>
 		<title>${title}</title>
+		<link rel="stylesheet" href="/public/demo.css">
 		<link rel="stylesheet" href="/public/main.css">
-		<link rel="stylesheet" href="/dist/component.css">
 	</head>
 
 	<body style="background-color:#fff1e5;" id="demo-page">

--- a/demos/views/jsx.js
+++ b/demos/views/jsx.js
@@ -1,0 +1,20 @@
+function main ({title}) {
+	return `
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>${title}</title>
+		<link rel="stylesheet" href="/public/main.css">
+		<link rel="stylesheet" href="/dist/component.css">
+	</head>
+
+	<body style="background-color:#fff1e5;" id="demo-page">
+		<div class="ncf" id="demoContent" />
+	</body>
+
+	<script type="text/javascript" src="/public/demo-jsx.js"></script>
+</html>
+`;
+}
+
+module.exports = main;

--- a/demos/webpack.jsx.config.js
+++ b/demos/webpack.jsx.config.js
@@ -1,0 +1,25 @@
+const path = require('path');
+
+module.exports = {
+	entry: {
+		demo: './demos/init-jsx.js'
+	},
+	output: {
+		path: path.resolve(__dirname, '../public'),
+		filename: '[name]-jsx.js'
+	},
+	module: {
+		rules: [
+			{
+				test: /\.(js|jsx)$/,
+				exclude: /node_modules/,
+				use: {
+					loader: 'babel-loader'
+				}
+			}
+		]
+	},
+	resolve: {
+		extensions: ['.js', '.jsx', '.es6']
+	},
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@financial-times/n-conversion-forms",
   "version": "0.0.0",
   "description": "Containing partials and styles for forms included on Conversion apps (next-signup, next-corp-signup, next-b2b-prospect etc).",
-  "main": "dist/main.js",
+  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "precommit": "node_modules/.bin/secret-squirrel",
@@ -40,7 +40,6 @@
     "@financial-times/n-internal-tool": "^2.3.1",
     "@sucrase/jest-plugin": "^2.0.0",
     "autoprefixer": "^8.6.3",
-    "babel-cli": "^6.26.0",
     "babel-loader": "^8.0.0-beta.6",
     "bower": "^1.8.8",
     "bower-resolve-webpack-plugin": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "@financial-times/n-conversion-forms",
   "version": "0.0.0",
   "description": "Containing partials and styles for forms included on Conversion apps (next-signup, next-corp-signup, next-b2b-prospect etc).",
-  "main": "index.js",
+  "main": "dist/main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "precommit": "node_modules/.bin/secret-squirrel",
     "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
     "prepush": "make verify -j3",
-    "prepare": "npx snyk protect || npx snyk protect -d || true"
+    "prepare": "npx snyk protect || npx snyk protect -d || true",
+    "transpile": "babel components/*.jsx -d dist --copy-files"
   },
   "repository": {
     "type": "git",
@@ -21,17 +22,26 @@
   },
   "homepage": "https://github.com/Financial-Times/n-conversion-forms#readme",
   "dependencies": {
+    "@babel/runtime": "^7.6.3",
     "diffable-html": "^4.0.0",
     "fetchres": "^1.7.2",
     "lodash.get": "^4.4.2",
     "n-common-static-data": "financial-times/n-common-static-data#v1.6.1"
   },
   "devDependencies": {
+    "@babel/cli": "^7.6.4",
+    "@babel/core": "^7.6.4",
+    "@babel/node": "^7.6.3",
+    "@babel/plugin-transform-runtime": "^7.6.2",
+    "@babel/preset-env": "^7.6.3",
+    "@babel/preset-react": "^7.6.3",
     "@financial-times/n-gage": "^3.6.0",
     "@financial-times/n-handlebars": "^1.21.0",
     "@financial-times/n-internal-tool": "^2.3.1",
     "@sucrase/jest-plugin": "^2.0.0",
     "autoprefixer": "^8.6.3",
+    "babel-cli": "^6.26.0",
+    "babel-loader": "^8.0.0-beta.6",
     "bower": "^1.8.8",
     "bower-resolve-webpack-plugin": "^1.0.4",
     "chai": "^4.2.0",

--- a/partials/debug.html
+++ b/partials/debug.html
@@ -135,5 +135,8 @@
 	.ncf__debug-button--production {
 		background-color: #990000;
 	}
+	.ncf__link {
+		background-color: #fdfdff;
+	}
 </style>
 {{/ifSome}}


### PR DESCRIPTION
### Description
- jsx components compiled/transpiled
- some basic demo added for jsx components 

### Ticket
- https://trello.com/c/gqAxe7Em/79-add-some-sort-of-demo-to-n-conversion-forms-for-the-jsx-components
- https://trello.com/c/XO3wbGq3/78-jsx-tooling-build-for-n-conversion-forms-integrate-a-component-with-next-profile

### notes
make build => is run by circle ci to generate the transpiled code in /dist
make build-demo => builds demo, replaces former make build

jsx demos added to existing `make run` under route /jsx

I've also added a demo with minimal dependencies:
`node demos/app-jsx.js`
go to http://host:5005