### PR TITLE
Fix cross browser issue looping over NodeList

### DIFF
--- a/utils/form-element.js
+++ b/utils/form-element.js
@@ -46,14 +46,18 @@ class FormElement {
 	 * Disable any inputs or selects inside form element
 	 */
 	disable () {
-		this.inputs.forEach(input => input.disabled = true);
+		for (let i = 0; i < this.inputs.length; i++) {
+			this.inputs[i].disabled = true;
+		}
 	}
 
 	/**
 	 * Enable any inputs or selects inside form element
 	 */
 	enable () {
-		this.inputs.forEach(input => input.disabled = false);
+		for (let i = 0; i < this.inputs.length; i++) {
+			this.inputs[i].disabled = false;
+		}
 	}
 
 	/**

--- a/utils/payment-term.js
+++ b/utils/payment-term.js
@@ -68,7 +68,8 @@ class PaymentTerm {
 	 */
 	updateOptions (options) {
 		const terms = this.$paymentTerm.querySelectorAll(ITEM_CLASS);
-		terms.forEach(term => {
+		for (let i = 0; i < terms.length; i++) {
+			const term = terms[i];
 			const value = term.querySelector(VALUE_CLASS).value;
 			const price = term.querySelector(PRICE_CLASS);
 			const trialPrice = term.querySelector(TRIAL_PRICE_CLASS);
@@ -89,7 +90,7 @@ class PaymentTerm {
 			if (weeklyPrice) {
 				weeklyPrice.innerHTML = update.weeklyPrice;
 			}
-		});
+		}
 	}
 }
 

--- a/utils/payment-type.js
+++ b/utils/payment-type.js
@@ -103,13 +103,14 @@ class PaymentType {
 	showPanel () {
 		const type = this.getSelected();
 		const content = this.$paymentType.querySelectorAll('.ncf__payment-type-panel');
-		content.forEach(element => {
+		for (let i = 0; i < content.length; i++) {
+			const element = content[i];
 			if (element.classList.contains(`ncf__payment-type-panel--${type}`)) {
 				element.classList.remove('n-ui-hide');
 			} else {
 				element.classList.add('n-ui-hide');
 			}
-		});
+		}
 	}
 
 	static get CREDITCARD () {

--- a/utils/postcode.js
+++ b/utils/postcode.js
@@ -8,7 +8,9 @@ class Postcode extends FormElement {
 	set changePostcodeReferenceForCountry (countryCode) {
 		const name = Postcode.getPostcodeReferenceByCountry(countryCode);
 		this.reference = this.$el.querySelectorAll('[data-reference=postcode]');
-		this.reference.forEach(reference => reference.innerHTML = name);
+		for (let i = 0; i < this.reference.length; i++) {
+			this.reference[i].innerHTML = name;
+		}
 		this.postcodeInput = this.$el.querySelector('input');
 		this.postcodeInput.placeholder = 'Enter your ' + name;
 	}


### PR DESCRIPTION
### Description

We've seen errors like this in sentry https://sentry.io/organizations/financial-times/issues/1183641809/?project=1420825&query=is%3Aunresolved+payment&statsPeriod=14d because some browsers don't have a `forEach` method on `NodeList`'s returned from `querySelectorAll`. 

Use `for` instead which is much more universal, not sure why this isn't being polyfiled.

Hunch that this may be related to the ticket below as client side errors may affect the ability to process the payment form.

[Ticket](https://trello.com/c/0D9f8C14/1651-subscriptions-being-sent-to-membership-without-payment-method-id)
