### PR TITLE
Upgrade o-message to the latest major version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,7 @@
     "o-forms": "^6.0.0",
     "n-ui-foundations": "^3.0.1",
     "o-buttons": "^5.15.1",
-    "o-message": "^2.4.1",
+    "o-message": "^4.0.0",
     "o-colors": "^5.0.2",
     "o-icons": "^6.0.0",
     "o-stepped-progress": "^1.0.0",

--- a/components/__snapshots__/message.spec.jsx.snap
+++ b/components/__snapshots__/message.spec.jsx.snap
@@ -4,7 +4,7 @@ exports[`Message can add a data attribute name 1`] = `
 <div class="ncf__message o-forms o-forms--wide"
      data-message-name="The Police best album ever"
 >
-  <div class="o-message o-message--alert-inner o-message--neutral"
+  <div class="o-message o-message--inner o-message--alert o-message--neutral"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -24,7 +24,7 @@ exports[`Message can add a data attribute name 2`] = `
 <div class="ncf__message o-forms o-forms--wide"
      data-message-name="The Police best album ever"
 >
-  <div class="o-message o-message--alert-inner o-message--neutral"
+  <div class="o-message o-message--inner o-message--alert o-message--neutral"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -42,7 +42,7 @@ exports[`Message can add a data attribute name 2`] = `
 
 exports[`Message can render a message as a Notice 1`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--notice-inner o-message--neutral"
+  <div class="o-message o-message--inner o-message--notice o-message--neutral"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -60,7 +60,7 @@ exports[`Message can render a message as a Notice 1`] = `
 
 exports[`Message can render a message as a Notice 2`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--notice-inner o-message--neutral"
+  <div class="o-message o-message--inner o-message--notice o-message--neutral"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -78,7 +78,7 @@ exports[`Message can render a message as a Notice 2`] = `
 
 exports[`Message can render a message as a Success 1`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--alert-inner o-message--success"
+  <div class="o-message o-message--inner o-message--alert o-message--success"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -96,7 +96,7 @@ exports[`Message can render a message as a Success 1`] = `
 
 exports[`Message can render a message as a Success 2`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--alert-inner o-message--success"
+  <div class="o-message o-message--inner o-message--alert o-message--success"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -114,7 +114,7 @@ exports[`Message can render a message as a Success 2`] = `
 
 exports[`Message can render a message as an Error 1`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--alert-inner o-message--error"
+  <div class="o-message o-message--inner o-message--alert o-message--error"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -132,7 +132,7 @@ exports[`Message can render a message as an Error 1`] = `
 
 exports[`Message can render a message as an Error 2`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--alert-inner o-message--error"
+  <div class="o-message o-message--inner o-message--alert o-message--error"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -150,7 +150,7 @@ exports[`Message can render a message as an Error 2`] = `
 
 exports[`Message can render a message as an Inform 1`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--alert-inner o-message--inform"
+  <div class="o-message o-message--inner o-message--alert o-message--inform"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -168,7 +168,7 @@ exports[`Message can render a message as an Inform 1`] = `
 
 exports[`Message can render a message as an Inform 2`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--alert-inner o-message--inform"
+  <div class="o-message o-message--inner o-message--alert o-message--inform"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -186,7 +186,7 @@ exports[`Message can render a message as an Inform 2`] = `
 
 exports[`Message can render a title 1`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--alert-inner o-message--neutral"
+  <div class="o-message o-message--inner o-message--alert o-message--neutral"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -207,7 +207,7 @@ exports[`Message can render a title 1`] = `
 
 exports[`Message can render a title 2`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--alert-inner o-message--neutral"
+  <div class="o-message o-message--inner o-message--alert o-message--neutral"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -228,7 +228,7 @@ exports[`Message can render a title 2`] = `
 
 exports[`Message can render additional information 1`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--alert-inner o-message--neutral"
+  <div class="o-message o-message--inner o-message--alert o-message--neutral"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -258,7 +258,7 @@ exports[`Message can render additional information 1`] = `
 
 exports[`Message can render additional information 2`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--alert-inner o-message--neutral"
+  <div class="o-message o-message--inner o-message--alert o-message--neutral"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -288,7 +288,7 @@ exports[`Message can render additional information 2`] = `
 
 exports[`Message can render some actions as primary 1`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--alert-inner o-message--neutral"
+  <div class="o-message o-message--inner o-message--alert o-message--neutral"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -316,7 +316,7 @@ exports[`Message can render some actions as primary 1`] = `
 
 exports[`Message can render some actions as primary 2`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--alert-inner o-message--neutral"
+  <div class="o-message o-message--inner o-message--alert o-message--neutral"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -344,7 +344,7 @@ exports[`Message can render some actions as primary 2`] = `
 
 exports[`Message can render some actions as secondary 1`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--alert-inner o-message--neutral"
+  <div class="o-message o-message--inner o-message--alert o-message--neutral"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -372,7 +372,7 @@ exports[`Message can render some actions as secondary 1`] = `
 
 exports[`Message can render some actions as secondary 2`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--alert-inner o-message--neutral"
+  <div class="o-message o-message--inner o-message--alert o-message--neutral"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -400,7 +400,7 @@ exports[`Message can render some actions as secondary 2`] = `
 
 exports[`Message render a message 1`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--alert-inner o-message--neutral"
+  <div class="o-message o-message--inner o-message--alert o-message--neutral"
        data-o-component="o-message"
   >
     <div class="o-message__container">
@@ -418,7 +418,7 @@ exports[`Message render a message 1`] = `
 
 exports[`Message render a message 2`] = `
 <div class="ncf__message o-forms o-forms--wide">
-  <div class="o-message o-message--alert-inner o-message--neutral"
+  <div class="o-message o-message--inner o-message--alert o-message--neutral"
        data-o-component="o-message"
   >
     <div class="o-message__container">

--- a/components/message.jsx
+++ b/components/message.jsx
@@ -10,8 +10,9 @@ export function Message ({ title, message, additional = [], actions = null, name
 
 	const oMessageClassNames = classNames({
 		'o-message': true,
-		'o-message--notice-inner': isNotice,
-		'o-message--alert-inner': !isNotice,
+		'o-message--inner': true,
+		'o-message--notice': isNotice,
+		'o-message--alert': !isNotice,
 		'o-message--error': isError,
 		'o-message--success': !isError && isSuccess,
 		'o-message--inform': !isError && !isSuccess && isInform,

--- a/partials/message.html
+++ b/partials/message.html
@@ -1,5 +1,5 @@
 <div class="ncf__message o-forms o-forms--wide{{#if isHidden}} n-ui-hide{{/if}}"{{#if name}} data-message-name="{{name}}"{{/if}}>
-	<div class="o-message {{#if isNotice}}o-message--notice-inner{{else}}o-message--alert-inner{{/if}}{{#if isError}} o-message--error{{else if isSuccess}} o-message--success{{else if isInform}} o-message--inform{{else}} o-message--neutral{{/if}}" data-o-component="o-message">
+	<div class="o-message o-message--inner {{#if isNotice}}o-message--notice{{else}}o-message--alert{{/if}}{{#if isError}} o-message--error{{else if isSuccess}} o-message--success{{else if isInform}} o-message--inform{{else}} o-message--neutral{{/if}}" data-o-component="o-message">
 		<div class="o-message__container">
 			<div class="o-message__content">
 				<p class="o-message__content-main">

--- a/test/partials/message.spec.js
+++ b/test/partials/message.spec.js
@@ -1,8 +1,8 @@
 const { expect } = require('chai');
 const { fetchPartial } = require('../helpers');
 
-const CLASS_ALERT = 'o-message--alert-inner';
-const CLASS_NOTICE = 'o-message--notice-inner';
+const CLASS_ALERT = 'o-message--alert';
+const CLASS_NOTICE = 'o-message--notice';
 const CLASS_ERROR = 'o-message--error';
 const CLASS_ACTIONS_PRIMARY = 'o-message__actions__primary';
 const CLASS_ACTIONS_SECONDARY = 'o-message__actions__secondary';


### PR DESCRIPTION
### Description
Main change was that we now use a separate `n-message--inner` class for the "inner" layout.

### Disclaimer
We expect the build to fail on this one, as there are other dependencies that need upgrading. Once all our changes are merged into the `origami-major-upgrade` feature branch, we should have a build that passes.