### PR TITLE
Add placeholder override attribute

### DIFF
--- a/components/__snapshots__/delivery-instructions.spec.js.snap
+++ b/components/__snapshots__/delivery-instructions.spec.js.snap
@@ -23,10 +23,7 @@ exports[`DeliveryInstructions renders with a custom value 1`] = `
             name="deliveryInstructions"
             class="o-forms__text js-field__input js-item__value"
             data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
-- Door colour, letterbox location
-- Placement i.e. letterbox delivery
-- Special handling i.e. place in plastic bag"
+            placeholder="test"
   >
     foobar
   </textarea>
@@ -59,10 +56,7 @@ exports[`DeliveryInstructions renders with a custom value 2`] = `
             name="deliveryInstructions"
             class="o-forms__text js-field__input js-item__value"
             data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
-- Door colour, letterbox location
-- Placement i.e. letterbox delivery
-- Special handling i.e. place in plastic bag"
+            placeholder="test"
   >
     foobar
   </textarea>
@@ -95,10 +89,7 @@ exports[`DeliveryInstructions renders with a disabled input element 1`] = `
             name="deliveryInstructions"
             class="o-forms__text js-field__input js-item__value"
             data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
-- Door colour, letterbox location
-- Placement i.e. letterbox delivery
-- Special handling i.e. place in plastic bag"
+            placeholder="test"
             disabled
   >
   </textarea>
@@ -131,10 +122,7 @@ exports[`DeliveryInstructions renders with a disabled input element 2`] = `
             name="deliveryInstructions"
             class="o-forms__text js-field__input js-item__value"
             data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
-- Door colour, letterbox location
-- Placement i.e. letterbox delivery
-- Special handling i.e. place in plastic bag"
+            placeholder="test"
             disabled
   >
   </textarea>
@@ -167,10 +155,7 @@ exports[`DeliveryInstructions renders with an error 1`] = `
             name="deliveryInstructions"
             class="o-forms__text js-field__input js-item__value"
             data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
-- Door colour, letterbox location
-- Placement i.e. letterbox delivery
-- Special handling i.e. place in plastic bag"
+            placeholder="test"
   >
   </textarea>
   <p>
@@ -202,10 +187,7 @@ exports[`DeliveryInstructions renders with an error 2`] = `
             name="deliveryInstructions"
             class="o-forms__text js-field__input js-item__value"
             data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
-- Door colour, letterbox location
-- Placement i.e. letterbox delivery
-- Special handling i.e. place in plastic bag"
+            placeholder="test"
   >
   </textarea>
   <p>
@@ -237,10 +219,7 @@ exports[`DeliveryInstructions renders with default props 1`] = `
             name="deliveryInstructions"
             class="o-forms__text js-field__input js-item__value"
             data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
-- Door colour, letterbox location
-- Placement i.e. letterbox delivery
-- Special handling i.e. place in plastic bag"
+            placeholder="test"
   >
   </textarea>
   <p>
@@ -272,10 +251,7 @@ exports[`DeliveryInstructions renders with default props 2`] = `
             name="deliveryInstructions"
             class="o-forms__text js-field__input js-item__value"
             data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
-- Door colour, letterbox location
-- Placement i.e. letterbox delivery
-- Special handling i.e. place in plastic bag"
+            placeholder="test"
   >
   </textarea>
   <p>
@@ -308,10 +284,7 @@ exports[`DeliveryInstructions renders with maxlength 1`] = `
             maxlength="200"
             class="o-forms__text js-field__input js-item__value"
             data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions (Max. 200 characters):
-- Door colour, letterbox location
-- Placement i.e. letterbox delivery
-- Special handling i.e. place in plastic bag"
+            placeholder="test"
   >
   </textarea>
   <p>
@@ -344,10 +317,7 @@ exports[`DeliveryInstructions renders with maxlength 2`] = `
             maxlength="200"
             class="o-forms__text js-field__input js-item__value"
             data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions (Max. 200 characters):
-- Door colour, letterbox location
-- Placement i.e. letterbox delivery
-- Special handling i.e. place in plastic bag"
+            placeholder="test"
   >
   </textarea>
   <p>
@@ -380,10 +350,7 @@ exports[`DeliveryInstructions renders with rows 1`] = `
             rows="20"
             class="o-forms__text js-field__input js-item__value"
             data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
-- Door colour, letterbox location
-- Placement i.e. letterbox delivery
-- Special handling i.e. place in plastic bag"
+            placeholder="test"
   >
   </textarea>
   <p>
@@ -416,10 +383,7 @@ exports[`DeliveryInstructions renders with rows 2`] = `
             rows="20"
             class="o-forms__text js-field__input js-item__value"
             data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
-- Door colour, letterbox location
-- Placement i.e. letterbox delivery
-- Special handling i.e. place in plastic bag"
+            placeholder="test"
   >
   </textarea>
   <p>

