### PR TITLE
Add option to hide CTA on B2C confirmation page

### DIFF
--- a/partials/confirmation.html
+++ b/partials/confirmation.html
@@ -43,11 +43,13 @@
 		We will automatically renew your subscription using the payment method provided unless you cancel before your renewal date.
 		See our <a class="ncf__link ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="_top" rel="noopener">Terms &amp; Conditions</a> for details on how to cancel.
 	</p>
+	{{#unless hideCta}}
 	<p class="ncf__center">
-	{{#if isPrintOnly}}
-		<a href="/todaysnewspaper " class="ncf__button ncf__button--submit">Explore our E-Paper</a>
-	{{else}}
-		<a href="/" class="ncf__button ncf__button--submit">Start exploring</a>
-	{{/if}}
+		{{#if isPrintOnly}}
+			<a href="/todaysnewspaper " class="ncf__button ncf__button--submit">Explore our E-Paper</a>
+		{{else}}
+			<a href="/" class="ncf__button ncf__button--submit">Start exploring</a>
+		{{/if}}
 	</p>
+	{{/unless}}
 </div>

--- a/test/partials/confirmation.spec.js
+++ b/test/partials/confirmation.spec.js
@@ -97,6 +97,26 @@ describe('confirmation template', () => {
 		expect($.text()).to.contain(buttonText);
 	});
 
+	it('should not display a CTA if hideCta is set', () => {
+		const isPrintOnly = false;
+		const hideCta = true;
+		const $ = context.template({
+			isPrintOnly,
+			hideCta
+		});
+		expect($.text()).to.not.contain('ncf__button--submit');
+	});
+
+	it('should not display a CTA if isPrintOnly and hideCta is set', () => {
+		const isPrintOnly = true;
+		const hideCta = true;
+		const $ = context.template({
+			isPrintOnly,
+			hideCta
+		});
+		expect($.text()).to.not.contain('ncf__button--submit');
+	});
+
 	it('should add a data-signup-is-trial="true" attribute for floodlight pixel tracking', () => {
 		const $ = context.template({
 			isTrial: true


### PR DESCRIPTION
### Description

Weekend only subscriptions don't have access to the site or the epaper so we deadend them.

[Ticket](https://trello.com/c/QqbHDTch/1636-remove-cta-on-weekend-only-print-from-confirmation-page)
