### PR TITLE
Bumps o-stepped-progress from v1 to v2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -43,7 +43,7 @@
     "o-message": "^2.4.1",
     "o-colors": "^5.0.2",
     "o-icons": "^6.0.0",
-    "o-stepped-progress": "^1.0.0",
+    "o-stepped-progress": "^2.0.0",
     "o-expander": "^4.7.0",
     "o-loading": "^4.0.0",
     "o-grid": "^5.0.0",


### PR DESCRIPTION
🐿 v2.12.5

### Description
Does not appear to require any changes according to the [migration notes](https://github.com/Financial-Times/o-stepped-progress/blob/master/MIGRATION.md#migrating-from-v1-to-v2)

