### PR TITLE
Allow the passing of custom back button text 

### DIFF
--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -491,5 +491,6 @@ A form submit button with o-button styling
 
 + `isCentered`: boolean - true - centers the button
 + `backButtonUrl`: string - URL of a back button to add next to the button
++ `backButtonText`: string - The text to display inside the back button. Defaults to "Back"
 + `id`: string - The ID of the button defaults to "submitButton"
 + `label`: string - Label to use for the button defaults to "Continue"

--- a/partials/submit.html
+++ b/partials/submit.html
@@ -1,7 +1,7 @@
 <div class="o-forms o-forms--wide ncf__field{{#if isCentered}} ncf__field--center{{/if}}{{#if backButtonUrl}} ncf__field--flex{{/if}}">
 
 	{{#if backButtonUrl }}
-	<a class="ncf__button" href="{{ backButtonUrl }}" target="_parent" data-trackable="link">Back</a>
+	<a class="ncf__button" href="{{ backButtonUrl }}" target="_parent" data-trackable="link">{{#if backButtonText}}{{backButtonText}}{{else}}Back{{/if}}</a>
 	{{/if}}
 
 	<button id="{{#if id}}{{id}}{{else}}submitButton{{/if}}" class="ncf__button ncf__button--submit" data-trackable="submit" type="submit"{{#if isDisabled}} disabled{{/if}}>

--- a/test/partials/submit.spec.js
+++ b/test/partials/submit.spec.js
@@ -58,6 +58,16 @@ describe('submit template', () => {
 		expect($(SELECTOR_BACK_BUTTON).attr('target')).to.equal('_parent');
 	});
 
+	it('should show custom back button text if supplied', () => {
+		const url = 'https://google.com';
+		const $ = context.template({
+			backButtonText: 'No thanks',
+			backButtonUrl: url
+		});
+
+		expect($(SELECTOR_BACK_BUTTON).html()).to.equal('No thanks');
+	});
+
 	it('should have an id of submit by default', () => {
 		const $ = context.template();
 		expect($('#submitButton').length).to.equal(1);


### PR DESCRIPTION
🐿 v2.12.5

### Description

Adds the ability to specify a custom text for the back button.

[Ticket](https://trello.com/c/QkchK4G1/1610-cancel-reasons-page-for-trials)

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality