### PR TITLE
Add compact version of customer care message

### DIFF
--- a/components/__snapshots__/customer-care.spec.js.snap
+++ b/components/__snapshots__/customer-care.spec.js.snap
@@ -1,7 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CustomerCare renders in compact mode 1`] = `
+<div class="ncf__wrapper ncf__center ncf__customer-care ncf__customer-care--compact">
+  <div class="ncf__paragraph">
+    <h1 class="ncf__header">
+      Sorry, this is not available online
+    </h1>
+    <p id="customer-care-message">
+      Speak now to our Customer Care team to discuss your options
+    </p>
+  </div>
+  <div class="ncf__paragraph">
+    <div class="ncf__icon ncf__icon--phone ncf__icon--large">
+    </div>
+    <p>
+      International Toll Free Number
+    </p>
+    <p class="ncf__customer-care__phone">
+      <a id="customer-care-international-number"
+         class="ncf__header ncf__link"
+         href="tel:+80007056477"
+      >
+        + 800 0705 6477
+      </a>
+    </p>
+  </div>
+  <div class="ncf__paragraph">
+    <a class="ncf__link"
+       href="https://help.ft.com/help/contact-us/"
+    >
+      Find a local phone number
+    </a>
+  </div>
+</div>
+`;
+
+exports[`CustomerCare renders in compact mode 2`] = `
+<div class="ncf__wrapper ncf__center ncf__customer-care ncf__customer-care--compact">
+  <div class="ncf__paragraph">
+    <h1 class="ncf__header">
+      Sorry, this is not available online
+    </h1>
+    <p id="customer-care-message">
+      Speak now to our Customer Care team to discuss your options
+    </p>
+  </div>
+  <div class="ncf__paragraph">
+    <div class="ncf__icon ncf__icon--phone ncf__icon--large">
+    </div>
+    <p>
+      International Toll Free Number
+    </p>
+    <p class="ncf__customer-care__phone">
+      <a id="customer-care-international-number"
+         class="ncf__header ncf__link"
+         href="tel:+80007056477"
+      >
+        + 800 0705 6477
+      </a>
+    </p>
+  </div>
+  <div class="ncf__paragraph">
+    <a class="ncf__link"
+       href="https://help.ft.com/help/contact-us/"
+    >
+      Find a local phone number
+    </a>
+  </div>
+</div>
+`;
+
 exports[`CustomerCare renders with custom header text 1`] = `
-<div class="ncf__wrapper ncf__center">
+<div class="ncf__wrapper ncf__center ncf__customer-care">
   <div class="ncf__paragraph">
     <h1 class="ncf__header">
       Header text
@@ -10,18 +80,20 @@ exports[`CustomerCare renders with custom header text 1`] = `
       Speak now to our Customer Care team to discuss your options
     </p>
   </div>
-  <div class="ncf__paragraph ncf__customer-care">
+  <div class="ncf__paragraph">
     <div class="ncf__icon ncf__icon--phone ncf__icon--large">
     </div>
     <p>
       International Toll Free Number
     </p>
-    <a id="customer-care-international-number"
-       class="ncf__header ncf__link"
-       href="tel:+80007056477"
-    >
-      + 800 0705 6477
-    </a>
+    <p class="ncf__customer-care__phone">
+      <a id="customer-care-international-number"
+         class="ncf__header ncf__link"
+         href="tel:+80007056477"
+      >
+        + 800 0705 6477
+      </a>
+    </p>
   </div>
   <div class="ncf__paragraph">
     <a class="ncf__link"
@@ -34,7 +106,7 @@ exports[`CustomerCare renders with custom header text 1`] = `
 `;
 
 exports[`CustomerCare renders with custom header text 2`] = `
-<div class="ncf__wrapper ncf__center">
+<div class="ncf__wrapper ncf__center ncf__customer-care">
   <div class="ncf__paragraph">
     <h1 class="ncf__header">
       Header text
@@ -43,18 +115,20 @@ exports[`CustomerCare renders with custom header text 2`] = `
       Speak now to our Customer Care team to discuss your options
     </p>
   </div>
-  <div class="ncf__paragraph ncf__customer-care">
+  <div class="ncf__paragraph">
     <div class="ncf__icon ncf__icon--phone ncf__icon--large">
     </div>
     <p>
       International Toll Free Number
     </p>
-    <a id="customer-care-international-number"
-       class="ncf__header ncf__link"
-       href="tel:+80007056477"
-    >
-      + 800 0705 6477
-    </a>
+    <p class="ncf__customer-care__phone">
+      <a id="customer-care-international-number"
+         class="ncf__header ncf__link"
+         href="tel:+80007056477"
+      >
+        + 800 0705 6477
+      </a>
+    </p>
   </div>
   <div class="ncf__paragraph">
     <a class="ncf__link"
@@ -67,7 +141,7 @@ exports[`CustomerCare renders with custom header text 2`] = `
 `;
 
 exports[`CustomerCare renders with custom message text 1`] = `
-<div class="ncf__wrapper ncf__center">
+<div class="ncf__wrapper ncf__center ncf__customer-care">
   <div class="ncf__paragraph">
     <h1 class="ncf__header">
       Sorry, this is not available online
@@ -76,18 +150,20 @@ exports[`CustomerCare renders with custom message text 1`] = `
       Message text
     </p>
   </div>
-  <div class="ncf__paragraph ncf__customer-care">
+  <div class="ncf__paragraph">
     <div class="ncf__icon ncf__icon--phone ncf__icon--large">
     </div>
     <p>
       International Toll Free Number
     </p>
-    <a id="customer-care-international-number"
-       class="ncf__header ncf__link"
-       href="tel:+80007056477"
-    >
-      + 800 0705 6477
-    </a>
+    <p class="ncf__customer-care__phone">
+      <a id="customer-care-international-number"
+         class="ncf__header ncf__link"
+         href="tel:+80007056477"
+      >
+        + 800 0705 6477
+      </a>
+    </p>
   </div>
   <div class="ncf__paragraph">
     <a class="ncf__link"
@@ -100,7 +176,7 @@ exports[`CustomerCare renders with custom message text 1`] = `
 `;
 
 exports[`CustomerCare renders with custom message text 2`] = `
-<div class="ncf__wrapper ncf__center">
+<div class="ncf__wrapper ncf__center ncf__customer-care">
   <div class="ncf__paragraph">
     <h1 class="ncf__header">
       Sorry, this is not available online
@@ -109,18 +185,20 @@ exports[`CustomerCare renders with custom message text 2`] = `
       Message text
     </p>
   </div>
-  <div class="ncf__paragraph ncf__customer-care">
+  <div class="ncf__paragraph">
     <div class="ncf__icon ncf__icon--phone ncf__icon--large">
     </div>
     <p>
       International Toll Free Number
     </p>
-    <a id="customer-care-international-number"
-       class="ncf__header ncf__link"
-       href="tel:+80007056477"
-    >
-      + 800 0705 6477
-    </a>
+    <p class="ncf__customer-care__phone">
+      <a id="customer-care-international-number"
+         class="ncf__header ncf__link"
+         href="tel:+80007056477"
+      >
+        + 800 0705 6477
+      </a>
+    </p>
   </div>
   <div class="ncf__paragraph">
     <a class="ncf__link"
@@ -133,7 +211,7 @@ exports[`CustomerCare renders with custom message text 2`] = `
 `;
 
 exports[`CustomerCare renders with default props 1`] = `
-<div class="ncf__wrapper ncf__center">
+<div class="ncf__wrapper ncf__center ncf__customer-care">
   <div class="ncf__paragraph">
     <h1 class="ncf__header">
       Sorry, this is not available online
