### PR TITLE
Add Licence Header JSX component

### DIFF
--- a/components/__snapshots__/licence-header.spec.js.snap
+++ b/components/__snapshots__/licence-header.spec.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LicenceHeader renders if is trial 1`] = `
+<h1 class="ncf__header">
+  Start your free trial
+</h1>
+`;
+
+exports[`LicenceHeader renders if is trial 2`] = `
+<h1 class="ncf__header">
+  Start your free trial
+</h1>
+`;
+
+exports[`LicenceHeader renders with custom display name 1`] = `
+<h1 class="ncf__header">
+  Display name text | Join your FT.com subscription
+</h1>
+`;
+
+exports[`LicenceHeader renders with custom display name 2`] = `
+<h1 class="ncf__header">
+  Display name text | Join your FT.com subscription
+</h1>
+`;
+
+exports[`LicenceHeader renders with custom welcome text (that requires escaping, e.g. ampersand) 1`] = `
+<h1 class="ncf__header">
+  Join your FT.com subscription
+</h1>
+<p>
+  Welcome text & some more welcome text
+</p>
+`;
+
+exports[`LicenceHeader renders with custom welcome text (that requires escaping, e.g. ampersand) 2`] = `
+<h1 class="ncf__header">
+  Join your FT.com subscription
+</h1>
+<p>
+  Welcome text & some more welcome text
+</p>
+`;
+
+exports[`LicenceHeader renders with default props 1`] = `
+<h1 class="ncf__header">
+  Join your FT.com subscription
+</h1>
+`;
+
+exports[`LicenceHeader renders with default props 2`] = `
+<h1 class="ncf__header">
+  Join your FT.com subscription
+</h1>
+`;

--- a/components/index.jsx
+++ b/components/index.jsx
@@ -17,6 +17,7 @@ import JobTitle from './job-title';
 import Form from './form';
 import LastName from './last-name';
 import LicenceConfirmation from './licence-confirmation';
+import LicenceHeader from './licence-header';
 import Message from './message';
 import Password from './password';
 import Phone from './phone';
@@ -43,6 +44,7 @@ export {
 	Form,
 	LastName,
 	LicenceConfirmation,
+	LicenceHeader,
 	Message,
 	Password,
 	Phone,

--- a/components/licence-header.jsx
+++ b/components/licence-header.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function LicenceHeader ({
+	displayName = null,
+	isTrial = false,
+	welcomeText = null
+}) {
+	function createMarkup (text) {
+		return { __html: text };
+	}
+
+	return (
+		<React.Fragment>
+			<h1 className="ncf__header">
+				{ displayName && (`${displayName} | `) }
+
+				{
+					isTrial
+						? ('Start your free trial')
+						: ('Join your FT.com subscription')
+				}
+			</h1>
+
+			{ welcomeText && (<p dangerouslySetInnerHTML={createMarkup(welcomeText)} />) }
+		</React.Fragment>
+	);
+}
+
+LicenceHeader.PropTypes = {
+	displayName: PropTypes.string,
+	isTrial: PropTypes.bool,
+	welcomeText: PropTypes.string
+}
+
+export default LicenceHeader;

--- a/components/licence-header.spec.js
+++ b/components/licence-header.spec.js
@@ -1,0 +1,37 @@
+import LicenceHeader from './licence-header';
+import { expectToRenderAs } from '../test-jest/helpers/expect-to-render-as';
+import { fetchPartialAsString } from '../test-jest/helpers/fetch-hbs-as-string';
+
+const context = {};
+
+expect.extend(expectToRenderAs);
+
+describe('LicenceHeader', () => {
+	beforeAll(async () => {
+		context.template = await fetchPartialAsString('licence-header.html');
+	});
+
+	it('renders with default props', () => {
+		const props = {};
+
+		expect(LicenceHeader).toRenderAs(context, props);
+	});
+
+	it('renders with custom display name', () => {
+		const props = { displayName: 'Display name text' };
+
+		expect(LicenceHeader).toRenderAs(context, props);
+	});
+
+	it('renders if is trial', () => {
+		const props = { isTrial: true };
+
+		expect(LicenceHeader).toRenderAs(context, props);
+	});
+
+	it('renders with custom welcome text (that requires escaping, e.g. ampersand)', () => {
+		const props = { welcomeText: 'Welcome text & some more welcome text' };
+
+		expect(LicenceHeader).toRenderAs(context, props);
+	});
+});

--- a/demos/init-jsx.js
+++ b/demos/init-jsx.js
@@ -27,6 +27,7 @@ function initDemo () {
 			<ncf.Form />
 			<ncf.LastName />
 			<ncf.LicenceConfirmation />
+			<ncf.LicenceHeader />
 			<ncf.Message {...fixture['message'].params}/>
 			<ncf.Password />
 			<ncf.Phone />

--- a/partials/licence-header.html
+++ b/partials/licence-header.html
@@ -1,12 +1,5 @@
 <h1 class="ncf__header">
-{{#if displayName }}
-	{{displayName}} |
-{{/if}}
-{{#if isTrial}}
-	Start your free trial
-{{else}}
-	Join your FT.com subscription
-{{/if}}
+{{#if displayName }}{{displayName}} | {{/if}}{{#if isTrial}}Start your free trial{{else}}Join your FT.com subscription{{/if}}
 </h1>
 {{#if welcomeText}}
 <p>{{{ welcomeText }}}</p>


### PR DESCRIPTION
### Description
This PR creates an **Licence Header** JSX component that matches the behaviour and usage of the existing Handlebars (HBS) partial, with tests to ensure they match.

[Trello ticket](https://trello.com/c/WYujLFFR/1597-n-conversion-forms-new-major).

I wonder if there is good reason for the usage of triple-stash (for the welcomeText), as it has forced me to use `dangerouslySetInnerHTML` which is best avoided where possible.
> Handlebars HTML-escapes values returned by a `{{expression}}`. If you don't want Handlebars to escape a value, use the "triple-stash", `{{{`
> `{{{foo}}}`

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [x] **Demos** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer 
- [ ] **Product Review** ran past the product owner

#### References:
- [Handlebars.js](http://handlebarsjs.com/expressions.html).
- [ReactJS: DOM Elements - dangerouslySetInnerHTML](https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml).