### PR TITLE
Export all components from files

### DIFF
--- a/components/index.jsx
+++ b/components/index.jsx
@@ -1,75 +1,36 @@
-import AcceptTerms from './accept-terms';
-import AppBanner from './app-banner';
-import BillingPostcode from './billing-postcode';
-import CompanyName from './company-name';
-import Confirmation from './confirmation';
-import ContinueReading from './continue-reading';
-import CustomerCare from './customer-care';
-import DecisionMaker from './decision-maker';
-import DeliveryAddress from './delivery-address';
-import DeliveryStartDate from './delivery-start-date';
-import DeliveryCity from './delivery-city';
-import DeliveryCounty from './delivery-county';
-import DeliveryOption from './delivery-option';
-import DeliveryInstructions from './delivery-instructions';
-import DeliveryPostcode from './delivery-postcode';
-import Email from './email';
-import Fieldset from './fieldset';
-import FirstName from './first-name';
-import Form from './form';
-import Industry from './industry';
-import JobTitle from './job-title';
-import LastName from './last-name';
-import LicenceConfirmation from './licence-confirmation';
-import LicenceHeader from './licence-header';
-import Message from './message';
-import Password from './password';
-import Phone from './phone';
-import Position from './position';
-import Province from './province';
-import ProgressIndicator from './progress-indicator';
-import RegistrationConfirmation from './registration-confirmation';
-import Responsibility from './responsibility';
-import Section from './section';
-import State from './state';
-import Submit from './submit';
-import TrialBanner from './trial-banner';
-
-export {
-	AcceptTerms,
-	AppBanner,
-	BillingPostcode,
-	CompanyName,
-	Confirmation,
-	ContinueReading,
-	CustomerCare,
-	DecisionMaker,
-	DeliveryAddress,
-	DeliveryCity,
-	DeliveryCounty,
-	DeliveryOption,
-	DeliveryInstructions,
-	DeliveryPostcode,
-	DeliveryStartDate,
-	Email,
-	Fieldset,
-	FirstName,
-	Form,
-	Industry,
-	JobTitle,
-	LastName,
-	LicenceConfirmation,
-	LicenceHeader,
-	Message,
-	Password,
-	Phone,
-	Position,
-	Province,
-	ProgressIndicator,
-	RegistrationConfirmation,
-	Responsibility,
-	Section,
-	State,
-	Submit,
-	TrialBanner
-};
+export * from './accept-terms';
+export * from './app-banner';
+export * from './billing-postcode';
+export * from './company-name';
+export * from './confirmation';
+export * from './continue-reading';
+export * from './customer-care';
+export * from './decision-maker';
+export * from './delivery-address';
+export * from './delivery-city';
+export * from './delivery-county';
+export * from './delivery-instructions';
+export * from './delivery-option';
+export * from './delivery-postcode';
+export * from './delivery-start-date';
+export * from './email';
+export * from './fieldset';
+export * from './first-name';
+export * from './form';
+export * from './industry';
+export * from './job-title';
+export * from './last-name';
+export * from './licence-confirmation';
+export * from './licence-header';
+export * from './message';
+export * from './password';
+export * from './phone';
+export * from './position';
+export * from './progress-indicator';
+export * from './province';
+export * from './registration-confirmation';
+export * from './responsibility';
+export * from './section';
+export * from './state';
+export * from './submit';
+export * from './trial-banner';


### PR DESCRIPTION
Use export instead of importing and exporting later to reduce
duplication and reduce instances of merge conflicts.