@@ -142,18 +220,20 @@ exports[`CustomerCare renders with default props 1`] = `
       Speak now to our Customer Care team to discuss your options
     </p>
   </div>
-  <div class="ncf__paragraph ncf__customer-care">
+  <div class="ncf__paragraph">
     <div class="ncf__icon ncf__icon--phone ncf__icon--large">
     </div>
     <p>
       International Toll Free Number
     </p>
-    <a id="customer-care-international-number"
-       class="ncf__header ncf__link"
-       href="tel:+80007056477"
-    >
-      + 800 0705 6477
-    </a>
+    <p class="ncf__customer-care__phone">
+      <a id="customer-care-international-number"
+         class="ncf__header ncf__link"
+         href="tel:+80007056477"
+      >
+        + 800 0705 6477
+      </a>
+    </p>
   </div>
   <div class="ncf__paragraph">
     <a class="ncf__link"
@@ -166,7 +246,7 @@ exports[`CustomerCare renders with default props 1`] = `
 `;
 
 exports[`CustomerCare renders with default props 2`] = `
-<div class="ncf__wrapper ncf__center">
+<div class="ncf__wrapper ncf__center ncf__customer-care">
   <div class="ncf__paragraph">
     <h1 class="ncf__header">
       Sorry, this is not available online
