### PR TITLE
Correct apostrophe in Industry partial/component error text

### DIFF
--- a/components/__snapshots__/industry.spec.js.snap
+++ b/components/__snapshots__/industry.spec.js.snap
@@ -115,7 +115,7 @@ exports[`Industry can render a disable select 1`] = `
     </option>
   </select>
   <div class="o-forms__errortext">
-    Please select your company‘s industry
+    Please select your company’s industry
   </div>
 </div>
 `;
@@ -235,7 +235,7 @@ exports[`Industry can render a disable select 2`] = `
     </option>
   </select>
   <div class="o-forms__errortext">
-    Please select your company‘s industry
+    Please select your company’s industry
   </div>
 </div>
 `;
@@ -354,7 +354,7 @@ exports[`Industry can render an error message 1`] = `
     </option>
   </select>
   <div class="o-forms__errortext">
-    Please select your company‘s industry
+    Please select your company’s industry
   </div>
 </div>
 `;
@@ -473,7 +473,7 @@ exports[`Industry can render an error message 2`] = `
     </option>
   </select>
   <div class="o-forms__errortext">
-    Please select your company‘s industry
+    Please select your company’s industry
   </div>
 </div>
 `;
@@ -594,7 +594,7 @@ exports[`Industry can render an initial selected value 1`] = `
     </option>
   </select>
   <div class="o-forms__errortext">
-    Please select your company‘s industry
+    Please select your company’s industry
   </div>
 </div>
 `;
@@ -715,7 +715,7 @@ exports[`Industry can render an initial selected value 2`] = `
     </option>
   </select>
   <div class="o-forms__errortext">
-    Please select your company‘s industry
+    Please select your company’s industry
   </div>
 </div>
 `;
@@ -834,7 +834,7 @@ exports[`Industry render a select with a label 1`] = `
     </option>
   </select>
   <div class="o-forms__errortext">
-    Please select your company‘s industry
+    Please select your company’s industry
   </div>
 </div>
 `;
@@ -953,7 +953,7 @@ exports[`Industry render a select with a label 2`] = `
     </option>
   </select>
   <div class="o-forms__errortext">
-    Please select your company‘s industry
+    Please select your company’s industry
   </div>
 </div>
 `;

--- a/components/industry.jsx
+++ b/components/industry.jsx
@@ -37,7 +37,7 @@ export default function Industry ({
 				return <option key={code} value={code}>{description}</option>;
 			})}
 		</select >
-		<div className="o-forms__errortext" >Please select your company‘s industry</div >
+		<div className="o-forms__errortext" >Please select your company’s industry</div >
 	</div >);
 
 }

--- a/partials/industry.html
+++ b/partials/industry.html
@@ -16,6 +16,6 @@
 
 	{{/ncf-common-data}}
 
-	<div class="o-forms__errortext">Please select your company‘s industry</div>
+	<div class="o-forms__errortext">Please select your company’s industry</div>
 
 </div>


### PR DESCRIPTION
As per: https://github.com/Financial-Times/n-conversion-forms/pull/295#discussion_r342049064.