### PR TITLE
Origami Upgrade: Dev dependencies for the demo

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,8 +33,8 @@
     "main.scss"
   ],
   "devDependencies": {
-    "o-layout": "^3.2.0",
-    "o-header-services": "^3.3.4"
+    "o-layout": "^4.0.1",
+    "o-header-services": "^4.0.0"
   },
   "dependencies": {
     "o-forms": "^6.0.0",

--- a/demos/main.scss
+++ b/demos/main.scss
@@ -1,3 +1,4 @@
+$system-code: 'n-conversion-forms-demo';
 $o-brand: 'internal';
 @import 'o-layout/main';
 @import 'o-header-services/main';


### PR DESCRIPTION
### Description
Upgrades the devDependencies bower components.

### Disclaimer
We expect the build to fail on this one, as there are other dependencies that need upgrading. Once all our changes are merged into the `origami-major-upgrade` feature branch, we _should_ have a build that passes.