--- a/components/delivery-instructions.jsx
+++ b/components/delivery-instructions.jsx
@@ -9,6 +9,7 @@ export function DeliveryInstructions ({
 	maxlength = null,
 	rows = null,
 	isDisabled = false,
+	placeholder = '',
 	value = ''
 }) {
 	const divClassName = classNames([
@@ -20,7 +21,7 @@ export function DeliveryInstructions ({
 	]);
 
 	const maxLengthText = maxlength ? `(Max. ${maxlength} characters)` : '';
-	const placeholder = `Enter instructions ${maxLengthText}:\u000a- Door colour, letterbox location\u000a- Placement i.e. letterbox delivery\u000a- Special handling i.e. place in plastic bag`;
+	const defaultPlaceholder = `Enter instructions ${maxLengthText}:\u000a- Door colour, letterbox location\u000a- Placement i.e. letterbox delivery\u000a- Special handling i.e. place in plastic bag`;
 
 	const textAreaProps = {
 		type: 'text',
@@ -30,10 +31,12 @@ export function DeliveryInstructions ({
 		...(rows && { rows }),
 		className: 'o-forms__text js-field__input js-item__value',
 		'data-trackable': 'field-deliveryInstructions',
-		placeholder,
+		placeholder: placeholder ? placeholder : defaultPlaceholder,
 		disabled: isDisabled,
 		defaultValue: value
 	};
+
+	const textarea = React.createElement('textarea', textAreaProps);
 
 	return (
 		<div
@@ -49,7 +52,7 @@ export function DeliveryInstructions ({
 				These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
 			</div>
 
-			<textarea {...textAreaProps} />
+			{textarea}
 
 			<p>Please note that we can only deliver to the ground floor level of your property.</p>
 		</div>

--- a/components/delivery-instructions.spec.js
+++ b/components/delivery-instructions.spec.js
@@ -12,37 +12,37 @@ describe('DeliveryInstructions', () => {
 	});
 
 	it('renders with default props', () => {
-		const props = {};
+		const props = { placeholder: 'test' };
 
 		expect(DeliveryInstructions).toRenderAs(context, props);
 	});
 
 	it('renders with an error', () => {
-		const props = { hasError: true };
+		const props = { placeholder: 'test', hasError: true };
 
 		expect(DeliveryInstructions).toRenderAs(context, props);
 	});
 
 	it('renders with maxlength', () => {
-		const props = { maxlength: 200 };
+		const props = { placeholder: 'test', maxlength: 200 };
 
 		expect(DeliveryInstructions).toRenderAs(context, props);
 	});
 
 	it('renders with rows', () => {
-		const props = { rows: 20 };
+		const props = { placeholder: 'test', rows: 20 };
 
 		expect(DeliveryInstructions).toRenderAs(context, props);
 	});
 
 	it('renders with a custom value', () => {
-		const props = { value: 'foobar' };
+		const props = { placeholder: 'test', value: 'foobar' };
 
 		expect(DeliveryInstructions).toRenderAs(context, props);
 	});
 
 	it('renders with a disabled input element', () => {
-		const props = { isDisabled: true };
+		const props = { placeholder: 'test', isDisabled: true };
 
 		expect(DeliveryInstructions).toRenderAs(context, props);
 	});

--- a/partials/delivery-instructions.html
+++ b/partials/delivery-instructions.html
@@ -15,10 +15,7 @@
 				{{#if rows}}rows="{{rows}}"{{/if}}
 				class="o-forms__text js-field__input js-item__value"
 				data-trackable="field-deliveryInstructions"
-				placeholder="Enter instructions {{#if maxlength}}(Max. {{maxlength}} characters){{/if}}:
-- Door colour, letterbox location
-- Placement i.e. letterbox delivery
-- Special handling i.e. place in plastic bag"
+				placeholder="{{#if placeholder}}{{placeholder}}{{else}}Enter instructions {{#if maxlength}}(Max. {{maxlength}} characters){{/if}}:&#x0a;- Door colour, letterbox location&#x0a;- Placement i.e. letterbox delivery&#x0a;- Special handling i.e. place in plastic bag{{/if}}"
 				{{#if isDisabled}}disabled{{/if}}>{{value}}</textarea>
 	<p>
 		Please note that we can only deliver to the ground floor level of your property.


### PR DESCRIPTION
JSX escapes all HTML attributes which causes issues for the
placeholder in the delivery instructions component. Because a line
break entity is used to put instructions across multiple lines this
breaks our tests as JSX will escape this. By adding the ability to
override the placeholder we can have two working but different default
placehodlers for JSX and Handlebars but still have tests pass.

https://trello.com/c/hcOuBGMF/1680-delivery-instructions-placeholder-look-wrong