### PR TITLE
Add full stops at the end of trial payment term copy

### DIFF
--- a/demos/data.json
+++ b/demos/data.json
@@ -225,22 +225,23 @@
     "params": {
       "options": [
         {
-          "name": "trial",
-          "value": "Test",
-          "description": "The quick brown fox jumped over the lazy hare."
-        }, {
           "name": "annual",
           "value": "Test 1",
           "description": "The <strong>quick</strong> brown fox<br />jumped over the lazy <a href=\"#\">hare</a>.",
-          "selected": true
+          "trialPrice": "£1.00",
+          "selected": true,
+          "isTrial": true
         }, {
           "name": "quarterly",
           "value": "Test 2",
           "description": "The <strong>quick</strong> brown fox<br />jumped over the lazy <a href=\"#\">hare</a>.",
-          "discount": "25%"
+          "discount": "25%",
+          "trialPrice": "£1.00",
+          "isTrial": true
         }, {
           "name": "monthly",
           "value": "Test 3",
+          "price": "$100.00",
           "description": "The <strong>quick</strong> brown fox<br />jumped over the lazy <a href=\"#\">hare</a>."
         }
       ]

--- a/partials/payment-term.html
+++ b/partials/payment-term.html
@@ -12,7 +12,7 @@
 			<div class="ncf__payment-term__description">
 				{{#if isTrial}}
 				{{#if trialDuration}}{{trialDuration}}{{else}}4 weeks{{/if}} for <span class="ncf__payment-term__trial-price">{{trialPrice}}</span><br />
-				Unless you cancel during your trial you will be billed <span class="ncf__payment-term__price">{{price}}</span> per year after the trial period
+				Unless you cancel during your trial you will be billed <span class="ncf__payment-term__price">{{price}}</span> per year after the trial period.
 				{{else}}
 				Single <span class="ncf__payment-term__price ncf__strong">{{price}}</span> payment
 				{{#if weeklyPrice}}<br /><span class="ncf__payment-term__weekly-price">That's just {{weeklyPrice}} per week</span>{{/if}}
@@ -27,7 +27,7 @@
 			<div class="ncf__payment-term__description">
 				{{#if isTrial}}
 				{{#if trialDuration}}{{trialDuration}}{{else}}4 weeks{{/if}} for <span class="ncf__payment-term__trial-price">{{trialPrice}}</span><br />
-				Unless you cancel during your trial you will be billed <span class="ncf__payment-term__price">{{price}}</span> per quarter after the trial period
+				Unless you cancel during your trial you will be billed <span class="ncf__payment-term__price">{{price}}</span> per quarter after the trial period.
 				{{else}}
 				<span class="ncf__payment-term__price">{{price}}</span> per quarter
 				{{/if}}
@@ -39,7 +39,7 @@
 			<div class="ncf__payment-term__description">
 				{{#if isTrial}}
 				{{#if trialDuration}}{{trialDuration}}{{else}}4 weeks{{/if}} for <span class="ncf__payment-term__trial-price">{{trialPrice}}</span><br />
-				Unless you cancel during your trial you will be billed <span class="ncf__payment-term__price">{{price}}</span> per month after the trial period
+				Unless you cancel during your trial you will be billed <span class="ncf__payment-term__price">{{price}}</span> per month after the trial period.
 				{{else}}
 				<span class="ncf__payment-term__price">{{price}}</span> per month
 				{{/if}}


### PR DESCRIPTION
### Description

Also updated the demo data to display the terms more correctly.

[Ticket](https://trello.com/c/q1fBrWTP/1626-add-a-full-stop-after-payment-options-copy)

