### PR TITLE
Cold One

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -262,7 +262,7 @@
 	}
 
 	&__icon-download {
-		@include oIconsGetIcon('download', oColorsGetPaletteColor('cold-1'), 32);
+		@include oIconsGetIcon('download', oColorsGetPaletteColor('black-70'), 32);
 		border: 0;
 		vertical-align: middle;
 	}


### PR DESCRIPTION
### Description
Who doesn't like a nice cold one? Origami doesn't apparently, and it was giving an error when building the Sass because `cold-1` does not exist as a colour. This migrates it to the new colour name.

![stone-cold](https://user-images.githubusercontent.com/6975428/67882412-1a558d00-fb3a-11e9-9464-0d191e92b9a2.gif)
