### PR TITLE
Remove o-techdocs for o-layout

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,8 @@
     "main.scss"
   ],
   "devDependencies": {
-    "o-techdocs": "^7.0.9"
+    "o-layout": "^3.2.0",
+    "o-header-services": "^3.3.4"
   },
   "dependencies": {
     "o-forms": "^6.0.0",

--- a/demos/main.scss
+++ b/demos/main.scss
@@ -1,4 +1,9 @@
-@import 'o-techdocs/main';
+$o-brand: 'internal';
+@import 'o-layout/main';
+@import 'o-header-services/main';
+
+@include oLayout();
+@include oHeaderServices();
 
 body {
 	margin: 0;
@@ -18,15 +23,4 @@ body {
 		position: relative;
 		z-index: 1001;
 	}
-}
-
-.o-techdocs-card {
-	resize: both;
-	overflow: auto;
-	max-width: none;
-	height: 300px;
-}
-
-.o-techdocs-card__content {
-	height: 100%;
 }

--- a/demos/views/index.html
+++ b/demos/views/index.html
@@ -1,40 +1,32 @@
-<header class="o-header-services" data-o-component="o-header">
-	<div class="o-header-services__top o-header-services__container">
-		<div class="o-header-services__ftlogo"></div>
-		<div class="o-header-services__title">
-			<div class="o-header-services__product-name">
-				<a href="/">n-conversion-forms</a>
-			</div>
-		</div>
-	</div>
-</header>
+<div class="o-layout o-layout--docs" data-o-component="o-layout">
+	<div class="o-layout__header">
+		<header class="o-header-services" data-o-component="o-header-services">
+			<div class="o-header-services__top">
+					<div class="o-header-services__logo"></div>
 
-<div class="o-techdocs-container">
-	<div class="o-techdocs-layout">
-		<div class="o-techdocs-sidebar">
-			<ul class="o-techdocs-nav">
-				{{#each partials}}
-				<li>
-					<a href="#{{name}}">{{name}}</a>
-				</li>
-				{{/each}}
-			</ul>
-		</div>
-
-		<div class="o-techdocs-main">
-			<div class="o-techdocs-content">
-				<h1>Demos</h1>
-				{{#each partials }}
-				<div class="demo__partial">
-					<h2 id={{name}}><a href="/partial/{{name}}" target="_blank">{{name}}</a></h2>
-					<div class="o-techdocs-card">
-						<div class="o-techdocs-card__content">
-							<iframe class="demo__iframe" src="/partial/{{name}}"></iframe>
-						</div>
+					<div class="o-header-services__title">
+						<span class="o-header-services__product-name"><a href="/">n-conversion-forms</a></span>
 					</div>
-				</div>
-				{{/each}}
 			</div>
-		</div>
+		</header>
+	</div>
+
+	<div class="o-layout__sidebar o-layout-typography">
+		<ul>
+			{{#each partials}}
+			<li>
+				<a href="#{{name}}">{{name}}</a>
+			</li>
+			{{/each}}
+		</ul>
+	</div>
+
+	<div class="o-layout__main o-layout-typography">
+		<h1>Demos</h1>
+		{{#each partials }}
+		<h2 id={{name}}><a href="/partial/{{name}}" target="_blank">{{name}}</a></h2>
+		<iframe class="demo__iframe" src="/partial/{{name}}"></iframe>
+		<br /><br />
+		{{/each}}
 	</div>
 </div>


### PR DESCRIPTION
### Description

o-techdocs is being decommissioned, use o-layout instead.

| Before | After |
| --- | --- |
| <img width="900" alt="Screenshot 2019-10-24 at 15 53 29" src="https://user-images.githubusercontent.com/1721150/67497829-7457dd80-f676-11e9-8bb7-e2949b091804.png"> | <img width="936" alt="Screenshot 2019-10-24 at 15 52 07" src="https://user-images.githubusercontent.com/1721150/67497752-54281e80-f676-11e9-95e6-4f32a5e68c6e.png"> |

