### PR TITLE
Update the weekly price when updating payment terms

### DIFF
--- a/partials/payment-term.html
+++ b/partials/payment-term.html
@@ -15,7 +15,7 @@
 				Unless you cancel during your trial you will be billed <span class="ncf__payment-term__price">{{price}}</span> per year after the trial period.
 				{{else}}
 				Single <span class="ncf__payment-term__price ncf__strong">{{price}}</span> payment
-				{{#if weeklyPrice}}<br /><span class="ncf__payment-term__weekly-price">That's just {{weeklyPrice}} per week</span>{{/if}}
+				{{#if weeklyPrice}}<br />That's just <span class="ncf__payment-term__weekly-price">{{weeklyPrice}}</span> per week{{/if}}
 				{{!-- Remove this discount text temporarily in favour of weekly price --}}
 				<!-- {{#unless discount}}<br />Save up to 25% when you pay annually{{/unless}} -->
 				{{/if}}

--- a/test/utils/payment-term.spec.js
+++ b/test/utils/payment-term.spec.js
@@ -112,6 +112,16 @@ describe('PaymentTerm', () => {
 				}]);
 				expect(trialPriceStub.innerHTML).to.equal('£1.01');
 			});
+
+			it('should replace the weekly price with the correct updated weekly price', () => {
+				const weeklyPriceStub = {};
+				elementStub.querySelector.withArgs('.ncf__payment-term__weekly-price').returns(weeklyPriceStub);
+				paymentTerm.updateOptions([{
+					value: 'test',
+					weeklyPrice: '£1.01'
+				}]);
+				expect(weeklyPriceStub.innerHTML).to.equal('£1.01');
+			});
 		});
 	});
 });

--- a/utils/payment-term.js
+++ b/utils/payment-term.js
@@ -19,6 +19,7 @@ const ITEM_CLASS = '.ncf__payment-term__item';
 const VALUE_CLASS = '.ncf__payment-term__item input';
 const PRICE_CLASS = '.ncf__payment-term__price';
 const TRIAL_PRICE_CLASS = '.ncf__payment-term__trial-price';
+const WEEKLY_PRICE_CLASS = '.ncf__payment-term__weekly-price';
 
 class PaymentTerm {
 	/**
@@ -71,6 +72,7 @@ class PaymentTerm {
 			const value = term.querySelector(VALUE_CLASS).value;
 			const price = term.querySelector(PRICE_CLASS);
 			const trialPrice = term.querySelector(TRIAL_PRICE_CLASS);
+			const weeklyPrice = term.querySelector(WEEKLY_PRICE_CLASS);
 			const update = options.find(option => option.value === value);
 
 			if (!update) {
@@ -83,6 +85,9 @@ class PaymentTerm {
 			}
 			if (trialPrice) {
 				trialPrice.innerHTML = update.trialPrice;
+			}
+			if (weeklyPrice) {
+				weeklyPrice.innerHTML = update.weeklyPrice;
 			}
 		});
 	}


### PR DESCRIPTION
### Description

The price and trial price dynamically updated when the user changes their currency, make sure the weekly price is also updated.

[Ticket](https://trello.com/c/5xJLpZ6E/1633-currency-for-weekly-prices-doesnt-adapt-to-billing-country-on-new-buy-flow-forms)

### Screenshots

| Before | After |
| ------ | ----- |
| <img width="532" alt="Screenshot 2019-11-01 at 09 36 50" src="https://user-images.githubusercontent.com/1721150/68016013-77ad2380-fc8b-11e9-85a9-d752f256302d.png"> | <img width="546" alt="Screenshot 2019-11-01 at 09 36 30" src="https://user-images.githubusercontent.com/1721150/68016017-7b40aa80-fc8b-11e9-825a-4f0e14e24c4c.png"> |
