### PR TITLE
fix: use 0 (zero) instead of mixin for spacing.

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -149,7 +149,7 @@
 
 			&:after {
 				padding-top: oSpacingByName('s3');
-				padding-bottom: oSpacingByName('s0');
+				padding-bottom: 0;
 				content: '';
 				display: block;
 				width: 90px;


### PR DESCRIPTION
We were using `oSpacingByName` with "s0" as the size, but that size doesn't exist, so we were getting Sass compilation errors.