### PR TITLE
Allow submit buttons to be full width

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -93,6 +93,21 @@
 			grid-template-columns: 1fr min-content min-content;
 		}
 
+		&--full-width-buttons {
+			display: flex;
+			justify-content: space-between;
+			padding-left: 0;
+			padding-right: 0;
+
+			.ncf__button {
+				flex: 1;
+
+				+ .ncf__button {
+					margin-left: 20px;
+				}
+			}
+		}
+
 		label small {
 			color: oColorsMix(black, white, 70);
 			font-weight: normal;

--- a/partials/submit.html
+++ b/partials/submit.html
@@ -1,4 +1,4 @@
-<div class="o-forms o-forms--wide ncf__field{{#if isCentered}} ncf__field--center{{/if}}{{#if backButtonUrl}} ncf__field--flex{{/if}}">
+<div class="o-forms o-forms--wide ncf__field{{#if isFullWidth}} ncf__field--full-width-buttons{{/if}}{{#if isCentered}} ncf__field--center{{/if}}{{#if backButtonUrl}} ncf__field--flex{{/if}}">
 
 	{{#if backButtonUrl }}
 	<a class="ncf__button" href="{{ backButtonUrl }}" target="_parent" data-trackable="link">{{#if backButtonText}}{{backButtonText}}{{else}}Back{{/if}}</a>

--- a/test/partials/submit.spec.js
+++ b/test/partials/submit.spec.js
@@ -1,6 +1,7 @@
 const { expect } = require('chai');
 const { fetchPartial } = require('../helpers');
 
+const FIELD = '.ncf__field';
 const SELECTOR_BUTTON = 'button';
 const SELECTOR_BACK_BUTTON = 'a.ncf__button';
 const SELECTOR_FIELD_CENTER = '.ncf__field--center';
@@ -39,6 +40,14 @@ describe('submit template', () => {
 		});
 
 		expect($(SELECTOR_FIELD_CENTER).length).to.equal(1);
+	});
+
+	it('should allow the buttons to be full width', () => {
+		const $ = context.template({
+			isFullWidth: true
+		});
+
+		expect($(FIELD).hasClass('ncf__field--full-width-buttons')).to.be.true;
 	});
 
 	it('should not show a back button by default', () => {

--- a/test/partials/submit.spec.js
+++ b/test/partials/submit.spec.js
@@ -50,6 +50,12 @@ describe('submit template', () => {
 		expect($(FIELD).hasClass('ncf__field--full-width-buttons')).to.be.true;
 	});
 
+	it('should not have the buttons be full width by default', () => {
+		const $ = context.template();
+
+		expect($(FIELD).hasClass('ncf__field--full-width-buttons')).not.to.be.true;
+	});
+
 	it('should not show a back button by default', () => {
 		const $ = context.template({});
 


### PR DESCRIPTION
🐿 v2.12.5

### Description

The designs for the cancel journey need the buttons to be full width.

[Ticket](https://trello.com/c/QkchK4G1/1610-cancel-reasons-page-for-trials)

### Screenshots

<img width="524" alt="1573637925" src="https://user-images.githubusercontent.com/708296/68752054-95b74400-05fa-11ea-9aa7-4ef54f60a111.png">

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Tests** written for new or updated for existing functionality