### PR TITLE
Migration of o-expander v4 to v5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -44,7 +44,7 @@
     "o-colors": "^5.0.2",
     "o-icons": "^6.0.0",
     "o-stepped-progress": "^1.0.0",
-    "o-expander": "^4.7.0",
+    "o-expander": "^5.0.0",
     "o-loading": "^4.0.0",
     "o-grid": "^5.0.0",
     "o-typography": "^6.1.0"

--- a/styles/payment-type.scss
+++ b/styles/payment-type.scss
@@ -62,12 +62,12 @@
 		text-align: center;
 
 		&-list {
-			@include oExpanderContent;
+			@include oExpander;
 			text-align: left;
 		}
 
 		&-toggle {
-			@include oExpanderToggle;
+			@include oExpander;
 			color: oColorsByName('teal');
 		}
 	}


### PR DESCRIPTION
🐿 v2.12.5

### Description
From what I understand from the [migration notes](https://github.com/Financial-Times/o-expander/blob/master/MIGRATION.md#migrating-from-v4-to-v5), these are the only changes that need to be made. 
