### PR TITLE
More options for the Password component

### DIFF
--- a/components/password.jsx
+++ b/components/password.jsx
@@ -13,6 +13,7 @@ export function Password ({
 	label = 'Password',
 	placeholder = 'Enter a password',
 	showDescription = true,
+	hasShowPassword = true,
 }) {
 	// This is necessary to make this backward compatible with the Handlebars partial.
 	const showPasswordId = inputId === 'password' ? 'showPassword' : `${inputId}-showPassword`;
@@ -58,10 +59,11 @@ export function Password ({
 					aria-required="true" required
 					pattern={pattern}
 					disabled={isDisabled} />
-				<span className="o-forms__suffix">
-					<input type="checkbox" id={showPasswordId} name={showPasswordName} className="o-forms__checkbox js-show-password__checkbox" data-trackable="field-show-password" />
-					<label htmlFor={showPasswordId} className="o-forms__label">Show password</label>
-				</span>
+				{hasShowPassword ?
+					(<span className="o-forms__suffix">
+						<input type="checkbox" id={showPasswordId} name={showPasswordName} className="o-forms__checkbox js-show-password__checkbox" data-trackable="field-show-password" />
+						<label htmlFor={showPasswordId} className="o-forms__label">Show password</label>
+					</span>) : null}
 			</div>
 			<div className="o-forms__errortext">Please enter a valid password</div>
 		</div>

--- a/components/password.jsx
+++ b/components/password.jsx
@@ -11,6 +11,7 @@ export function Password ({
 	inputId = 'password',
 	inputName,
 	label = 'Password',
+	placeholder = 'Enter a password',
 }) {
 	// This is necessary to make this backward compatible with the Handlebars partial.
 	const showPasswordId = inputId === 'password' ? 'showPassword' : `${inputId}-showPassword`;
@@ -47,7 +48,7 @@ export function Password ({
 					type="password"
 					id={inputId}
 					name={inputName}
-					placeholder="Enter a password"
+					placeholder={placeholder}
 					className="no-mouseflow o-forms__text o-forms__text--suffixed js-field__input js-show-password__password-input js-item__value"
 					autoComplete="new-password"
 					data-trackable="field-password"
@@ -74,4 +75,5 @@ Password.propTypes = {
 	inputId: PropTypes.string,
 	inputName: PropTypes.string,
 	label: PropTypes.string,
+	placeholder: PropTypes.string,
 };

--- a/components/password.jsx
+++ b/components/password.jsx
@@ -12,6 +12,7 @@ export function Password ({
 	inputName,
 	label = 'Password',
 	placeholder = 'Enter a password',
+	description = 'Use 8 or more characters with a mix of letters, numbers & symbols',
 	showDescription = true,
 	hasShowPassword = true,
 }) {
@@ -43,7 +44,7 @@ export function Password ({
 			<label htmlFor={inputId} className="o-forms__label">{label}</label>
 			{showDescription ?
 				(<small id="password-description" className="o-forms__additional-info">
-					Use 8 or more characters with a mix of letters, numbers &amp; symbols
+					{description}
 				</small>) : null}
 
 			<div className="o-forms__affix-wrapper js-show-password">

--- a/components/password.jsx
+++ b/components/password.jsx
@@ -10,6 +10,7 @@ export function Password ({
 	fieldId = 'passwordField',
 	inputId = 'password',
 	inputName,
+	label = 'Password',
 }) {
 	// This is necessary to make this backward compatible with the Handlebars partial.
 	const showPasswordId = inputId === 'password' ? 'showPassword' : `${inputId}-showPassword`;
@@ -36,7 +37,7 @@ export function Password ({
 			data-validate="required,password"
 		>
 
-			<label htmlFor={inputId} className="o-forms__label">Password</label>
+			<label htmlFor={inputId} className="o-forms__label">{label}</label>
 			<small id="password-description" className="o-forms__additional-info">
 				Use 8 or more characters with a mix of letters, numbers &amp; symbols
 			</small>
@@ -72,4 +73,5 @@ Password.propTypes = {
 	fieldId: PropTypes.string,
 	inputId: PropTypes.string,
 	inputName: PropTypes.string,
+	label: PropTypes.string,
 };

--- a/components/password.jsx
+++ b/components/password.jsx
@@ -12,6 +12,7 @@ export function Password ({
 	inputName,
 	label = 'Password',
 	placeholder = 'Enter a password',
+	showDescription = true,
 }) {
 	// This is necessary to make this backward compatible with the Handlebars partial.
 	const showPasswordId = inputId === 'password' ? 'showPassword' : `${inputId}-showPassword`;
@@ -39,9 +40,10 @@ export function Password ({
 		>
 
 			<label htmlFor={inputId} className="o-forms__label">{label}</label>
-			<small id="password-description" className="o-forms__additional-info">
-				Use 8 or more characters with a mix of letters, numbers &amp; symbols
-			</small>
+			{showDescription ?
+				(<small id="password-description" className="o-forms__additional-info">
+					Use 8 or more characters with a mix of letters, numbers &amp; symbols
+				</small>) : null}
 
 			<div className="o-forms__affix-wrapper js-show-password">
 				<input
@@ -52,7 +54,7 @@ export function Password ({
 					className="no-mouseflow o-forms__text o-forms__text--suffixed js-field__input js-show-password__password-input js-item__value"
 					autoComplete="new-password"
 					data-trackable="field-password"
-					aria-describedby="password-description"
+					aria-describedby={showDescription ? 'password-description' : undefined}
 					aria-required="true" required
 					pattern={pattern}
 					disabled={isDisabled} />

--- a/components/password.spec.js
+++ b/components/password.spec.js
@@ -95,4 +95,16 @@ describe('Password', () => {
 
 		expect(Password).toRenderAs(context, props);
 	});
+
+	it('can render without a description', () => {
+		const props = {
+			showDescription: false,
+			inputId: 'passwordWithoutDescription',
+		};
+
+		const renderedPassword = mount(Password(props));
+		const inputElement = renderedPassword.find(`#${props.inputId}`);
+		expect(renderedPassword.exists('#password-description')).toBe(false);
+		expect(inputElement.prop('aria-describedby')).toBeUndefined();
+	});
 });

--- a/components/password.spec.js
+++ b/components/password.spec.js
@@ -27,6 +27,18 @@ describe('Password', () => {
 
 	});
 
+	it('can have a different label', () => {
+		const props = {
+			label: 'Current password',
+			inputId: 'passwordWithCustomLabel',
+		};
+
+		const renderedPassword = mount(Password(props));
+		const inputElement = renderedPassword.find(`label[htmlFor="${props.inputId}"]`);
+		expect(inputElement.text()).toBe(props.label);
+
+	});
+
 	it('can have an input ID different from an input name', () => {
 		const props = {
 			inputId: 'i-m-kebab-case',

--- a/components/password.spec.js
+++ b/components/password.spec.js
@@ -96,6 +96,17 @@ describe('Password', () => {
 		expect(Password).toRenderAs(context, props);
 	});
 
+	it('can have different description text', () => {
+		const props = {
+			description: 'Keep this a secret!',
+			inputId: 'passwordWithCustomDescription',
+		};
+
+		const renderedPassword = mount(Password(props));
+		const passwordDescription = renderedPassword.find('#password-description');
+		expect(passwordDescription.text()).toBe(props.description);
+	});
+
 	it('can render without a description', () => {
 		const props = {
 			showDescription: false,

--- a/components/password.spec.js
+++ b/components/password.spec.js
@@ -107,4 +107,14 @@ describe('Password', () => {
 		expect(renderedPassword.exists('#password-description')).toBe(false);
 		expect(inputElement.prop('aria-describedby')).toBeUndefined();
 	});
+
+	it('can render without the show password checkbox', () => {
+		const props = {
+			hasShowPassword: false,
+			inputId: 'passwordWithoutShowPassword',
+		};
+
+		const renderedPassword = mount(Password(props));
+		expect(renderedPassword.exists('input[data-trackable="field-show-password"]')).toBe(false);
+	});
 });

--- a/components/password.spec.js
+++ b/components/password.spec.js
@@ -39,6 +39,17 @@ describe('Password', () => {
 
 	});
 
+	it('can have different placeholder text', () => {
+		const props = {
+			placeholder: 'Please enter your current password',
+			inputId: 'passwordWithCustomPlaceholder',
+		};
+
+		const renderedPassword = mount(Password(props));
+		const inputElement = renderedPassword.find(`#${props.inputId}`);
+		expect(inputElement.prop('placeholder')).toBe(props.placeholder);
+	});
+
 	it('can have an input ID different from an input name', () => {
 		const props = {
 			inputId: 'i-m-kebab-case',


### PR DESCRIPTION
### Description
The Personal Details page on Account Settings will need to have three password fields displayed, but with small differences between them.

- They will each have their own label.
- None of them will have placeholder text.
- One will have microcopy above the field that is different to the existing copy.
- Two will not have any microcopy.
- Only one will have the "Show password" checkbox next to it.

This PR adds the following props to the `<Password>` JSX component:

- `label` - Text that will be used for the label of the field. Defaults to "Password".
- `placeholder` - Text that will be used for the placeholder text on the field. Defaults to "Enter a password".
- `hasDescription` - Whether or not to show the description for the field. Defaults to `true`.
- `description` - The description text to be displayed. Defaults to "Use 8 or more characters with a mix of letters, numbers & symbols".
- `hasShowPassword` - Whether or not to show the "Show password" checkbox. Defaults to `true`.

The defaults that have been chosen are so that it renders the same as the existing Handlebars partial.

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Tests** written for new or updated for existing functionality
- [x] **Accessibility** checked for screen readers and contrast
