### PR TITLE
Add App Banner JSX component

### DIFF
--- a/components/__snapshots__/app-banner.spec.js.snap
+++ b/components/__snapshots__/app-banner.spec.js.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AppBanner renders 1`] = `
+<div id="appBanner"
+     class="ncf ncf__app-banner"
+>
+  <div class="ncf__app-banner-inner">
+    <div class="ncf__app-banner-image">
+      <img alt="FT app"
+           src="https://www.ft.com/__origami/service/image/v2/images/raw/https://s3-eu-west-1.amazonaws.com/envoy-b2b-trial/phone.png?source=ip-envoy"
+      >
+    </div>
+    <div class="ncf__app-banner-content">
+      <div class="ncf__app-banner-header">
+        Get our free App
+      </div>
+      Download the
+      <span class="ncf__app-banner-strong">
+        FT app
+      </span>
+      to access articles on the move.
+    </div>
+    <div class="ncf__app-banner-actions">
+      <div class="ncf__app-banner-action ncf__app-banner-action--ios">
+        <a href="https://itunes.apple.com/app/apple-store/id1200842933?pt=246269&amp;ct=onsite-app-promotion&amp;mt=8"
+           target="_blank"
+           role="link"
+        >
+          <img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg"
+               alt="Download from the iOS App store"
+               height="35"
+          >
+        </a>
+      </div>
+      <div class="ncf__app-banner-action ncf__app-banner-action--android">
+        <a href="https://play.google.com/store/apps/details?id=com.ft.news&amp;referrer=utm_source%3Donsite-app-promotion%26utm_campaign%3DOnsite%2520Messaging"
+           target="_blank"
+           role="link"
+        >
+          <img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy"
+               height="35"
+               alt="Download on Google Play"
+          >
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AppBanner renders 2`] = `
+<div id="appBanner"
+     class="ncf ncf__app-banner"
+>
+  <div class="ncf__app-banner-inner">
+    <div class="ncf__app-banner-image">
+      <img alt="FT app"
+           src="https://www.ft.com/__origami/service/image/v2/images/raw/https://s3-eu-west-1.amazonaws.com/envoy-b2b-trial/phone.png?source=ip-envoy"
+      >
+    </div>
+    <div class="ncf__app-banner-content">
+      <div class="ncf__app-banner-header">
+        Get our free App
+      </div>
+      Download the
+      <span class="ncf__app-banner-strong">
+        FT app
+      </span>
+      to access articles on the move.
+    </div>
+    <div class="ncf__app-banner-actions">
+      <div class="ncf__app-banner-action ncf__app-banner-action--ios">
+        <a href="https://itunes.apple.com/app/apple-store/id1200842933?pt=246269&amp;ct=onsite-app-promotion&amp;mt=8"
+           target="_blank"
+           role="link"
+        >
+          <img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg"
+               alt="Download from the iOS App store"
+               height="35"
+          >
+        </a>
+      </div>
+      <div class="ncf__app-banner-action ncf__app-banner-action--android">
+        <a href="https://play.google.com/store/apps/details?id=com.ft.news&amp;referrer=utm_source%3Donsite-app-promotion%26utm_campaign%3DOnsite%2520Messaging"
+           target="_blank"
+           role="link"
+        >
+          <img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy"
+               height="35"
+               alt="Download on Google Play"
+          >
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/components/app-banner.jsx
+++ b/components/app-banner.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+function AppBanner () {
+	return (
+		<div id="appBanner" className="ncf ncf__app-banner">
+			<div className="ncf__app-banner-inner">
+				<div className="ncf__app-banner-image">
+					<img
+						alt="FT app"
+						src="https://www.ft.com/__origami/service/image/v2/images/raw/https://s3-eu-west-1.amazonaws.com/envoy-b2b-trial/phone.png?source=ip-envoy"
+					/>
+				</div>
+				<div className="ncf__app-banner-content">
+				<div className="ncf__app-banner-header">Get our free App</div>
+					Download the <span className="ncf__app-banner-strong">FT app</span> to access articles on the move.
+				</div>
+				<div className="ncf__app-banner-actions">
+					<div className="ncf__app-banner-action ncf__app-banner-action--ios">
+						<a
+							href="https://itunes.apple.com/app/apple-store/id1200842933?pt=246269&ct=onsite-app-promotion&mt=8"
+							target="_blank"
+							role="link"
+						>
+							<img
+								src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg"
+								alt="Download from the iOS App store"
+								height="35"
+							/>
+						</a>
+					</div>
+					<div className="ncf__app-banner-action ncf__app-banner-action--android">
+						<a
+							href="https://play.google.com/store/apps/details?id=com.ft.news&referrer=utm_source%3Donsite-app-promotion%26utm_campaign%3DOnsite%2520Messaging"
+							target="_blank"
+							role="link"
+						>
+							<img
+								src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy"
+								height="35"
+								alt="Download on Google Play"
+							/>
+						</a>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export default AppBanner;

--- a/components/app-banner.spec.js
+++ b/components/app-banner.spec.js
@@ -1,0 +1,19 @@
+import AppBanner from './app-banner';
+import { expectToRenderAs } from '../test-jest/helpers/expect-to-render-as';
+import { fetchPartialAsString } from '../test-jest/helpers/fetch-hbs-as-string';
+
+const context = {};
+
+expect.extend(expectToRenderAs);
+
+describe('AppBanner', () => {
+	beforeAll(async () => {
+		context.template = await fetchPartialAsString('app-banner.html');
+	});
+
+	it('renders', () => {
+		const props = {};
+
+		expect(AppBanner).toRenderAs(context, props);
+	});
+});

--- a/components/index.jsx
+++ b/components/index.jsx
@@ -1,3 +1,4 @@
+import AppBanner from './app-banner';
 import BillingPostcode from './billing-postcode';
 import DeliveryPostcode from './delivery-postcode';
 import Email from './email';
@@ -14,6 +15,7 @@ import Position from './position';
 import Submit from './submit';
 
 export {
+	AppBanner,
 	BillingPostcode,
 	DeliveryPostcode,
 	Email,

--- a/demos/init-jsx.js
+++ b/demos/init-jsx.js
@@ -8,6 +8,7 @@ function initDemo () {
 
 	const element =
 		<React.Fragment>
+			<ncf.AppBanner />
 			<ncf.BillingPostcode postcodeReference={'billing postcode'}/>
 			<ncf.DeliveryPostcode postcodeReference={'delivery postcode'}/>
 			<ncf.Email />

--- a/partials/app-banner.html
+++ b/partials/app-banner.html
@@ -9,10 +9,10 @@
 		</div>
 		<div class="ncf__app-banner-actions">
 			<div class="ncf__app-banner-action ncf__app-banner-action--ios">
-				<a href="https://itunes.apple.com/app/apple-store/id1200842933?pt=246269&ct=onsite-app-promotion&mt=8" target="_blank" role="link"><img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg" alt="Download from the iOS App store" height="35"></a>
+				<a href="https://itunes.apple.com/app/apple-store/id1200842933?pt=246269&amp;ct=onsite-app-promotion&amp;mt=8" target="_blank" role="link"><img src="https://www.ft.com/__assets/creatives/tour/apps/ios-download.svg" alt="Download from the iOS App store" height="35"></a>
 			</div>
 			<div class="ncf__app-banner-action ncf__app-banner-action--android">
-				<a href="https://play.google.com/store/apps/details?id=com.ft.news&referrer=utm_source%3Donsite-app-promotion%26utm_campaign%3DOnsite%2520Messaging" target="_blank" role="link"><img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy" height="35" alt="Download on Google Play"></a>
+				<a href="https://play.google.com/store/apps/details?id=com.ft.news&amp;referrer=utm_source%3Donsite-app-promotion%26utm_campaign%3DOnsite%2520Messaging" target="_blank" role="link"><img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%253A%252F%252Fwww.ft.com%252F__assets%252Fcreatives%252Ftour%252Fapps%252Fgoogle-play-badge-3x.png?source=ip-envoy" height="35" alt="Download on Google Play"></a>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
### Description
This PR creates an **App Banner** JSX component that matches the behaviour and usage of the existing Handlebars (HBS) partial, with tests to ensure they match.

React will escape ampersands in `href` values, and so the same needed to be applied to the HBS partial, which resulted in no change to the output HTML - e.g. `https://itunes.apple.com/app/apple-store/id1200842933?pt=246269&amp;ct=onsite-app-promotion&amp;mt=8` gets output as:

![Screenshot 2019-11-04 at 14 57 28](https://user-images.githubusercontent.com/10484515/68130942-2499d180-ff14-11e9-90b9-92bd94ed5311.png)


[*I will add Trello ticket once I am added to the board*]

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [x] **Demos** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer 
- [ ] **Product Review** ran past the product owner

#### References:
- [GitHub - facebook/react Issues: Escaped ampersands in query params within src/href attributes](https://github.com/facebook/react/issues/6873).