@@ -175,18 +255,20 @@ exports[`CustomerCare renders with default props 2`] = `
       Speak now to our Customer Care team to discuss your options
     </p>
   </div>
-  <div class="ncf__paragraph ncf__customer-care">
+  <div class="ncf__paragraph">
     <div class="ncf__icon ncf__icon--phone ncf__icon--large">
     </div>
     <p>
       International Toll Free Number
     </p>
-    <a id="customer-care-international-number"
-       class="ncf__header ncf__link"
-       href="tel:+80007056477"
-    >
-      + 800 0705 6477
-    </a>
+    <p class="ncf__customer-care__phone">
+      <a id="customer-care-international-number"
+         class="ncf__header ncf__link"
+         href="tel:+80007056477"
+      >
+        + 800 0705 6477
+      </a>
+    </p>
   </div>
   <div class="ncf__paragraph">
     <a class="ncf__link"

--- a/components/customer-care.jsx
+++ b/components/customer-care.jsx
@@ -1,24 +1,35 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 const DEFAULT_HEADER_TEXT = 'Sorry, this is not available online';
 const DEFAULT_MESSAGE_TEXT = 'Speak now to our Customer Care team to discuss your options';
 
 export function CustomerCare ({
 	header = DEFAULT_HEADER_TEXT,
+	isCompact = false,
 	message = DEFAULT_MESSAGE_TEXT
 }) {
+	const className = classNames([
+		'ncf__wrapper',
+		'ncf__center',
+		'ncf__customer-care',
+		{ 'ncf__customer-care--compact': (isCompact === true) }
+	]);
+
 	return (
-		<div className="ncf__wrapper ncf__center">
+		<div className={className}>
 			<div className="ncf__paragraph">
 				<h1 className="ncf__header">{header}</h1>
 				<p id="customer-care-message">{message}</p>
 			</div>
 
-			<div className="ncf__paragraph ncf__customer-care">
+			<div className="ncf__paragraph">
 				<div className="ncf__icon ncf__icon--phone ncf__icon--large"></div>
 				<p>International Toll Free Number</p>
-				<a id="customer-care-international-number" className="ncf__header ncf__link" href="tel:+80007056477">+ 800 0705 6477</a>
+				<p className="ncf__customer-care__phone">
+					<a id="customer-care-international-number" className="ncf__header ncf__link" href="tel:+80007056477">+ 800 0705 6477</a>
+				</p>
 			</div>
 
 			<div className="ncf__paragraph">
@@ -30,5 +41,6 @@ export function CustomerCare ({
 
 CustomerCare.propTypes = {
 	header: PropTypes.string,
+	isCompact: PropTypes.bool,
 	message: PropTypes.string
 };

--- a/components/customer-care.spec.js
+++ b/components/customer-care.spec.js
@@ -23,6 +23,12 @@ describe('CustomerCare', () => {
 		expect(CustomerCare).toRenderAs(context, props);
 	});
 
+	it('renders in compact mode', () => {
+		const props = { isCompact: true };
+
+		expect(CustomerCare).toRenderAs(context, props);
+	});
+
 	it('renders with custom message text', () => {
 		const props = { message: 'Message text' };
 

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -144,6 +144,7 @@ Renders a "contact customer support" page.
 
 ### Options
 + `header`: string - Custom header text. Defaults to "Sorry, this is not available online".
++ `isCompact`: boolean - This removes the phone icon and makes the spacing smaller.
 + `message`: string - Custom message text, defaults to "Speak now to our Customer Care team to discuss your options".
 
 ## Decision Maker

--- a/partials/customer-care.html
+++ b/partials/customer-care.html
@@ -1,14 +1,16 @@
-<div class="ncf__wrapper ncf__center">
+<div class="ncf__wrapper ncf__center ncf__customer-care{{#if isCompact}} ncf__customer-care--compact{{/if}}">
 
 	<div class="ncf__paragraph">
 		<h1 class="ncf__header">{{#if header}}{{header}}{{else}}Sorry, this is not available online{{/if}}</h1>
 		<p id="customer-care-message">{{#if message}}{{message}}{{else}}Speak now to our Customer Care team to discuss your options{{/if}}</p>
 	</div>
 
-	<div class="ncf__paragraph ncf__customer-care">
+	<div class="ncf__paragraph">
 		<div class="ncf__icon ncf__icon--phone ncf__icon--large"></div>
 		<p>International Toll Free Number</p>
-		<a id="customer-care-international-number" class="ncf__header ncf__link" href="tel:+80007056477">+ 800 0705 6477</a>
+		<p class="ncf__customer-care__phone">
+			<a id="customer-care-international-number" class="ncf__header ncf__link" href="tel:+80007056477">+ 800 0705 6477</a>
+		</p>
 	</div>
 
 	<div class="ncf__paragraph">

--- a/styles/customer-care.scss
+++ b/styles/customer-care.scss
@@ -24,4 +24,25 @@
 
 	}
 
+	&__customer-care {
+		&__phone {
+			margin-bottom: 0;
+		}
+
+		&--compact {
+			padding-bottom: 15px;
+			padding-top: 15px;
+
+			.ncf__icon--phone {
+				display: none;
+			}
+			.ncf__customer-care__phone {
+				margin-bottom: 1em;
+			}
+			.ncf__paragraph {
+				padding: 0;
+			}
+		}
+	}
+
 }

--- a/test/partials/customer-care.spec.js
+++ b/test/partials/customer-care.spec.js
@@ -29,6 +29,18 @@ describe('customer care template', () => {
 		expect($('#customer-care-message').text()).to.equal(sampleMessage);
 	});
 
+	it('should display the non-compact version unless requested', () => {
+		const $ = context.template();
+		expect($('.ncf__customer-care--compact').length).to.equal(0);
+	});
+
+	it('should display the compact version if requested', () => {
+		const $ = context.template({
+			isCompact: true
+		});
+		expect($('.ncf__customer-care--compact').length).to.equal(1);
+	});
+
 	it('should default the message text if not provided', () => {
 		const $ = context.template({});
 		expect($('#customer-care-message').text()).to.equal('Speak now to our Customer Care team to discuss your options');


### PR DESCRIPTION
🐿 v2.12.5

### Description

The Cancel Confirmation page needs to display this information but without the phone icon and with the spacing a lot more compact.

[Ticket](https://trello.com/c/hFrTJ1J2/1613-trial-cancellation-confirmation-page)

### Screenshots

| Before | After |
| ------ | ----- |
| <img width="645" alt="1574171020" src="https://user-images.githubusercontent.com/708296/69242673-41333c00-0b99-11ea-93c4-0aac1b703e7d.png">|<img width="625" alt="1574242215" src="https://user-images.githubusercontent.com/708296/69242697-4db79480-0b99-11ea-800b-abbbb2224407.png">|

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [x] **Design Review** ran past the designer 
