### PR TITLE
Upgrade o-forms from v6 to v8

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,7 @@
     "o-header-services": "^4.0.0"
   },
   "dependencies": {
-    "o-forms": "^6.0.0",
+    "o-forms": "^8.0.0",
     "n-ui-foundations": "^3.0.1",
     "o-buttons": "^6.0.2",
     "o-message": "^4.0.0",

--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -2,2300 +2,2346 @@
 
 exports[`AcceptTerms renders appropriately if a registration 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="register-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a registration 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="register-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-      <a class="ncf__link--external"
-         href="https://help.ft.com/help/contact-us/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        customer service through chat, phone or email
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-    </p>
-    <p class="terms-signup">
-      Find out more about our cancellation policy in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
+          <a class="ncf__link--external"
+             href="https://help.ft.com/help/contact-us/"
+             target="_blank"
+             rel="noopener"
+          >
+            customer service through chat, phone or email
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
+        </p>
+        <p class="terms-signup">
+          Find out more about our cancellation policy in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-      <a class="ncf__link--external"
-         href="https://help.ft.com/help/contact-us/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        customer service through chat, phone or email
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-    </p>
-    <p class="terms-signup">
-      Find out more about our cancellation policy in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
+          <a class="ncf__link--external"
+             href="https://help.ft.com/help/contact-us/"
+             target="_blank"
+             rel="noopener"
+          >
+            customer service through chat, phone or email
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
+        </p>
+        <p class="terms-signup">
+          Find out more about our cancellation policy in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup and has special terms 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-      <a class="ncf__link--external"
-         href="https://help.ft.com/help/contact-us/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        customer service through chat, phone or email
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-    </p>
-    <p class="terms-signup">
-      Find out more about our cancellation policy in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p id="terms-special">
-      Special terms text
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
+          <a class="ncf__link--external"
+             href="https://help.ft.com/help/contact-us/"
+             target="_blank"
+             rel="noopener"
+          >
+            customer service through chat, phone or email
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
+        </p>
+        <p class="terms-signup">
+          Find out more about our cancellation policy in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p id="terms-special">
+          Special terms text
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup and has special terms 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-      <a class="ncf__link--external"
-         href="https://help.ft.com/help/contact-us/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        customer service through chat, phone or email
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-    </p>
-    <p class="terms-signup">
-      Find out more about our cancellation policy in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p id="terms-special">
-      Special terms text
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
+          <a class="ncf__link--external"
+             href="https://help.ft.com/help/contact-us/"
+             target="_blank"
+             rel="noopener"
+          >
+            customer service through chat, phone or email
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
+        </p>
+        <p class="terms-signup">
+          Find out more about our cancellation policy in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p id="terms-special">
+          Special terms text
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup for the print product 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-print">
-      Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
-    </p>
-    <p class="terms-print">
-      Find out more about your delivery start date in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-print">
+          Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
+        </p>
+        <p class="terms-print">
+          Find out more about your delivery start date in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup for the print product 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-print">
-      Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
-    </p>
-    <p class="terms-print">
-      Find out more about your delivery start date in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-print">
+          Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
+        </p>
+        <p class="terms-print">
+          Find out more about your delivery start date in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup for the print product and is embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_top"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-print">
-      Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
-    </p>
-    <p class="terms-print">
-      Find out more about your delivery start date in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_top"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_top"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-print">
+          Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
+        </p>
+        <p class="terms-print">
+          Find out more about your delivery start date in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_top"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup for the print product and is embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_top"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-print">
-      Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
-    </p>
-    <p class="terms-print">
-      Find out more about your delivery start date in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_top"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_top"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-print">
+          Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
+        </p>
+        <p class="terms-print">
+          Find out more about your delivery start date in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_top"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup for the print product and is not embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-print">
-      Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
-    </p>
-    <p class="terms-print">
-      Find out more about your delivery start date in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-print">
+          Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
+        </p>
+        <p class="terms-print">
+          Find out more about your delivery start date in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup for the print product and is not embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-print">
-      Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
-    </p>
-    <p class="terms-print">
-      Find out more about your delivery start date in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-print">
+          Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
+        </p>
+        <p class="terms-print">
+          Find out more about your delivery start date in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-      <a class="ncf__link--external"
-         href="https://help.ft.com/help/contact-us/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        customer service through chat, phone or email
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-    </p>
-    <p class="terms-signup">
-      Find out more about our cancellation policy in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
+          <a class="ncf__link--external"
+             href="https://help.ft.com/help/contact-us/"
+             target="_blank"
+             rel="noopener"
+          >
+            customer service through chat, phone or email
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
+        </p>
+        <p class="terms-signup">
+          Find out more about our cancellation policy in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-      <a class="ncf__link--external"
-         href="https://help.ft.com/help/contact-us/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        customer service through chat, phone or email
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-    </p>
-    <p class="terms-signup">
-      Find out more about our cancellation policy in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
+          <a class="ncf__link--external"
+             href="https://help.ft.com/help/contact-us/"
+             target="_blank"
+             rel="noopener"
+          >
+            customer service through chat, phone or email
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
+        </p>
+        <p class="terms-signup">
+          Find out more about our cancellation policy in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product and is embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_top"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-      <a class="ncf__link--external"
-         href="https://help.ft.com/help/contact-us/"
-         target="_top"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        customer service through chat, phone or email
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-    </p>
-    <p class="terms-signup">
-      Find out more about our cancellation policy in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_top"
-         rel="noopener"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_top"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
+          <a class="ncf__link--external"
+             href="https://help.ft.com/help/contact-us/"
+             target="_top"
+             rel="noopener"
+          >
+            customer service through chat, phone or email
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
+        </p>
+        <p class="terms-signup">
+          Find out more about our cancellation policy in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_top"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product and is embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_top"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-      <a class="ncf__link--external"
-         href="https://help.ft.com/help/contact-us/"
-         target="_top"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        customer service through chat, phone or email
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-    </p>
-    <p class="terms-signup">
-      Find out more about our cancellation policy in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_top"
-         rel="noopener"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_top"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
+          <a class="ncf__link--external"
+             href="https://help.ft.com/help/contact-us/"
+             target="_top"
+             rel="noopener"
+          >
+            customer service through chat, phone or email
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
+        </p>
+        <p class="terms-signup">
+          Find out more about our cancellation policy in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_top"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product and is not embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-      <a class="ncf__link--external"
-         href="https://help.ft.com/help/contact-us/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        customer service through chat, phone or email
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-    </p>
-    <p class="terms-signup">
-      Find out more about our cancellation policy in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
+          <a class="ncf__link--external"
+             href="https://help.ft.com/help/contact-us/"
+             target="_blank"
+             rel="noopener"
+          >
+            customer service through chat, phone or email
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
+        </p>
+        <p class="terms-signup">
+          Find out more about our cancellation policy in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product and is not embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-      <a class="ncf__link--external"
-         href="https://help.ft.com/help/contact-us/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        customer service through chat, phone or email
-      </a>
-      .
-    </p>
-    <p class="terms-signup">
-      By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-    </p>
-    <p class="terms-signup">
-      Find out more about our cancellation policy in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
+          <a class="ncf__link--external"
+             href="https://help.ft.com/help/contact-us/"
+             target="_blank"
+             rel="noopener"
+          >
+            customer service through chat, phone or email
+          </a>
+          .
+        </p>
+        <p class="terms-signup">
+          By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
+        </p>
+        <p class="terms-signup">
+          Find out more about our cancellation policy in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if input is checked 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-         checked
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+             checked
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if input is checked 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-         checked
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+             checked
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is B2B 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-b2b">
-      By submitting this form, you indicate your consent to also being contacted by Financial Times by email, post, or phone about our other products, services or special offers unless you untick this box.
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-b2b">
+          By submitting this form, you indicate your consent to also being contacted by Financial Times by email, post, or phone about our other products, services or special offers unless you untick this box.
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is B2B 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-b2b">
-      By submitting this form, you indicate your consent to also being contacted by Financial Times by email, post, or phone about our other products, services or special offers unless you untick this box.
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-b2b">
+          By submitting this form, you indicate your consent to also being contacted by Financial Times by email, post, or phone about our other products, services or special offers unless you untick this box.
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is corporate signup 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-corp-signup">
-      Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
-    </p>
-    <p class="terms-corp-signup">
-      Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
-    </p>
-    <p class="terms-corp-signup">
-      myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-corp-signup">
+          Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
+        </p>
+        <p class="terms-corp-signup">
+          Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
+        </p>
+        <p class="terms-corp-signup">
+          myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is corporate signup 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-corp-signup">
-      Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
-    </p>
-    <p class="terms-corp-signup">
-      Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
-    </p>
-    <p class="terms-corp-signup">
-      myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-corp-signup">
+          Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
+        </p>
+        <p class="terms-corp-signup">
+          Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
+        </p>
+        <p class="terms-corp-signup">
+          myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is corporate signup and not trial 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-corp-signup">
-      Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
-    </p>
-    <p class="terms-corp-signup">
-      Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
-    </p>
-    <p class="terms-corp-signup">
-      myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-corp-signup">
+          Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
+        </p>
+        <p class="terms-corp-signup">
+          Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
+        </p>
+        <p class="terms-corp-signup">
+          myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is corporate signup and not trial 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-corp-signup">
-      Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
-    </p>
-    <p class="terms-corp-signup">
-      Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
-    </p>
-    <p class="terms-corp-signup">
-      myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-corp-signup">
+          Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
+        </p>
+        <p class="terms-corp-signup">
+          Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
+        </p>
+        <p class="terms-corp-signup">
+          myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is corporate signup and trial 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-corp-signup">
-      Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
-    </p>
-    <p class="terms-corp-signup">
-      Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
-    </p>
-    <p class="terms-corp-signup">
-      myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
-    </p>
-    <p class="terms-corp-signup">
-      This trial is to demonstrate the value of a group subscription and we’ll contact you during your trial.
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-corp-signup">
+          Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
+        </p>
+        <p class="terms-corp-signup">
+          Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
+        </p>
+        <p class="terms-corp-signup">
+          myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
+        </p>
+        <p class="terms-corp-signup">
+          This trial is to demonstrate the value of a group subscription and we’ll contact you during your trial.
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is corporate signup and trial 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-corp-signup">
-      Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
-    </p>
-    <p class="terms-corp-signup">
-      Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
-    </p>
-    <p class="terms-corp-signup">
-      myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
-    </p>
-    <p class="terms-corp-signup">
-      This trial is to demonstrate the value of a group subscription and we’ll contact you during your trial.
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-corp-signup">
+          Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
+        </p>
+        <p class="terms-corp-signup">
+          Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
+        </p>
+        <p class="terms-corp-signup">
+          myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
+        </p>
+        <p class="terms-corp-signup">
+          This trial is to demonstrate the value of a group subscription and we’ll contact you during your trial.
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and custom age restriction is provided 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 21 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 21 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and custom age restriction is provided 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 21 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 21 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and is embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_top"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_top"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and is embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_top"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_top"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and is not embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and is not embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is transition 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-transition">
-      I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-      <a class="ncf__link--external"
-         href="https://help.ft.com/help/contact-us/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        customer service through chat, phone or email
-      </a>
-      .
-    </p>
-    <p class="terms-transition  terms-transition--other">
-      By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.
-    </p>
-    <p class="terms-transition">
-      Find out more about our cancellation policy in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-transition">
+          I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
+          <a class="ncf__link--external"
+             href="https://help.ft.com/help/contact-us/"
+             target="_blank"
+             rel="noopener"
+          >
+            customer service through chat, phone or email
+          </a>
+          .
+        </p>
+        <p class="terms-transition  terms-transition--other">
+          By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.
+        </p>
+        <p class="terms-transition">
+          Find out more about our cancellation policy in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is transition 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-transition">
-      I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-      <a class="ncf__link--external"
-         href="https://help.ft.com/help/contact-us/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        customer service through chat, phone or email
-      </a>
-      .
-    </p>
-    <p class="terms-transition  terms-transition--other">
-      By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.
-    </p>
-    <p class="terms-transition">
-      Find out more about our cancellation policy in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-transition">
+          I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
+          <a class="ncf__link--external"
+             href="https://help.ft.com/help/contact-us/"
+             target="_blank"
+             rel="noopener"
+          >
+            customer service through chat, phone or email
+          </a>
+          .
+        </p>
+        <p class="terms-transition  terms-transition--other">
+          By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.
+        </p>
+        <p class="terms-transition">
+          Find out more about our cancellation policy in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is transition with transition type of immediate 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-transition">
-      I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-      <a class="ncf__link--external"
-         href="https://help.ft.com/help/contact-us/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        customer service through chat, phone or email
-      </a>
-      .
-    </p>
-    <p class="terms-transition terms-transition--immediate">
-      By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-    </p>
-    <p class="terms-transition">
-      Find out more about our cancellation policy in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-transition">
+          I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
+          <a class="ncf__link--external"
+             href="https://help.ft.com/help/contact-us/"
+             target="_blank"
+             rel="noopener"
+          >
+            customer service through chat, phone or email
+          </a>
+          .
+        </p>
+        <p class="terms-transition terms-transition--immediate">
+          By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
+        </p>
+        <p class="terms-transition">
+          Find out more about our cancellation policy in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is transition with transition type of immediate 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-transition">
-      I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-      <a class="ncf__link--external"
-         href="https://help.ft.com/help/contact-us/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        customer service through chat, phone or email
-      </a>
-      .
-    </p>
-    <p class="terms-transition terms-transition--immediate">
-      By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-    </p>
-    <p class="terms-transition">
-      Find out more about our cancellation policy in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-transition">
+          I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
+          <a class="ncf__link--external"
+             href="https://help.ft.com/help/contact-us/"
+             target="_blank"
+             rel="noopener"
+          >
+            customer service through chat, phone or email
+          </a>
+          .
+        </p>
+        <p class="terms-transition terms-transition--immediate">
+          By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
+        </p>
+        <p class="terms-transition">
+          Find out more about our cancellation policy in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is transition with transition type other than immediate 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-transition">
-      I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-      <a class="ncf__link--external"
-         href="https://help.ft.com/help/contact-us/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        customer service through chat, phone or email
-      </a>
-      .
-    </p>
-    <p class="terms-transition  terms-transition--other">
-      By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.
-    </p>
-    <p class="terms-transition">
-      Find out more about our cancellation policy in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-transition">
+          I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
+          <a class="ncf__link--external"
+             href="https://help.ft.com/help/contact-us/"
+             target="_blank"
+             rel="noopener"
+          >
+            customer service through chat, phone or email
+          </a>
+          .
+        </p>
+        <p class="terms-transition  terms-transition--other">
+          By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.
+        </p>
+        <p class="terms-transition">
+          Find out more about our cancellation policy in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is transition with transition type other than immediate 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-    <p class="terms-transition">
-      I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-      <a class="ncf__link--external"
-         href="https://help.ft.com/help/contact-us/"
-         target="_blank"
-         rel="noopener"
+      <span class="o-forms-input__label"
+            aria-hidden="true"
       >
-        customer service through chat, phone or email
-      </a>
-      .
-    </p>
-    <p class="terms-transition  terms-transition--other">
-      By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.
-    </p>
-    <p class="terms-transition">
-      Find out more about our cancellation policy in our
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+        <p class="terms-transition">
+          I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
+          <a class="ncf__link--external"
+             href="https://help.ft.com/help/contact-us/"
+             target="_blank"
+             rel="noopener"
+          >
+            customer service through chat, phone or email
+          </a>
+          .
+        </p>
+        <p class="terms-transition  terms-transition--other">
+          By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.
+        </p>
+        <p class="terms-transition">
+          Find out more about our cancellation policy in our
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders with an error 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox o-forms-input--invalid">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders with an error 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox o-forms-input--invalid">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders with default props 1`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders with default props 2`] = `
 <div id="acceptTermsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="multi"
-     data-ui-item-name="acceptTerms"
+     class="o-forms-field"
      data-validate="required,checked"
 >
-  <input type="checkbox"
-         id="termsAcceptance"
-         name="termsAcceptance"
-         value="true"
-         class="o-forms__checkbox js-item__value js-field__input"
-         data-trackable="field-terms"
-         aria-required="true"
-         required
-  >
-  <label for="termsAcceptance"
-         class="o-forms__label ncf__terms"
-  >
-    <p id="terms-default">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener"
-         data-trackable="terms-and-conditions"
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label>
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
       >
-        Terms &amp; Conditions
-      </a>
-      .
-    </p>
-  </label>
-  <div class="o-forms__errortext">
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        <p id="terms-default">
+          I confirm I am 16 years or older and have read and agree to the
+          <a class="ncf__link--external"
+             href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+             target="_blank"
+             rel="noopener"
+             data-trackable="terms-and-conditions"
+          >
+            Terms &amp; Conditions
+          </a>
+          .
+        </p>
+      </span>
+    </label>
+  </span>
+  <span class="o-forms-input__error">
     Please accept our terms &amp; conditions
-  </div>
+  </span>
 </div>
 `;

--- a/components/__snapshots__/billing-country.spec.js.snap
+++ b/components/__snapshots__/billing-country.spec.js.snap
@@ -1,6645 +1,6633 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Country renders with default props 1`] = `
-<div id="billingCountryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="billingCountry"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="billingCountryField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingCountry"
-         class="o-forms__label"
-  >
-    Billing Country
-  </label>
-  <select id="billingCountry"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="billingCountry"
-          data-trackable="field-billing-country"
-  >
-    <option value
-            disabled
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="billingCountry"
+            class="js-field__input js-item__value"
+            aria-required="true"
+            required
+            name="billingCountry"
+            data-trackable="field-billing-country"
     >
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
-    Please select your country
-  </div>
-</div>
+      <option value
+              disabled
+      >
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+    <span class="o-forms-input__error">
+      Please select your country
+    </span>
+  </span>
+</label>
 `;
 
 exports[`Country renders with default props 2`] = `
-<div id="billingCountryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="billingCountry"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="billingCountryField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingCountry"
-         class="o-forms__label"
-  >
-    Billing Country
-  </label>
-  <select id="billingCountry"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="billingCountry"
-          data-trackable="field-billing-country"
-  >
-    <option value
-            disabled
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="billingCountry"
+            class="js-field__input js-item__value"
+            aria-required="true"
+            required
+            name="billingCountry"
+            data-trackable="field-billing-country"
     >
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
-    Please select your country
-  </div>
-</div>
+      <option value
+              disabled
+      >
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+    <span class="o-forms-input__error">
+      Please select your country
+    </span>
+  </span>
+</label>
 `;
 
 exports[`Country renders with hasError 1`] = `
-<div id="billingCountryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field o-forms--error"
-     data-ui-item="select"
-     data-ui-item-name="billingCountry"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="billingCountryField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingCountry"
-         class="o-forms__label"
-  >
-    Billing Country
-  </label>
-  <select id="billingCountry"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="billingCountry"
-          data-trackable="field-billing-country"
-  >
-    <option value
-            disabled
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select o-forms-input--invalid">
+    <select id="billingCountry"
+            class="js-field__input js-item__value"
+            aria-required="true"
+            required
+            name="billingCountry"
+            data-trackable="field-billing-country"
     >
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
-    Please select your country
-  </div>
-</div>
+      <option value
+              disabled
+      >
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+    <span class="o-forms-input__error">
+      Please select your country
+    </span>
+  </span>
+</label>
 `;
 
 exports[`Country renders with hasError 2`] = `
-<div id="billingCountryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field o-forms--error"
-     data-ui-item="select"
-     data-ui-item-name="billingCountry"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="billingCountryField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingCountry"
-         class="o-forms__label"
-  >
-    Billing Country
-  </label>
-  <select id="billingCountry"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="billingCountry"
-          data-trackable="field-billing-country"
-  >
-    <option value
-            disabled
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select o-forms-input--invalid">
+    <select id="billingCountry"
+            class="js-field__input js-item__value"
+            aria-required="true"
+            required
+            name="billingCountry"
+            data-trackable="field-billing-country"
     >
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
-    Please select your country
-  </div>
-</div>
+      <option value
+              disabled
+      >
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+    <span class="o-forms-input__error">
+      Please select your country
+    </span>
+  </span>
+</label>
 `;
 
 exports[`Country renders with isDisabled 1`] = `
-<div id="billingCountryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="billingCountry"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="billingCountryField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingCountry"
-         class="o-forms__label"
-  >
-    Billing Country
-  </label>
-  <select id="billingCountry"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="billingCountry"
-          data-trackable="field-billing-country"
-          disabled
-  >
-    <option value
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="billingCountry"
+            class="js-field__input js-item__value"
+            aria-required="true"
+            required
+            name="billingCountry"
+            data-trackable="field-billing-country"
             disabled
     >
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
-    Please select your country
-  </div>
-</div>
+      <option value
+              disabled
+      >
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+    <span class="o-forms-input__error">
+      Please select your country
+    </span>
+  </span>
+</label>
 `;
 
 exports[`Country renders with isDisabled 2`] = `
-<div id="billingCountryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="billingCountry"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="billingCountryField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingCountry"
-         class="o-forms__label"
-  >
-    Billing Country
-  </label>
-  <select id="billingCountry"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="billingCountry"
-          data-trackable="field-billing-country"
-          disabled
-  >
-    <option value
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="billingCountry"
+            class="js-field__input js-item__value"
+            aria-required="true"
+            required
+            name="billingCountry"
+            data-trackable="field-billing-country"
             disabled
     >
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
-    Please select your country
-  </div>
-</div>
+      <option value
+              disabled
+      >
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+    <span class="o-forms-input__error">
+      Please select your country
+    </span>
+  </span>
+</label>
 `;
 
 exports[`Country renders with large filterList 1`] = `
-<div id="billingCountryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="billingCountry"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="billingCountryField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingCountry"
-         class="o-forms__label"
-  >
-    Billing Country
-  </label>
-  <select id="billingCountry"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="billingCountry"
-          data-trackable="field-billing-country"
-  >
-    <option value
-            disabled
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="billingCountry"
+            class="js-field__input js-item__value"
+            aria-required="true"
+            required
+            name="billingCountry"
+            data-trackable="field-billing-country"
     >
-      Please select a country
-    </option>
-    <option value="AFG">
-      Afghanistan
-    </option>
-    <option value="ALA">
-      Aland Islands
-    </option>
-    <option value="ALB">
-      Albania
-    </option>
-    <option value="DZA">
-      Algeria
-    </option>
-    <option value="ASM">
-      American Samoa
-    </option>
-    <option value="AND">
-      Andorra
-    </option>
-    <option value="AGO">
-      Angola
-    </option>
-    <option value="AIA">
-      Anguilla
-    </option>
-    <option value="ATA">
-      Antarctica
-    </option>
-    <option value="ATG">
-      Antigua And Barbuda
-    </option>
-    <option value="ARG">
-      Argentina
-    </option>
-    <option value="ARM">
-      Armenia
-    </option>
-    <option value="ABW">
-      Aruba
-    </option>
-    <option value="AUS">
-      Australia
-    </option>
-    <option value="AUT">
-      Austria
-    </option>
-    <option value="AZE">
-      Azerbaijan
-    </option>
-    <option value="BHS">
-      Bahamas
-    </option>
-    <option value="BHR">
-      Bahrain
-    </option>
-    <option value="BGD">
-      Bangladesh
-    </option>
-    <option value="BRB">
-      Barbados
-    </option>
-  </select>
-  <div class="o-forms__errortext">
-    Please select your country
-  </div>
-</div>
+      <option value
+              disabled
+      >
+        Please select a country
+      </option>
+      <option value="AFG">
+        Afghanistan
+      </option>
+      <option value="ALA">
+        Aland Islands
+      </option>
+      <option value="ALB">
+        Albania
+      </option>
+      <option value="DZA">
+        Algeria
+      </option>
+      <option value="ASM">
+        American Samoa
+      </option>
+      <option value="AND">
+        Andorra
+      </option>
+      <option value="AGO">
+        Angola
+      </option>
+      <option value="AIA">
+        Anguilla
+      </option>
+      <option value="ATA">
+        Antarctica
+      </option>
+      <option value="ATG">
+        Antigua And Barbuda
+      </option>
+      <option value="ARG">
+        Argentina
+      </option>
+      <option value="ARM">
+        Armenia
+      </option>
+      <option value="ABW">
+        Aruba
+      </option>
+      <option value="AUS">
+        Australia
+      </option>
+      <option value="AUT">
+        Austria
+      </option>
+      <option value="AZE">
+        Azerbaijan
+      </option>
+      <option value="BHS">
+        Bahamas
+      </option>
+      <option value="BHR">
+        Bahrain
+      </option>
+      <option value="BGD">
+        Bangladesh
+      </option>
+      <option value="BRB">
+        Barbados
+      </option>
+    </select>
+    <span class="o-forms-input__error">
+      Please select your country
+    </span>
+  </span>
+</label>
 `;
 
 exports[`Country renders with large filterList 2`] = `
-<div id="billingCountryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="billingCountry"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="billingCountryField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingCountry"
-         class="o-forms__label"
-  >
-    Billing Country
-  </label>
-  <select id="billingCountry"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="billingCountry"
-          data-trackable="field-billing-country"
-  >
-    <option value
-            disabled
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="billingCountry"
+            class="js-field__input js-item__value"
+            aria-required="true"
+            required
+            name="billingCountry"
+            data-trackable="field-billing-country"
     >
-      Please select a country
-    </option>
-    <option value="AFG">
-      Afghanistan
-    </option>
-    <option value="ALA">
-      Aland Islands
-    </option>
-    <option value="ALB">
-      Albania
-    </option>
-    <option value="DZA">
-      Algeria
-    </option>
-    <option value="ASM">
-      American Samoa
-    </option>
-    <option value="AND">
-      Andorra
-    </option>
-    <option value="AGO">
-      Angola
-    </option>
-    <option value="AIA">
-      Anguilla
-    </option>
-    <option value="ATA">
-      Antarctica
-    </option>
-    <option value="ATG">
-      Antigua And Barbuda
-    </option>
-    <option value="ARG">
-      Argentina
-    </option>
-    <option value="ARM">
-      Armenia
-    </option>
-    <option value="ABW">
-      Aruba
-    </option>
-    <option value="AUS">
-      Australia
-    </option>
-    <option value="AUT">
-      Austria
-    </option>
-    <option value="AZE">
-      Azerbaijan
-    </option>
-    <option value="BHS">
-      Bahamas
-    </option>
-    <option value="BHR">
-      Bahrain
-    </option>
-    <option value="BGD">
-      Bangladesh
-    </option>
-    <option value="BRB">
-      Barbados
-    </option>
-  </select>
-  <div class="o-forms__errortext">
-    Please select your country
-  </div>
-</div>
+      <option value
+              disabled
+      >
+        Please select a country
+      </option>
+      <option value="AFG">
+        Afghanistan
+      </option>
+      <option value="ALA">
+        Aland Islands
+      </option>
+      <option value="ALB">
+        Albania
+      </option>
+      <option value="DZA">
+        Algeria
+      </option>
+      <option value="ASM">
+        American Samoa
+      </option>
+      <option value="AND">
+        Andorra
+      </option>
+      <option value="AGO">
+        Angola
+      </option>
+      <option value="AIA">
+        Anguilla
+      </option>
+      <option value="ATA">
+        Antarctica
+      </option>
+      <option value="ATG">
+        Antigua And Barbuda
+      </option>
+      <option value="ARG">
+        Argentina
+      </option>
+      <option value="ARM">
+        Armenia
+      </option>
+      <option value="ABW">
+        Aruba
+      </option>
+      <option value="AUS">
+        Australia
+      </option>
+      <option value="AUT">
+        Austria
+      </option>
+      <option value="AZE">
+        Azerbaijan
+      </option>
+      <option value="BHS">
+        Bahamas
+      </option>
+      <option value="BHR">
+        Bahrain
+      </option>
+      <option value="BGD">
+        Bangladesh
+      </option>
+      <option value="BRB">
+        Barbados
+      </option>
+    </select>
+    <span class="o-forms-input__error">
+      Please select your country
+    </span>
+  </span>
+</label>
 `;
 
 exports[`Country renders with small filterList 1`] = `
-<div id="billingCountryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="billingCountry"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="billingCountryField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingCountry"
-         class="o-forms__label"
-  >
-    Billing Country
-  </label>
-  <select id="billingCountry"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="billingCountry"
-          data-trackable="field-billing-country"
-  >
-    <option value
-            disabled
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="billingCountry"
+            class="js-field__input js-item__value"
+            aria-required="true"
+            required
+            name="billingCountry"
+            data-trackable="field-billing-country"
     >
-      Please select a country
-    </option>
-    <option value="GBR">
-      United Kingdom
-    </option>
-  </select>
-  <div class="o-forms__errortext">
-    Please select your country
-  </div>
-</div>
+      <option value
+              disabled
+      >
+        Please select a country
+      </option>
+      <option value="GBR">
+        United Kingdom
+      </option>
+    </select>
+    <span class="o-forms-input__error">
+      Please select your country
+    </span>
+  </span>
+</label>
 `;
 
 exports[`Country renders with small filterList 2`] = `
-<div id="billingCountryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="billingCountry"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="billingCountryField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingCountry"
-         class="o-forms__label"
-  >
-    Billing Country
-  </label>
-  <select id="billingCountry"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="billingCountry"
-          data-trackable="field-billing-country"
-  >
-    <option value
-            disabled
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="billingCountry"
+            class="js-field__input js-item__value"
+            aria-required="true"
+            required
+            name="billingCountry"
+            data-trackable="field-billing-country"
     >
-      Please select a country
-    </option>
-    <option value="GBR">
-      United Kingdom
-    </option>
-  </select>
-  <div class="o-forms__errortext">
-    Please select your country
-  </div>
-</div>
+      <option value
+              disabled
+      >
+        Please select a country
+      </option>
+      <option value="GBR">
+        United Kingdom
+      </option>
+    </select>
+    <span class="o-forms-input__error">
+      Please select your country
+    </span>
+  </span>
+</label>
 `;
 
 exports[`Country renders with value 1`] = `
-<div id="billingCountryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="billingCountry"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="billingCountryField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingCountry"
-         class="o-forms__label"
-  >
-    Billing Country
-  </label>
-  <select id="billingCountry"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="billingCountry"
-          data-trackable="field-billing-country"
-  >
-    <option value
-            disabled
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="billingCountry"
+            class="js-field__input js-item__value"
+            aria-required="true"
+            required
+            name="billingCountry"
+            data-trackable="field-billing-country"
     >
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR"
-              selected
+      <option value
+              disabled
       >
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
-    Please select your country
-  </div>
-</div>
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR"
+                selected
+        >
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+    <span class="o-forms-input__error">
+      Please select your country
+    </span>
+  </span>
+</label>
 `;
 
 exports[`Country renders with value 2`] = `
-<div id="billingCountryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="billingCountry"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="billingCountryField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingCountry"
-         class="o-forms__label"
-  >
-    Billing Country
-  </label>
-  <select id="billingCountry"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="billingCountry"
-          data-trackable="field-billing-country"
-  >
-    <option value
-            disabled
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="billingCountry"
+            class="js-field__input js-item__value"
+            aria-required="true"
+            required
+            name="billingCountry"
+            data-trackable="field-billing-country"
     >
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR"
-              selected
+      <option value
+              disabled
       >
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
-    Please select your country
-  </div>
-</div>
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR"
+                selected
+        >
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+    <span class="o-forms-input__error">
+      Please select your country
+    </span>
+  </span>
+</label>
 `;

--- a/components/__snapshots__/billing-postcode.spec.js.snap
+++ b/components/__snapshots__/billing-postcode.spec.js.snap
@@ -1,365 +1,355 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Billing Postcode can render a disable input 1`] = `
-<div id="billingPostcodeField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryPostcode"
-     data-validate="required"
+<label id="billingPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingPostcode"
-         class="o-forms__label"
-  >
-    Billing
-    <span data-reference="postcode">
-      ZipCode
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing
+      <span data-reference="postcode">
+        ZipCode
+      </span>
     </span>
-  </label>
-  <input type="text"
-         id="billingPostcode"
-         name="billingPostcode"
-         placeholder="Enter your ZipCode"
-         autocomplete="postal-code"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="billing-postcode"
-         aria-required="true"
-         required
-         disabled
-         value
-  >
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="billingPostcode"
+           name="billingPostcode"
+           placeholder="Enter your ZipCode"
+           autocomplete="postal-code"
+           data-trackable="billing-postcode"
+           aria-required="true"
+           required
+           disabled
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter a valid
     <span data-reference="postcode">
       ZipCode
     </span>
     .
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Billing Postcode can render a disable input 2`] = `
-<div id="billingPostcodeField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryPostcode"
-     data-validate="required"
+<label id="billingPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingPostcode"
-         class="o-forms__label"
-  >
-    Billing
-    <span data-reference="postcode">
-      ZipCode
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing
+      <span data-reference="postcode">
+        ZipCode
+      </span>
     </span>
-  </label>
-  <input type="text"
-         id="billingPostcode"
-         name="billingPostcode"
-         placeholder="Enter your ZipCode"
-         autocomplete="postal-code"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="billing-postcode"
-         aria-required="true"
-         required
-         disabled
-         value
-  >
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="billingPostcode"
+           name="billingPostcode"
+           placeholder="Enter your ZipCode"
+           autocomplete="postal-code"
+           data-trackable="billing-postcode"
+           aria-required="true"
+           required
+           disabled
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter a valid
     <span data-reference="postcode">
       ZipCode
     </span>
     .
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Billing Postcode can render a pattern attribute 1`] = `
-<div id="billingPostcodeField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryPostcode"
-     data-validate="required"
+<label id="billingPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingPostcode"
-         class="o-forms__label"
-  >
-    Billing
-    <span data-reference="postcode">
-      ZipCode
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing
+      <span data-reference="postcode">
+        ZipCode
+      </span>
     </span>
-  </label>
-  <input type="text"
-         id="billingPostcode"
-         name="billingPostcode"
-         placeholder="Enter your ZipCode"
-         autocomplete="postal-code"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="billing-postcode"
-         aria-required="true"
-         required
-         pattern="Whatever"
-         value
-  >
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="billingPostcode"
+           name="billingPostcode"
+           placeholder="Enter your ZipCode"
+           autocomplete="postal-code"
+           data-trackable="billing-postcode"
+           aria-required="true"
+           required
+           pattern="Whatever"
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter a valid
     <span data-reference="postcode">
       ZipCode
     </span>
     .
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Billing Postcode can render a pattern attribute 2`] = `
-<div id="billingPostcodeField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryPostcode"
-     data-validate="required"
+<label id="billingPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingPostcode"
-         class="o-forms__label"
-  >
-    Billing
-    <span data-reference="postcode">
-      ZipCode
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing
+      <span data-reference="postcode">
+        ZipCode
+      </span>
     </span>
-  </label>
-  <input type="text"
-         id="billingPostcode"
-         name="billingPostcode"
-         placeholder="Enter your ZipCode"
-         autocomplete="postal-code"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="billing-postcode"
-         aria-required="true"
-         required
-         pattern="Whatever"
-         value
-  >
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="billingPostcode"
+           name="billingPostcode"
+           placeholder="Enter your ZipCode"
+           autocomplete="postal-code"
+           data-trackable="billing-postcode"
+           aria-required="true"
+           required
+           pattern="Whatever"
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter a valid
     <span data-reference="postcode">
       ZipCode
     </span>
     .
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Billing Postcode can render as an Error 1`] = `
-<div id="billingPostcodeField"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryPostcode"
-     data-validate="required"
+<label id="billingPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingPostcode"
-         class="o-forms__label"
-  >
-    Billing
-    <span data-reference="postcode">
-      ZipCode
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing
+      <span data-reference="postcode">
+        ZipCode
+      </span>
     </span>
-  </label>
-  <input type="text"
-         id="billingPostcode"
-         name="billingPostcode"
-         placeholder="Enter your ZipCode"
-         autocomplete="postal-code"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="billing-postcode"
-         aria-required="true"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+    <input type="text"
+           id="billingPostcode"
+           name="billingPostcode"
+           placeholder="Enter your ZipCode"
+           autocomplete="postal-code"
+           data-trackable="billing-postcode"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter a valid
     <span data-reference="postcode">
       ZipCode
     </span>
     .
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Billing Postcode can render as an Error 2`] = `
-<div id="billingPostcodeField"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryPostcode"
-     data-validate="required"
+<label id="billingPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingPostcode"
-         class="o-forms__label"
-  >
-    Billing
-    <span data-reference="postcode">
-      ZipCode
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing
+      <span data-reference="postcode">
+        ZipCode
+      </span>
     </span>
-  </label>
-  <input type="text"
-         id="billingPostcode"
-         name="billingPostcode"
-         placeholder="Enter your ZipCode"
-         autocomplete="postal-code"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="billing-postcode"
-         aria-required="true"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+    <input type="text"
+           id="billingPostcode"
+           name="billingPostcode"
+           placeholder="Enter your ZipCode"
+           autocomplete="postal-code"
+           data-trackable="billing-postcode"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter a valid
     <span data-reference="postcode">
       ZipCode
     </span>
     .
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Billing Postcode can render as an hidden field 1`] = `
-<div id="billingPostcodeField"
-     class="o-forms o-forms--wide ncf__field js-field n-ui-hide"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryPostcode"
-     data-validate="required"
+<label id="billingPostcodeField"
+       class="o-forms-field n-ui-hide"
+       data-validate="required"
 >
-  <label for="billingPostcode"
-         class="o-forms__label"
-  >
-    Billing
-    <span data-reference="postcode">
-      ZipCode
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing
+      <span data-reference="postcode">
+        ZipCode
+      </span>
     </span>
-  </label>
-  <input type="text"
-         id="billingPostcode"
-         name="billingPostcode"
-         placeholder="Enter your ZipCode"
-         autocomplete="postal-code"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="billing-postcode"
-         aria-required="true"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="billingPostcode"
+           name="billingPostcode"
+           placeholder="Enter your ZipCode"
+           autocomplete="postal-code"
+           data-trackable="billing-postcode"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter a valid
     <span data-reference="postcode">
       ZipCode
     </span>
     .
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Billing Postcode can render as an hidden field 2`] = `
-<div id="billingPostcodeField"
-     class="o-forms o-forms--wide ncf__field js-field n-ui-hide"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryPostcode"
-     data-validate="required"
+<label id="billingPostcodeField"
+       class="o-forms-field n-ui-hide"
+       data-validate="required"
 >
-  <label for="billingPostcode"
-         class="o-forms__label"
-  >
-    Billing
-    <span data-reference="postcode">
-      ZipCode
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing
+      <span data-reference="postcode">
+        ZipCode
+      </span>
     </span>
-  </label>
-  <input type="text"
-         id="billingPostcode"
-         name="billingPostcode"
-         placeholder="Enter your ZipCode"
-         autocomplete="postal-code"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="billing-postcode"
-         aria-required="true"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="billingPostcode"
+           name="billingPostcode"
+           placeholder="Enter your ZipCode"
+           autocomplete="postal-code"
+           data-trackable="billing-postcode"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter a valid
     <span data-reference="postcode">
       ZipCode
     </span>
     .
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Billing Postcode render a postcode input with a label 1`] = `
-<div id="billingPostcodeField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryPostcode"
-     data-validate="required"
+<label id="billingPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingPostcode"
-         class="o-forms__label"
-  >
-    Billing
-    <span data-reference="postcode">
-      ZipCode
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing
+      <span data-reference="postcode">
+        ZipCode
+      </span>
     </span>
-  </label>
-  <input type="text"
-         id="billingPostcode"
-         name="billingPostcode"
-         placeholder="Enter your ZipCode"
-         autocomplete="postal-code"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="billing-postcode"
-         aria-required="true"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="billingPostcode"
+           name="billingPostcode"
+           placeholder="Enter your ZipCode"
+           autocomplete="postal-code"
+           data-trackable="billing-postcode"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter a valid
     <span data-reference="postcode">
       ZipCode
     </span>
     .
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Billing Postcode render a postcode input with a label 2`] = `
-<div id="billingPostcodeField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryPostcode"
-     data-validate="required"
+<label id="billingPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="billingPostcode"
-         class="o-forms__label"
-  >
-    Billing
-    <span data-reference="postcode">
-      ZipCode
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing
+      <span data-reference="postcode">
+        ZipCode
+      </span>
     </span>
-  </label>
-  <input type="text"
-         id="billingPostcode"
-         name="billingPostcode"
-         placeholder="Enter your ZipCode"
-         autocomplete="postal-code"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="billing-postcode"
-         aria-required="true"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="billingPostcode"
+           name="billingPostcode"
+           placeholder="Enter your ZipCode"
+           autocomplete="postal-code"
+           data-trackable="billing-postcode"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter a valid
     <span data-reference="postcode">
       ZipCode
     </span>
     .
-  </div>
-</div>
+  </span>
+</label>
 `;

--- a/components/__snapshots__/company-name.spec.js.snap
+++ b/components/__snapshots__/company-name.spec.js.snap
@@ -1,235 +1,227 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CompanyName renders with a custom value 1`] = `
-<div id="companyNameField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="companyName"
-     data-validate="required"
+<label id="companyNameField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="companyName"
-         class="o-forms__label"
-  >
-    Company name
-  </label>
-  <input type="text"
-         id="companyName"
-         name="company"
-         placeholder="Enter your company name"
-         autocomplete="organization"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="company-name"
-         aria-required="true"
-         required
-         value="foobar"
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Company name
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="companyName"
+           name="company"
+           placeholder="Enter your company name"
+           autocomplete="organization"
+           data-trackable="company-name"
+           aria-required="true"
+           required
+           value="foobar"
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter your company name.
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`CompanyName renders with a custom value 2`] = `
-<div id="companyNameField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="companyName"
-     data-validate="required"
+<label id="companyNameField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="companyName"
-         class="o-forms__label"
-  >
-    Company name
-  </label>
-  <input type="text"
-         id="companyName"
-         name="company"
-         placeholder="Enter your company name"
-         autocomplete="organization"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="company-name"
-         aria-required="true"
-         required
-         value="foobar"
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Company name
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="companyName"
+           name="company"
+           placeholder="Enter your company name"
+           autocomplete="organization"
+           data-trackable="company-name"
+           aria-required="true"
+           required
+           value="foobar"
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter your company name.
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`CompanyName renders with an error 1`] = `
-<div id="companyNameField"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
-     data-ui-item="form-field"
-     data-ui-item-name="companyName"
-     data-validate="required"
+<label id="companyNameField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="companyName"
-         class="o-forms__label"
-  >
-    Company name
-  </label>
-  <input type="text"
-         id="companyName"
-         name="company"
-         placeholder="Enter your company name"
-         autocomplete="organization"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="company-name"
-         aria-required="true"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Company name
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+    <input type="text"
+           id="companyName"
+           name="company"
+           placeholder="Enter your company name"
+           autocomplete="organization"
+           data-trackable="company-name"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter your company name.
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`CompanyName renders with an error 2`] = `
-<div id="companyNameField"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
-     data-ui-item="form-field"
-     data-ui-item-name="companyName"
-     data-validate="required"
+<label id="companyNameField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="companyName"
-         class="o-forms__label"
-  >
-    Company name
-  </label>
-  <input type="text"
-         id="companyName"
-         name="company"
-         placeholder="Enter your company name"
-         autocomplete="organization"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="company-name"
-         aria-required="true"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Company name
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+    <input type="text"
+           id="companyName"
+           name="company"
+           placeholder="Enter your company name"
+           autocomplete="organization"
+           data-trackable="company-name"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter your company name.
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`CompanyName renders with default props 1`] = `
-<div id="companyNameField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="companyName"
-     data-validate="required"
+<label id="companyNameField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="companyName"
-         class="o-forms__label"
-  >
-    Company name
-  </label>
-  <input type="text"
-         id="companyName"
-         name="company"
-         placeholder="Enter your company name"
-         autocomplete="organization"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="company-name"
-         aria-required="true"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Company name
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="companyName"
+           name="company"
+           placeholder="Enter your company name"
+           autocomplete="organization"
+           data-trackable="company-name"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter your company name.
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`CompanyName renders with default props 2`] = `
-<div id="companyNameField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="companyName"
-     data-validate="required"
+<label id="companyNameField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="companyName"
-         class="o-forms__label"
-  >
-    Company name
-  </label>
-  <input type="text"
-         id="companyName"
-         name="company"
-         placeholder="Enter your company name"
-         autocomplete="organization"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="company-name"
-         aria-required="true"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Company name
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="companyName"
+           name="company"
+           placeholder="Enter your company name"
+           autocomplete="organization"
+           data-trackable="company-name"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter your company name.
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`CompanyName renders with disabled input 1`] = `
-<div id="companyNameField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="companyName"
-     data-validate="required"
+<label id="companyNameField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="companyName"
-         class="o-forms__label"
-  >
-    Company name
-  </label>
-  <input type="text"
-         id="companyName"
-         name="company"
-         placeholder="Enter your company name"
-         autocomplete="organization"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="company-name"
-         aria-required="true"
-         required
-         disabled
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Company name
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="companyName"
+           name="company"
+           placeholder="Enter your company name"
+           autocomplete="organization"
+           data-trackable="company-name"
+           aria-required="true"
+           required
+           disabled
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter your company name.
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`CompanyName renders with disabled input 2`] = `
-<div id="companyNameField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="companyName"
-     data-validate="required"
+<label id="companyNameField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="companyName"
-         class="o-forms__label"
-  >
-    Company name
-  </label>
-  <input type="text"
-         id="companyName"
-         name="company"
-         placeholder="Enter your company name"
-         autocomplete="organization"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="company-name"
-         aria-required="true"
-         required
-         disabled
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Company name
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="companyName"
+           name="company"
+           placeholder="Enter your company name"
+           autocomplete="organization"
+           data-trackable="company-name"
+           aria-required="true"
+           required
+           disabled
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter your company name.
-  </div>
-</div>
+  </span>
+</label>
 `;

--- a/components/__snapshots__/country.spec.js.snap
+++ b/components/__snapshots__/country.spec.js.snap
@@ -1,9805 +1,8185 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Country renders with default props 1`] = `
-<div id="countryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="country"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="countryField"
+       class="o-forms-field js-unknown-user-field"
+       data-validate="required"
 >
-  <label for="country"
-         class="o-forms__label"
-  >
-    Country
-  </label>
-  <select id="country"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="country"
-          data-trackable="field-country"
-  >
-    <option value>
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="field-country"
+    >
+      <option value>
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+  </span>
+  <span class="o-forms-input__error">
     Please select your country
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Country renders with default props 2`] = `
-<div id="countryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="country"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="countryField"
+       class="o-forms-field js-unknown-user-field"
+       data-validate="required"
 >
-  <label for="country"
-         class="o-forms__label"
-  >
-    Country
-  </label>
-  <select id="country"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="country"
-          data-trackable="field-country"
-  >
-    <option value>
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="field-country"
+    >
+      <option value>
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+  </span>
+  <span class="o-forms-input__error">
     Please select your country
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Country renders with hasError 1`] = `
-<div id="countryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field o-forms--error"
-     data-ui-item="select"
-     data-ui-item-name="country"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="countryField"
+       class="o-forms-field js-unknown-user-field"
+       data-validate="required"
 >
-  <label for="country"
-         class="o-forms__label"
-  >
-    Country
-  </label>
-  <select id="country"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="country"
-          data-trackable="field-country"
-  >
-    <option value>
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select o-forms-input--invalid">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="field-country"
+    >
+      <option value>
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+  </span>
+  <span class="o-forms-input__error">
     Please select your country
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Country renders with hasError 2`] = `
-<div id="countryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field o-forms--error"
-     data-ui-item="select"
-     data-ui-item-name="country"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="countryField"
+       class="o-forms-field js-unknown-user-field"
+       data-validate="required"
 >
-  <label for="country"
-         class="o-forms__label"
-  >
-    Country
-  </label>
-  <select id="country"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="country"
-          data-trackable="field-country"
-  >
-    <option value>
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select o-forms-input--invalid">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="field-country"
+    >
+      <option value>
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+  </span>
+  <span class="o-forms-input__error">
     Please select your country
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Country renders with isB2b 1`] = `
-<div id="countryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="country"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="countryField"
+       class="o-forms-field js-unknown-user-field"
+       data-validate="required"
 >
-  <label for="country"
-         class="o-forms__label"
-  >
-    Country/Region
-  </label>
-  <select id="country"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="country"
-          data-trackable="field-country"
-  >
-    <option value>
-      Please select a country/region
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country/Region
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="field-country"
+    >
+      <option value>
+        Please select a country/region
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+  </span>
+  <span class="o-forms-input__error">
     Please select your country/region
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Country renders with isB2b 2`] = `
-<div id="countryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="country"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="countryField"
+       class="o-forms-field js-unknown-user-field"
+       data-validate="required"
 >
-  <label for="country"
-         class="o-forms__label"
-  >
-    Country/Region
-  </label>
-  <select id="country"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="country"
-          data-trackable="field-country"
-  >
-    <option value>
-      Please select a country/region
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country/Region
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="field-country"
+    >
+      <option value>
+        Please select a country/region
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+  </span>
+  <span class="o-forms-input__error">
     Please select your country/region
-  </div>
-</div>
-`;
-
-exports[`Country renders with isBillingCountry 1`] = `
-<div id="countryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="billingCountry"
-     data-ui-item-store-previous="true"
-     data-validate="required"
->
-  <label for="country"
-         class="o-forms__label"
-  >
-    Billing Country
-  </label>
-  <select id="country"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="billingCountry"
-          data-trackable="field-billing-country"
-  >
-    <option value>
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
-    Please select your country
-  </div>
-</div>
-`;
-
-exports[`Country renders with isBillingCountry 2`] = `
-<div id="countryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="billingCountry"
-     data-ui-item-store-previous="true"
-     data-validate="required"
->
-  <label for="country"
-         class="o-forms__label"
-  >
-    Billing Country
-  </label>
-  <select id="country"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="billingCountry"
-          data-trackable="field-billing-country"
-  >
-    <option value>
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
-    Please select your country
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Country renders with isDisabled 1`] = `
-<div id="countryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="country"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="countryField"
+       class="o-forms-field js-unknown-user-field"
+       data-validate="required"
 >
-  <label for="country"
-         class="o-forms__label"
-  >
-    Country
-  </label>
-  <select id="country"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="country"
-          data-trackable="field-country"
-          disabled
-  >
-    <option value>
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="field-country"
+            disabled
+    >
+      <option value>
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+  </span>
+  <span class="o-forms-input__error">
     Please select your country
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Country renders with isDisabled 2`] = `
-<div id="countryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="country"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="countryField"
+       class="o-forms-field js-unknown-user-field"
+       data-validate="required"
 >
-  <label for="country"
-         class="o-forms__label"
-  >
-    Country
-  </label>
-  <select id="country"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="country"
-          data-trackable="field-country"
-          disabled
-  >
-    <option value>
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="field-country"
+            disabled
+    >
+      <option value>
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+  </span>
+  <span class="o-forms-input__error">
     Please select your country
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Country renders with large filterList 1`] = `
-<div id="countryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="country"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="countryField"
+       class="o-forms-field js-unknown-user-field"
+       data-validate="required"
 >
-  <label for="country"
-         class="o-forms__label"
-  >
-    Country
-  </label>
-  <select id="country"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="country"
-          data-trackable="field-country"
-  >
-    <option value>
-      Please select a country
-    </option>
-    <option value="AFG">
-      Afghanistan
-    </option>
-    <option value="ALA">
-      Aland Islands
-    </option>
-    <option value="ALB">
-      Albania
-    </option>
-    <option value="DZA">
-      Algeria
-    </option>
-    <option value="ASM">
-      American Samoa
-    </option>
-    <option value="AND">
-      Andorra
-    </option>
-    <option value="AGO">
-      Angola
-    </option>
-    <option value="AIA">
-      Anguilla
-    </option>
-    <option value="ATA">
-      Antarctica
-    </option>
-    <option value="ATG">
-      Antigua And Barbuda
-    </option>
-    <option value="ARG">
-      Argentina
-    </option>
-    <option value="ARM">
-      Armenia
-    </option>
-    <option value="ABW">
-      Aruba
-    </option>
-    <option value="AUS">
-      Australia
-    </option>
-    <option value="AUT">
-      Austria
-    </option>
-    <option value="AZE">
-      Azerbaijan
-    </option>
-    <option value="BHS">
-      Bahamas
-    </option>
-    <option value="BHR">
-      Bahrain
-    </option>
-    <option value="BGD">
-      Bangladesh
-    </option>
-    <option value="BRB">
-      Barbados
-    </option>
-  </select>
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="field-country"
+    >
+      <option value>
+        Please select a country
+      </option>
+      <option value="AFG">
+        Afghanistan
+      </option>
+      <option value="ALA">
+        Aland Islands
+      </option>
+      <option value="ALB">
+        Albania
+      </option>
+      <option value="DZA">
+        Algeria
+      </option>
+      <option value="ASM">
+        American Samoa
+      </option>
+      <option value="AND">
+        Andorra
+      </option>
+      <option value="AGO">
+        Angola
+      </option>
+      <option value="AIA">
+        Anguilla
+      </option>
+      <option value="ATA">
+        Antarctica
+      </option>
+      <option value="ATG">
+        Antigua And Barbuda
+      </option>
+      <option value="ARG">
+        Argentina
+      </option>
+      <option value="ARM">
+        Armenia
+      </option>
+      <option value="ABW">
+        Aruba
+      </option>
+      <option value="AUS">
+        Australia
+      </option>
+      <option value="AUT">
+        Austria
+      </option>
+      <option value="AZE">
+        Azerbaijan
+      </option>
+      <option value="BHS">
+        Bahamas
+      </option>
+      <option value="BHR">
+        Bahrain
+      </option>
+      <option value="BGD">
+        Bangladesh
+      </option>
+      <option value="BRB">
+        Barbados
+      </option>
+    </select>
+  </span>
+  <span class="o-forms-input__error">
     Please select your country
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Country renders with large filterList 2`] = `
-<div id="countryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="country"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="countryField"
+       class="o-forms-field js-unknown-user-field"
+       data-validate="required"
 >
-  <label for="country"
-         class="o-forms__label"
-  >
-    Country
-  </label>
-  <select id="country"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="country"
-          data-trackable="field-country"
-  >
-    <option value>
-      Please select a country
-    </option>
-    <option value="AFG">
-      Afghanistan
-    </option>
-    <option value="ALA">
-      Aland Islands
-    </option>
-    <option value="ALB">
-      Albania
-    </option>
-    <option value="DZA">
-      Algeria
-    </option>
-    <option value="ASM">
-      American Samoa
-    </option>
-    <option value="AND">
-      Andorra
-    </option>
-    <option value="AGO">
-      Angola
-    </option>
-    <option value="AIA">
-      Anguilla
-    </option>
-    <option value="ATA">
-      Antarctica
-    </option>
-    <option value="ATG">
-      Antigua And Barbuda
-    </option>
-    <option value="ARG">
-      Argentina
-    </option>
-    <option value="ARM">
-      Armenia
-    </option>
-    <option value="ABW">
-      Aruba
-    </option>
-    <option value="AUS">
-      Australia
-    </option>
-    <option value="AUT">
-      Austria
-    </option>
-    <option value="AZE">
-      Azerbaijan
-    </option>
-    <option value="BHS">
-      Bahamas
-    </option>
-    <option value="BHR">
-      Bahrain
-    </option>
-    <option value="BGD">
-      Bangladesh
-    </option>
-    <option value="BRB">
-      Barbados
-    </option>
-  </select>
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="field-country"
+    >
+      <option value>
+        Please select a country
+      </option>
+      <option value="AFG">
+        Afghanistan
+      </option>
+      <option value="ALA">
+        Aland Islands
+      </option>
+      <option value="ALB">
+        Albania
+      </option>
+      <option value="DZA">
+        Algeria
+      </option>
+      <option value="ASM">
+        American Samoa
+      </option>
+      <option value="AND">
+        Andorra
+      </option>
+      <option value="AGO">
+        Angola
+      </option>
+      <option value="AIA">
+        Anguilla
+      </option>
+      <option value="ATA">
+        Antarctica
+      </option>
+      <option value="ATG">
+        Antigua And Barbuda
+      </option>
+      <option value="ARG">
+        Argentina
+      </option>
+      <option value="ARM">
+        Armenia
+      </option>
+      <option value="ABW">
+        Aruba
+      </option>
+      <option value="AUS">
+        Australia
+      </option>
+      <option value="AUT">
+        Austria
+      </option>
+      <option value="AZE">
+        Azerbaijan
+      </option>
+      <option value="BHS">
+        Bahamas
+      </option>
+      <option value="BHR">
+        Bahrain
+      </option>
+      <option value="BGD">
+        Bangladesh
+      </option>
+      <option value="BRB">
+        Barbados
+      </option>
+    </select>
+  </span>
+  <span class="o-forms-input__error">
     Please select your country
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Country renders with small filterList 1`] = `
-<div id="countryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="country"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="countryField"
+       class="o-forms-field js-unknown-user-field"
+       data-validate="required"
 >
-  <label for="country"
-         class="o-forms__label"
-  >
-    Country
-  </label>
-  <select id="country"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="country"
-          data-trackable="field-country"
-  >
-    <option value>
-      Please select a country
-    </option>
-    <option value="GBR">
-      United Kingdom
-    </option>
-  </select>
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="field-country"
+    >
+      <option value>
+        Please select a country
+      </option>
+      <option value="GBR">
+        United Kingdom
+      </option>
+    </select>
+  </span>
+  <span class="o-forms-input__error">
     Please select your country
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Country renders with small filterList 2`] = `
-<div id="countryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="country"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="countryField"
+       class="o-forms-field js-unknown-user-field"
+       data-validate="required"
 >
-  <label for="country"
-         class="o-forms__label"
-  >
-    Country
-  </label>
-  <select id="country"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="country"
-          data-trackable="field-country"
-  >
-    <option value>
-      Please select a country
-    </option>
-    <option value="GBR">
-      United Kingdom
-    </option>
-  </select>
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="field-country"
+    >
+      <option value>
+        Please select a country
+      </option>
+      <option value="GBR">
+        United Kingdom
+      </option>
+    </select>
+  </span>
+  <span class="o-forms-input__error">
     Please select your country
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Country renders with value 1`] = `
-<div id="countryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="country"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="countryField"
+       class="o-forms-field js-unknown-user-field"
+       data-validate="required"
 >
-  <label for="country"
-         class="o-forms__label"
-  >
-    Country
-  </label>
-  <select id="country"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="country"
-          data-trackable="field-country"
-  >
-    <option value>
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR"
-              selected
-      >
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="field-country"
+    >
+      <option value>
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR"
+                selected
+        >
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+  </span>
+  <span class="o-forms-input__error">
     Please select your country
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Country renders with value 2`] = `
-<div id="countryField"
-     class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field"
-     data-ui-item="select"
-     data-ui-item-name="country"
-     data-ui-item-store-previous="true"
-     data-validate="required"
+<label id="countryField"
+       class="o-forms-field js-unknown-user-field"
+       data-validate="required"
 >
-  <label for="country"
-         class="o-forms__label"
-  >
-    Country
-  </label>
-  <select id="country"
-          class="o-forms__select js-field__input js-item__value"
-          aria-required="true"
-          required
-          name="country"
-          data-trackable="field-country"
-  >
-    <option value>
-      Please select a country
-    </option>
-    <optgroup label="Frequently Used">
-      <option value="GBR"
-              selected
-      >
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-    </optgroup>
-    <optgroup label="Alphabetical">
-      <option value="AFG">
-        Afghanistan
-      </option>
-      <option value="ALA">
-        Aland Islands
-      </option>
-      <option value="ALB">
-        Albania
-      </option>
-      <option value="DZA">
-        Algeria
-      </option>
-      <option value="ASM">
-        American Samoa
-      </option>
-      <option value="AND">
-        Andorra
-      </option>
-      <option value="AGO">
-        Angola
-      </option>
-      <option value="AIA">
-        Anguilla
-      </option>
-      <option value="ATA">
-        Antarctica
-      </option>
-      <option value="ATG">
-        Antigua And Barbuda
-      </option>
-      <option value="ARG">
-        Argentina
-      </option>
-      <option value="ARM">
-        Armenia
-      </option>
-      <option value="ABW">
-        Aruba
-      </option>
-      <option value="AUS">
-        Australia
-      </option>
-      <option value="AUT">
-        Austria
-      </option>
-      <option value="AZE">
-        Azerbaijan
-      </option>
-      <option value="BHS">
-        Bahamas
-      </option>
-      <option value="BHR">
-        Bahrain
-      </option>
-      <option value="BGD">
-        Bangladesh
-      </option>
-      <option value="BRB">
-        Barbados
-      </option>
-      <option value="BLR">
-        Belarus
-      </option>
-      <option value="BEL">
-        Belgium
-      </option>
-      <option value="BLZ">
-        Belize
-      </option>
-      <option value="BEN">
-        Benin
-      </option>
-      <option value="BMU">
-        Bermuda
-      </option>
-      <option value="BTN">
-        Bhutan
-      </option>
-      <option value="BOL">
-        Bolivia
-      </option>
-      <option value="BES">
-        Bonaire, Saint Eustatius and Saba
-      </option>
-      <option value="BIH">
-        Bosnia and Herzegovina
-      </option>
-      <option value="BWA">
-        Botswana
-      </option>
-      <option value="BVT">
-        Bouvet Island
-      </option>
-      <option value="BRA">
-        Brazil
-      </option>
-      <option value="IOT">
-        British Indian Ocean Territory
-      </option>
-      <option value="BRN">
-        Brunei Darussalam
-      </option>
-      <option value="BGR">
-        Bulgaria
-      </option>
-      <option value="BFA">
-        Burkina Faso
-      </option>
-      <option value="BDI">
-        Burundi
-      </option>
-      <option value="KHM">
-        Cambodia
-      </option>
-      <option value="CMR">
-        Cameroon
-      </option>
-      <option value="CAN">
-        Canada
-      </option>
-      <option value="CPV">
-        Cape Verde
-      </option>
-      <option value="CYM">
-        Cayman Islands
-      </option>
-      <option value="CAF">
-        Central African Republic
-      </option>
-      <option value="TCD">
-        Chad
-      </option>
-      <option value="CHL">
-        Chile
-      </option>
-      <option value="CHN">
-        China
-      </option>
-      <option value="CXR">
-        Christmas Island
-      </option>
-      <option value="CCK">
-        Cocos (Keeling) Islands
-      </option>
-      <option value="COL">
-        Colombia
-      </option>
-      <option value="COM">
-        Comoros
-      </option>
-      <option value="COG">
-        Congo
-      </option>
-      <option value="COD">
-        Congo, the Democratic Republic of the
-      </option>
-      <option value="COK">
-        Cook Islands
-      </option>
-      <option value="CRI">
-        Costa Rica
-      </option>
-      <option value="CIV">
-        Cote d&#x27;Ivoire
-      </option>
-      <option value="HRV">
-        Croatia
-      </option>
-      <option value="CUB">
-        Cuba
-      </option>
-      <option value="CUW">
-        Curacao
-      </option>
-      <option value="CYP">
-        Cyprus
-      </option>
-      <option value="CZE">
-        Czech Republic
-      </option>
-      <option value="DNK">
-        Denmark
-      </option>
-      <option value="DJI">
-        Djibouti
-      </option>
-      <option value="DMA">
-        Dominica
-      </option>
-      <option value="DOM">
-        Dominican Republic
-      </option>
-      <option value="ECU">
-        Ecuador
-      </option>
-      <option value="EGY">
-        Egypt
-      </option>
-      <option value="SLV">
-        El Salvador
-      </option>
-      <option value="GNQ">
-        Equatorial Guinea
-      </option>
-      <option value="ERI">
-        Eritrea
-      </option>
-      <option value="EST">
-        Estonia
-      </option>
-      <option value="ETH">
-        Ethiopia
-      </option>
-      <option value="FLK">
-        Falkland Islands (Malvinas)
-      </option>
-      <option value="FRO">
-        Faroe Islands
-      </option>
-      <option value="FJI">
-        Fiji
-      </option>
-      <option value="FIN">
-        Finland
-      </option>
-      <option value="FRA">
-        France
-      </option>
-      <option value="GUF">
-        French Guiana
-      </option>
-      <option value="PYF">
-        French Polynesia
-      </option>
-      <option value="ATF">
-        French Southern Territories
-      </option>
-      <option value="GAB">
-        Gabon
-      </option>
-      <option value="GMB">
-        Gambia
-      </option>
-      <option value="GEO">
-        Georgia
-      </option>
-      <option value="DEU">
-        Germany
-      </option>
-      <option value="GHA">
-        Ghana
-      </option>
-      <option value="GIB">
-        Gibraltar
-      </option>
-      <option value="GRC">
-        Greece
-      </option>
-      <option value="GRL">
-        Greenland
-      </option>
-      <option value="GRD">
-        Grenada
-      </option>
-      <option value="GLP">
-        Guadeloupe
-      </option>
-      <option value="GUM">
-        Guam
-      </option>
-      <option value="GTM">
-        Guatemala
-      </option>
-      <option value="GGY">
-        Guernsey
-      </option>
-      <option value="GIN">
-        Guinea
-      </option>
-      <option value="GNB">
-        Guinea-Bissau
-      </option>
-      <option value="GUY">
-        Guyana
-      </option>
-      <option value="HTI">
-        Haiti
-      </option>
-      <option value="HMD">
-        Heard Island and McDonald Islands
-      </option>
-      <option value="VAT">
-        Holy See (Vatican City State)
-      </option>
-      <option value="HND">
-        Honduras
-      </option>
-      <option value="HKG">
-        Hong Kong
-      </option>
-      <option value="HUN">
-        Hungary
-      </option>
-      <option value="ISL">
-        Iceland
-      </option>
-      <option value="IND">
-        India
-      </option>
-      <option value="IDN">
-        Indonesia
-      </option>
-      <option value="IRN">
-        Iran, Islamic Republic of
-      </option>
-      <option value="IRQ">
-        Iraq
-      </option>
-      <option value="IRL">
-        Ireland
-      </option>
-      <option value="IMN">
-        Isle of Man
-      </option>
-      <option value="ISR">
-        Israel
-      </option>
-      <option value="ITA">
-        Italy
-      </option>
-      <option value="JAM">
-        Jamaica
-      </option>
-      <option value="JPN">
-        Japan
-      </option>
-      <option value="JEY">
-        Jersey
-      </option>
-      <option value="JOR">
-        Jordan
-      </option>
-      <option value="KAZ">
-        Kazakhstan
-      </option>
-      <option value="KEN">
-        Kenya
-      </option>
-      <option value="KIR">
-        Kiribati
-      </option>
-      <option value="PRK">
-        Korea, Democratic People&#x27;s Republic of
-      </option>
-      <option value="KOR">
-        Korea, Republic of
-      </option>
-      <option value="XKX">
-        Kosovo
-      </option>
-      <option value="KWT">
-        Kuwait
-      </option>
-      <option value="KGZ">
-        Kyrgyzstan
-      </option>
-      <option value="LAO">
-        Lao People&#x27;s Democratic Republic
-      </option>
-      <option value="LVA">
-        Latvia
-      </option>
-      <option value="LBN">
-        Lebanon
-      </option>
-      <option value="LSO">
-        Lesotho
-      </option>
-      <option value="LBR">
-        Liberia
-      </option>
-      <option value="LBY">
-        Libyan Arab Jamahiriya
-      </option>
-      <option value="LIE">
-        Liechtenstein
-      </option>
-      <option value="LTU">
-        Lithuania
-      </option>
-      <option value="LUX">
-        Luxembourg
-      </option>
-      <option value="MAC">
-        Macao
-      </option>
-      <option value="MKD">
-        Macedonia, the former Yugoslav Republic of
-      </option>
-      <option value="MDG">
-        Madagascar
-      </option>
-      <option value="MWI">
-        Malawi
-      </option>
-      <option value="MYS">
-        Malaysia
-      </option>
-      <option value="MDV">
-        Maldives
-      </option>
-      <option value="MLI">
-        Mali
-      </option>
-      <option value="MLT">
-        Malta
-      </option>
-      <option value="MHL">
-        Marshall Islands
-      </option>
-      <option value="MTQ">
-        Martinique
-      </option>
-      <option value="MRT">
-        Mauritania
-      </option>
-      <option value="MUS">
-        Mauritius
-      </option>
-      <option value="MYT">
-        Mayotte
-      </option>
-      <option value="MEX">
-        Mexico
-      </option>
-      <option value="FSM">
-        Micronesia, Federated States of
-      </option>
-      <option value="MDA">
-        Moldova, Republic of
-      </option>
-      <option value="MCO">
-        Monaco
-      </option>
-      <option value="MNG">
-        Mongolia
-      </option>
-      <option value="MNE">
-        Montenegro
-      </option>
-      <option value="MSR">
-        Montserrat
-      </option>
-      <option value="MAR">
-        Morocco
-      </option>
-      <option value="MOZ">
-        Mozambique
-      </option>
-      <option value="MMR">
-        Myanmar
-      </option>
-      <option value="NAM">
-        Namibia
-      </option>
-      <option value="NRU">
-        Nauru
-      </option>
-      <option value="NPL">
-        Nepal
-      </option>
-      <option value="NLD">
-        Netherlands
-      </option>
-      <option value="NCL">
-        New Caledonia
-      </option>
-      <option value="NZL">
-        New Zealand
-      </option>
-      <option value="NIC">
-        Nicaragua
-      </option>
-      <option value="NER">
-        Niger
-      </option>
-      <option value="NGA">
-        Nigeria
-      </option>
-      <option value="NIU">
-        Niue
-      </option>
-      <option value="NFK">
-        Norfolk Island
-      </option>
-      <option value="MNP">
-        Northern Mariana Islands
-      </option>
-      <option value="NOR">
-        Norway
-      </option>
-      <option value="OMN">
-        Oman
-      </option>
-      <option value="PAK">
-        Pakistan
-      </option>
-      <option value="PLW">
-        Palau
-      </option>
-      <option value="PSE">
-        Palestinian Territory, Occupied
-      </option>
-      <option value="PAN">
-        Panama
-      </option>
-      <option value="PNG">
-        Papua New Guinea
-      </option>
-      <option value="PRY">
-        Paraguay
-      </option>
-      <option value="PER">
-        Peru
-      </option>
-      <option value="PHL">
-        Philippines
-      </option>
-      <option value="PCN">
-        Pitcairn
-      </option>
-      <option value="POL">
-        Poland
-      </option>
-      <option value="PRT">
-        Portugal
-      </option>
-      <option value="PRI">
-        Puerto Rico
-      </option>
-      <option value="QAT">
-        Qatar
-      </option>
-      <option value="REU">
-        Reunion
-      </option>
-      <option value="ROU">
-        Romania
-      </option>
-      <option value="RUS">
-        Russian Federation
-      </option>
-      <option value="RWA">
-        Rwanda
-      </option>
-      <option value="BLM">
-        Saint Barthelemy
-      </option>
-      <option value="SHN">
-        Saint Helena
-      </option>
-      <option value="KNA">
-        Saint Kitts and Nevis
-      </option>
-      <option value="LCA">
-        Saint Lucia
-      </option>
-      <option value="MAF">
-        Saint Martin (French part)
-      </option>
-      <option value="SPM">
-        Saint Pierre and Miquelon
-      </option>
-      <option value="VCT">
-        Saint Vincent and the Grenadines
-      </option>
-      <option value="WSM">
-        Samoa
-      </option>
-      <option value="SMR">
-        San Marino
-      </option>
-      <option value="STP">
-        Sao Tome and Principe
-      </option>
-      <option value="SAU">
-        Saudi Arabia
-      </option>
-      <option value="SEN">
-        Senegal
-      </option>
-      <option value="SRB">
-        Serbia
-      </option>
-      <option value="SYC">
-        Seychelles
-      </option>
-      <option value="SLE">
-        Sierra Leone
-      </option>
-      <option value="SGP">
-        Singapore
-      </option>
-      <option value="SXM">
-        Sint Maarten
-      </option>
-      <option value="SVK">
-        Slovakia
-      </option>
-      <option value="SVN">
-        Slovenia
-      </option>
-      <option value="SLB">
-        Solomon Islands
-      </option>
-      <option value="SOM">
-        Somalia
-      </option>
-      <option value="ZAF">
-        South Africa
-      </option>
-      <option value="SGS">
-        South Georgia and the South Sandwich Islands
-      </option>
-      <option value="ESP">
-        Spain
-      </option>
-      <option value="LKA">
-        Sri Lanka
-      </option>
-      <option value="SDN">
-        Sudan
-      </option>
-      <option value="SUR">
-        Suriname
-      </option>
-      <option value="SJM">
-        Svalbard and Jan Mayen
-      </option>
-      <option value="SWZ">
-        Swaziland
-      </option>
-      <option value="SWE">
-        Sweden
-      </option>
-      <option value="CHE">
-        Switzerland
-      </option>
-      <option value="SYR">
-        Syrian Arab Republic
-      </option>
-      <option value="TWN">
-        Taiwan
-      </option>
-      <option value="TJK">
-        Tajikistan
-      </option>
-      <option value="TZA">
-        Tanzania, United Republic of
-      </option>
-      <option value="THA">
-        Thailand
-      </option>
-      <option value="TLS">
-        Timor-Leste
-      </option>
-      <option value="TGO">
-        Togo
-      </option>
-      <option value="TKL">
-        Tokelau
-      </option>
-      <option value="TON">
-        Tonga
-      </option>
-      <option value="TTO">
-        Trinidad and Tobago
-      </option>
-      <option value="TUN">
-        Tunisia
-      </option>
-      <option value="TUR">
-        Turkey
-      </option>
-      <option value="TKM">
-        Turkmenistan
-      </option>
-      <option value="TCA">
-        Turks and Caicos Islands
-      </option>
-      <option value="TUV">
-        Tuvalu
-      </option>
-      <option value="UGA">
-        Uganda
-      </option>
-      <option value="UKR">
-        Ukraine
-      </option>
-      <option value="ARE">
-        United Arab Emirates
-      </option>
-      <option value="GBR">
-        United Kingdom
-      </option>
-      <option value="USA">
-        United States
-      </option>
-      <option value="UMI">
-        United States Minor Outlying Islands
-      </option>
-      <option value="URY">
-        Uruguay
-      </option>
-      <option value="UZB">
-        Uzbekistan
-      </option>
-      <option value="VUT">
-        Vanuatu
-      </option>
-      <option value="VEN">
-        Venezuela
-      </option>
-      <option value="VNM">
-        Viet Nam
-      </option>
-      <option value="VGB">
-        Virgin Islands, British
-      </option>
-      <option value="VIR">
-        Virgin Islands, U.S.
-      </option>
-      <option value="WLF">
-        Wallis and Futuna
-      </option>
-      <option value="ESH">
-        Western Sahara
-      </option>
-      <option value="YEM">
-        Yemen
-      </option>
-      <option value="ZMB">
-        Zambia
-      </option>
-      <option value="ZWE">
-        Zimbabwe
-      </option>
-    </optgroup>
-  </select>
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="field-country"
+    >
+      <option value>
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR"
+                selected
+        >
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+  </span>
+  <span class="o-forms-input__error">
     Please select your country
-  </div>
-</div>
+  </span>
+</label>
 `;

--- a/components/__snapshots__/decision-maker.spec.js.snap
+++ b/components/__snapshots__/decision-maker.spec.js.snap
@@ -1,277 +1,307 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DecisionMaker renders with 'no' as default state for radio buttons 1`] = `
-<fieldset id="decisionMakerField"
-          class="o-forms o-forms--wide o-forms--inline ncf__field js-field"
-          data-ui-item="form-field"
-          data-ui-item-name="decisionMaker"
-          data-validate="required"
+<div id="decisionMakerField"
+     role="group"
+     aria-labelledby="decisionMakerFieldLabel"
+     class="o-forms-field"
+     data-validate="required"
 >
-  <legend class="o-normalise-visually-hidden">
-    Are you a manager with direct reports?
-  </legend>
-  <div class="o-forms__inline-container ncf__field--min-content">
-    <div class="o-forms__label">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main"
+          id="decisionMakerFieldLabel"
+    >
       Are you a manager with direct reports?
-    </div>
-    <div class="o-forms__group o-forms__group--inline-together">
-      <input type="radio"
-             id="decisionMakerYes"
-             name="decisionMaker"
-             value="yes"
-             class="o-forms__radio-button"
-      >
-      <label for="decisionMakerYes"
-             class="o-forms__label"
-      >
-        Yes
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--radio-box o-forms-input--inline">
+    <div class="o-forms-input--radio-box__container">
+      <label>
+        <input type="radio"
+               id="decisionMakerYes"
+               name="decisionMaker"
+               aria-label="Yes"
+               value="yes"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Yes
+        </span>
       </label>
-      <input type="radio"
-             id="decisionMakerNo"
-             name="decisionMaker"
-             value="no"
-             class="o-forms__radio-button o-forms__radio-button--negative"
-             checked
-      >
-      <label for="decisionMakerNo"
-             class="o-forms__label"
-      >
-        No
+      <label>
+        <input type="radio"
+               id="decisionMakerNo"
+               name="decisionMaker"
+               aria-label="No"
+               value="no"
+               checked
+        >
+        <span class="o-forms-input__label o-forms-input__label--negative"
+              aria-hidden="true"
+        >
+          No
+        </span>
       </label>
     </div>
-  </div>
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input__error">
     Please select an option
-  </div>
-</fieldset>
+  </span>
+</div>
 `;
 
 exports[`DecisionMaker renders with 'no' as default state for radio buttons 2`] = `
-<fieldset id="decisionMakerField"
-          class="o-forms o-forms--wide o-forms--inline ncf__field js-field"
-          data-ui-item="form-field"
-          data-ui-item-name="decisionMaker"
-          data-validate="required"
+<div id="decisionMakerField"
+     role="group"
+     aria-labelledby="decisionMakerFieldLabel"
+     class="o-forms-field"
+     data-validate="required"
 >
-  <legend class="o-normalise-visually-hidden">
-    Are you a manager with direct reports?
-  </legend>
-  <div class="o-forms__inline-container ncf__field--min-content">
-    <div class="o-forms__label">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main"
+          id="decisionMakerFieldLabel"
+    >
       Are you a manager with direct reports?
-    </div>
-    <div class="o-forms__group o-forms__group--inline-together">
-      <input type="radio"
-             id="decisionMakerYes"
-             name="decisionMaker"
-             value="yes"
-             class="o-forms__radio-button"
-      >
-      <label for="decisionMakerYes"
-             class="o-forms__label"
-      >
-        Yes
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--radio-box o-forms-input--inline">
+    <div class="o-forms-input--radio-box__container">
+      <label>
+        <input type="radio"
+               id="decisionMakerYes"
+               name="decisionMaker"
+               aria-label="Yes"
+               value="yes"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Yes
+        </span>
       </label>
-      <input type="radio"
-             id="decisionMakerNo"
-             name="decisionMaker"
-             value="no"
-             class="o-forms__radio-button o-forms__radio-button--negative"
-             checked
-      >
-      <label for="decisionMakerNo"
-             class="o-forms__label"
-      >
-        No
+      <label>
+        <input type="radio"
+               id="decisionMakerNo"
+               name="decisionMaker"
+               aria-label="No"
+               value="no"
+               checked
+        >
+        <span class="o-forms-input__label o-forms-input__label--negative"
+              aria-hidden="true"
+        >
+          No
+        </span>
       </label>
     </div>
-  </div>
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input__error">
     Please select an option
-  </div>
-</fieldset>
+  </span>
+</div>
 `;
 
 exports[`DecisionMaker renders with an error 1`] = `
-<fieldset id="decisionMakerField"
-          class="o-forms o-forms--wide o-forms--inline ncf__field js-field o-forms--error"
-          data-ui-item="form-field"
-          data-ui-item-name="decisionMaker"
-          data-validate="required"
+<div id="decisionMakerField"
+     role="group"
+     aria-labelledby="decisionMakerFieldLabel"
+     class="o-forms-field"
+     data-validate="required"
 >
-  <legend class="o-normalise-visually-hidden">
-    Are you a manager with direct reports?
-  </legend>
-  <div class="o-forms__inline-container ncf__field--min-content">
-    <div class="o-forms__label">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main"
+          id="decisionMakerFieldLabel"
+    >
       Are you a manager with direct reports?
-    </div>
-    <div class="o-forms__group o-forms__group--inline-together">
-      <input type="radio"
-             id="decisionMakerYes"
-             name="decisionMaker"
-             value="yes"
-             class="o-forms__radio-button"
-             checked
-      >
-      <label for="decisionMakerYes"
-             class="o-forms__label"
-      >
-        Yes
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--radio-box o-forms-input--inline o-forms-input--invalid">
+    <div class="o-forms-input--radio-box__container">
+      <label>
+        <input type="radio"
+               id="decisionMakerYes"
+               name="decisionMaker"
+               aria-label="Yes"
+               value="yes"
+               checked
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Yes
+        </span>
       </label>
-      <input type="radio"
-             id="decisionMakerNo"
-             name="decisionMaker"
-             value="no"
-             class="o-forms__radio-button o-forms__radio-button--negative"
-      >
-      <label for="decisionMakerNo"
-             class="o-forms__label"
-      >
-        No
+      <label>
+        <input type="radio"
+               id="decisionMakerNo"
+               name="decisionMaker"
+               aria-label="No"
+               value="no"
+        >
+        <span class="o-forms-input__label o-forms-input__label--negative"
+              aria-hidden="true"
+        >
+          No
+        </span>
       </label>
     </div>
-  </div>
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input__error">
     Please select an option
-  </div>
-</fieldset>
+  </span>
+</div>
 `;
 
 exports[`DecisionMaker renders with an error 2`] = `
-<fieldset id="decisionMakerField"
-          class="o-forms o-forms--wide o-forms--inline ncf__field js-field o-forms--error"
-          data-ui-item="form-field"
-          data-ui-item-name="decisionMaker"
-          data-validate="required"
+<div id="decisionMakerField"
+     role="group"
+     aria-labelledby="decisionMakerFieldLabel"
+     class="o-forms-field"
+     data-validate="required"
 >
-  <legend class="o-normalise-visually-hidden">
-    Are you a manager with direct reports?
-  </legend>
-  <div class="o-forms__inline-container ncf__field--min-content">
-    <div class="o-forms__label">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main"
+          id="decisionMakerFieldLabel"
+    >
       Are you a manager with direct reports?
-    </div>
-    <div class="o-forms__group o-forms__group--inline-together">
-      <input type="radio"
-             id="decisionMakerYes"
-             name="decisionMaker"
-             value="yes"
-             class="o-forms__radio-button"
-             checked
-      >
-      <label for="decisionMakerYes"
-             class="o-forms__label"
-      >
-        Yes
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--radio-box o-forms-input--inline o-forms-input--invalid">
+    <div class="o-forms-input--radio-box__container">
+      <label>
+        <input type="radio"
+               id="decisionMakerYes"
+               name="decisionMaker"
+               aria-label="Yes"
+               value="yes"
+               checked
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Yes
+        </span>
       </label>
-      <input type="radio"
-             id="decisionMakerNo"
-             name="decisionMaker"
-             value="no"
-             class="o-forms__radio-button o-forms__radio-button--negative"
-      >
-      <label for="decisionMakerNo"
-             class="o-forms__label"
-      >
-        No
+      <label>
+        <input type="radio"
+               id="decisionMakerNo"
+               name="decisionMaker"
+               aria-label="No"
+               value="no"
+        >
+        <span class="o-forms-input__label o-forms-input__label--negative"
+              aria-hidden="true"
+        >
+          No
+        </span>
       </label>
     </div>
-  </div>
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input__error">
     Please select an option
-  </div>
-</fieldset>
+  </span>
+</div>
 `;
 
 exports[`DecisionMaker renders with default props 1`] = `
-<fieldset id="decisionMakerField"
-          class="o-forms o-forms--wide o-forms--inline ncf__field js-field"
-          data-ui-item="form-field"
-          data-ui-item-name="decisionMaker"
-          data-validate="required"
+<div id="decisionMakerField"
+     role="group"
+     aria-labelledby="decisionMakerFieldLabel"
+     class="o-forms-field"
+     data-validate="required"
 >
-  <legend class="o-normalise-visually-hidden">
-    Are you a manager with direct reports?
-  </legend>
-  <div class="o-forms__inline-container ncf__field--min-content">
-    <div class="o-forms__label">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main"
+          id="decisionMakerFieldLabel"
+    >
       Are you a manager with direct reports?
-    </div>
-    <div class="o-forms__group o-forms__group--inline-together">
-      <input type="radio"
-             id="decisionMakerYes"
-             name="decisionMaker"
-             value="yes"
-             class="o-forms__radio-button"
-             checked
-      >
-      <label for="decisionMakerYes"
-             class="o-forms__label"
-      >
-        Yes
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--radio-box o-forms-input--inline">
+    <div class="o-forms-input--radio-box__container">
+      <label>
+        <input type="radio"
+               id="decisionMakerYes"
+               name="decisionMaker"
+               aria-label="Yes"
+               value="yes"
+               checked
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Yes
+        </span>
       </label>
-      <input type="radio"
-             id="decisionMakerNo"
-             name="decisionMaker"
-             value="no"
-             class="o-forms__radio-button o-forms__radio-button--negative"
-      >
-      <label for="decisionMakerNo"
-             class="o-forms__label"
-      >
-        No
+      <label>
+        <input type="radio"
+               id="decisionMakerNo"
+               name="decisionMaker"
+               aria-label="No"
+               value="no"
+        >
+        <span class="o-forms-input__label o-forms-input__label--negative"
+              aria-hidden="true"
+        >
+          No
+        </span>
       </label>
     </div>
-  </div>
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input__error">
     Please select an option
-  </div>
-</fieldset>
+  </span>
+</div>
 `;
 
 exports[`DecisionMaker renders with default props 2`] = `
-<fieldset id="decisionMakerField"
-          class="o-forms o-forms--wide o-forms--inline ncf__field js-field"
-          data-ui-item="form-field"
-          data-ui-item-name="decisionMaker"
-          data-validate="required"
+<div id="decisionMakerField"
+     role="group"
+     aria-labelledby="decisionMakerFieldLabel"
+     class="o-forms-field"
+     data-validate="required"
 >
-  <legend class="o-normalise-visually-hidden">
-    Are you a manager with direct reports?
-  </legend>
-  <div class="o-forms__inline-container ncf__field--min-content">
-    <div class="o-forms__label">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main"
+          id="decisionMakerFieldLabel"
+    >
       Are you a manager with direct reports?
-    </div>
-    <div class="o-forms__group o-forms__group--inline-together">
-      <input type="radio"
-             id="decisionMakerYes"
-             name="decisionMaker"
-             value="yes"
-             class="o-forms__radio-button"
-             checked
-      >
-      <label for="decisionMakerYes"
-             class="o-forms__label"
-      >
-        Yes
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--radio-box o-forms-input--inline">
+    <div class="o-forms-input--radio-box__container">
+      <label>
+        <input type="radio"
+               id="decisionMakerYes"
+               name="decisionMaker"
+               aria-label="Yes"
+               value="yes"
+               checked
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Yes
+        </span>
       </label>
-      <input type="radio"
-             id="decisionMakerNo"
-             name="decisionMaker"
-             value="no"
-             class="o-forms__radio-button o-forms__radio-button--negative"
-      >
-      <label for="decisionMakerNo"
-             class="o-forms__label"
-      >
-        No
+      <label>
+        <input type="radio"
+               id="decisionMakerNo"
+               name="decisionMaker"
+               aria-label="No"
+               value="no"
+        >
+        <span class="o-forms-input__label o-forms-input__label--negative"
+              aria-hidden="true"
+        >
+          No
+        </span>
       </label>
     </div>
-  </div>
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input__error">
     Please select an option
-  </div>
-</fieldset>
+  </span>
+</div>
 `;

--- a/components/__snapshots__/delivery-address.spec.js.snap
+++ b/components/__snapshots__/delivery-address.spec.js.snap
@@ -2,798 +2,798 @@
 
 exports[`DeliveryAddress renders default props 1`] = `
 <div id="deliveryAddressFields"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryAddress"
      data-validate="required"
 >
-  <p>
-    <label for="deliveryAddressLine1"
-           class="o-forms__label"
-    >
-      Address line 1
-    </label>
-    <input type="text"
-           id="deliveryAddressLine1"
-           name="deliveryAddressLine1"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine1"
-           autocomplete="address-line1"
-           placeholder="e.g. 10 Elm Street"
-           aria-required="true"
-           required
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine2"
-           class="o-forms__label"
-    >
-      Address line 2
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine2"
-           name="deliveryAddressLine2"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine2"
-           autocomplete="address-line2"
-           placeholder="e.g. Apartment 1"
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine3"
-           class="o-forms__label"
-    >
-      Address line 3
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine3"
-           name="deliveryAddressLine3"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine3"
-           autocomplete="address-line3"
-           placeholder
-           value
-    >
-  </p>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 1
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine1"
+             name="deliveryAddressLine1"
+             data-trackable="field-deliveryAddressLine1"
+             autocomplete="address-line1"
+             placeholder="e.g. 10 Elm Street"
+             aria-required="true"
+             required
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 2
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine2"
+             name="deliveryAddressLine2"
+             data-trackable="field-deliveryAddressLine2"
+             autocomplete="address-line2"
+             placeholder="e.g. Apartment 1"
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 3
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine3"
+             name="deliveryAddressLine3"
+             data-trackable="field-deliveryAddressLine3"
+             autocomplete="address-line3"
+             placeholder
+             value
+      >
+    </span>
+  </label>
 </div>
 `;
 
 exports[`DeliveryAddress renders default props 2`] = `
 <div id="deliveryAddressFields"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryAddress"
      data-validate="required"
 >
-  <p>
-    <label for="deliveryAddressLine1"
-           class="o-forms__label"
-    >
-      Address line 1
-    </label>
-    <input type="text"
-           id="deliveryAddressLine1"
-           name="deliveryAddressLine1"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine1"
-           autocomplete="address-line1"
-           placeholder="e.g. 10 Elm Street"
-           aria-required="true"
-           required
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine2"
-           class="o-forms__label"
-    >
-      Address line 2
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine2"
-           name="deliveryAddressLine2"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine2"
-           autocomplete="address-line2"
-           placeholder="e.g. Apartment 1"
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine3"
-           class="o-forms__label"
-    >
-      Address line 3
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine3"
-           name="deliveryAddressLine3"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine3"
-           autocomplete="address-line3"
-           placeholder
-           value
-    >
-  </p>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 1
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine1"
+             name="deliveryAddressLine1"
+             data-trackable="field-deliveryAddressLine1"
+             autocomplete="address-line1"
+             placeholder="e.g. 10 Elm Street"
+             aria-required="true"
+             required
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 2
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine2"
+             name="deliveryAddressLine2"
+             data-trackable="field-deliveryAddressLine2"
+             autocomplete="address-line2"
+             placeholder="e.g. Apartment 1"
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 3
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine3"
+             name="deliveryAddressLine3"
+             data-trackable="field-deliveryAddressLine3"
+             autocomplete="address-line3"
+             placeholder
+             value
+      >
+    </span>
+  </label>
 </div>
 `;
 
 exports[`DeliveryAddress renders with an error 1`] = `
 <div id="deliveryAddressFields"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryAddress"
      data-validate="required"
 >
-  <p>
-    <label for="deliveryAddressLine1"
-           class="o-forms__label"
-    >
-      Address line 1
-    </label>
-    <input type="text"
-           id="deliveryAddressLine1"
-           name="deliveryAddressLine1"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine1"
-           autocomplete="address-line1"
-           placeholder="e.g. 10 Elm Street"
-           aria-required="true"
-           required
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine2"
-           class="o-forms__label"
-    >
-      Address line 2
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine2"
-           name="deliveryAddressLine2"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine2"
-           autocomplete="address-line2"
-           placeholder="e.g. Apartment 1"
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine3"
-           class="o-forms__label"
-    >
-      Address line 3
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine3"
-           name="deliveryAddressLine3"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine3"
-           autocomplete="address-line3"
-           placeholder
-           value
-    >
-  </p>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 1
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+      <input type="text"
+             id="deliveryAddressLine1"
+             name="deliveryAddressLine1"
+             data-trackable="field-deliveryAddressLine1"
+             autocomplete="address-line1"
+             placeholder="e.g. 10 Elm Street"
+             aria-required="true"
+             required
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 2
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+      <input type="text"
+             id="deliveryAddressLine2"
+             name="deliveryAddressLine2"
+             data-trackable="field-deliveryAddressLine2"
+             autocomplete="address-line2"
+             placeholder="e.g. Apartment 1"
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 3
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+      <input type="text"
+             id="deliveryAddressLine3"
+             name="deliveryAddressLine3"
+             data-trackable="field-deliveryAddressLine3"
+             autocomplete="address-line3"
+             placeholder
+             value
+      >
+    </span>
+  </label>
 </div>
 `;
 
 exports[`DeliveryAddress renders with an error 2`] = `
 <div id="deliveryAddressFields"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryAddress"
      data-validate="required"
 >
-  <p>
-    <label for="deliveryAddressLine1"
-           class="o-forms__label"
-    >
-      Address line 1
-    </label>
-    <input type="text"
-           id="deliveryAddressLine1"
-           name="deliveryAddressLine1"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine1"
-           autocomplete="address-line1"
-           placeholder="e.g. 10 Elm Street"
-           aria-required="true"
-           required
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine2"
-           class="o-forms__label"
-    >
-      Address line 2
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine2"
-           name="deliveryAddressLine2"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine2"
-           autocomplete="address-line2"
-           placeholder="e.g. Apartment 1"
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine3"
-           class="o-forms__label"
-    >
-      Address line 3
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine3"
-           name="deliveryAddressLine3"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine3"
-           autocomplete="address-line3"
-           placeholder
-           value
-    >
-  </p>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 1
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+      <input type="text"
+             id="deliveryAddressLine1"
+             name="deliveryAddressLine1"
+             data-trackable="field-deliveryAddressLine1"
+             autocomplete="address-line1"
+             placeholder="e.g. 10 Elm Street"
+             aria-required="true"
+             required
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 2
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+      <input type="text"
+             id="deliveryAddressLine2"
+             name="deliveryAddressLine2"
+             data-trackable="field-deliveryAddressLine2"
+             autocomplete="address-line2"
+             placeholder="e.g. Apartment 1"
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 3
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+      <input type="text"
+             id="deliveryAddressLine3"
+             name="deliveryAddressLine3"
+             data-trackable="field-deliveryAddressLine3"
+             autocomplete="address-line3"
+             placeholder
+             value
+      >
+    </span>
+  </label>
 </div>
 `;
 
 exports[`DeliveryAddress renders with custom line 1 value 1`] = `
 <div id="deliveryAddressFields"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryAddress"
      data-validate="required"
 >
-  <p>
-    <label for="deliveryAddressLine1"
-           class="o-forms__label"
-    >
-      Address line 1
-    </label>
-    <input type="text"
-           id="deliveryAddressLine1"
-           name="deliveryAddressLine1"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine1"
-           autocomplete="address-line1"
-           placeholder="e.g. 10 Elm Street"
-           aria-required="true"
-           required
-           value="Line 1 text"
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine2"
-           class="o-forms__label"
-    >
-      Address line 2
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine2"
-           name="deliveryAddressLine2"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine2"
-           autocomplete="address-line2"
-           placeholder="e.g. Apartment 1"
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine3"
-           class="o-forms__label"
-    >
-      Address line 3
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine3"
-           name="deliveryAddressLine3"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine3"
-           autocomplete="address-line3"
-           placeholder
-           value
-    >
-  </p>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 1
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine1"
+             name="deliveryAddressLine1"
+             data-trackable="field-deliveryAddressLine1"
+             autocomplete="address-line1"
+             placeholder="e.g. 10 Elm Street"
+             aria-required="true"
+             required
+             value="Line 1 text"
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 2
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine2"
+             name="deliveryAddressLine2"
+             data-trackable="field-deliveryAddressLine2"
+             autocomplete="address-line2"
+             placeholder="e.g. Apartment 1"
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 3
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine3"
+             name="deliveryAddressLine3"
+             data-trackable="field-deliveryAddressLine3"
+             autocomplete="address-line3"
+             placeholder
+             value
+      >
+    </span>
+  </label>
 </div>
 `;
 
 exports[`DeliveryAddress renders with custom line 1 value 2`] = `
 <div id="deliveryAddressFields"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryAddress"
      data-validate="required"
 >
-  <p>
-    <label for="deliveryAddressLine1"
-           class="o-forms__label"
-    >
-      Address line 1
-    </label>
-    <input type="text"
-           id="deliveryAddressLine1"
-           name="deliveryAddressLine1"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine1"
-           autocomplete="address-line1"
-           placeholder="e.g. 10 Elm Street"
-           aria-required="true"
-           required
-           value="Line 1 text"
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine2"
-           class="o-forms__label"
-    >
-      Address line 2
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine2"
-           name="deliveryAddressLine2"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine2"
-           autocomplete="address-line2"
-           placeholder="e.g. Apartment 1"
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine3"
-           class="o-forms__label"
-    >
-      Address line 3
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine3"
-           name="deliveryAddressLine3"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine3"
-           autocomplete="address-line3"
-           placeholder
-           value
-    >
-  </p>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 1
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine1"
+             name="deliveryAddressLine1"
+             data-trackable="field-deliveryAddressLine1"
+             autocomplete="address-line1"
+             placeholder="e.g. 10 Elm Street"
+             aria-required="true"
+             required
+             value="Line 1 text"
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 2
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine2"
+             name="deliveryAddressLine2"
+             data-trackable="field-deliveryAddressLine2"
+             autocomplete="address-line2"
+             placeholder="e.g. Apartment 1"
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 3
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine3"
+             name="deliveryAddressLine3"
+             data-trackable="field-deliveryAddressLine3"
+             autocomplete="address-line3"
+             placeholder
+             value
+      >
+    </span>
+  </label>
 </div>
 `;
 
 exports[`DeliveryAddress renders with custom line 2 value 1`] = `
 <div id="deliveryAddressFields"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryAddress"
      data-validate="required"
 >
-  <p>
-    <label for="deliveryAddressLine1"
-           class="o-forms__label"
-    >
-      Address line 1
-    </label>
-    <input type="text"
-           id="deliveryAddressLine1"
-           name="deliveryAddressLine1"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine1"
-           autocomplete="address-line1"
-           placeholder="e.g. 10 Elm Street"
-           aria-required="true"
-           required
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine2"
-           class="o-forms__label"
-    >
-      Address line 2
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine2"
-           name="deliveryAddressLine2"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine2"
-           autocomplete="address-line2"
-           placeholder="e.g. Apartment 1"
-           value="Line 2 text"
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine3"
-           class="o-forms__label"
-    >
-      Address line 3
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine3"
-           name="deliveryAddressLine3"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine3"
-           autocomplete="address-line3"
-           placeholder
-           value
-    >
-  </p>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 1
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine1"
+             name="deliveryAddressLine1"
+             data-trackable="field-deliveryAddressLine1"
+             autocomplete="address-line1"
+             placeholder="e.g. 10 Elm Street"
+             aria-required="true"
+             required
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 2
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine2"
+             name="deliveryAddressLine2"
+             data-trackable="field-deliveryAddressLine2"
+             autocomplete="address-line2"
+             placeholder="e.g. Apartment 1"
+             value="Line 2 text"
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 3
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine3"
+             name="deliveryAddressLine3"
+             data-trackable="field-deliveryAddressLine3"
+             autocomplete="address-line3"
+             placeholder
+             value
+      >
+    </span>
+  </label>
 </div>
 `;
 
 exports[`DeliveryAddress renders with custom line 2 value 2`] = `
 <div id="deliveryAddressFields"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryAddress"
      data-validate="required"
 >
-  <p>
-    <label for="deliveryAddressLine1"
-           class="o-forms__label"
-    >
-      Address line 1
-    </label>
-    <input type="text"
-           id="deliveryAddressLine1"
-           name="deliveryAddressLine1"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine1"
-           autocomplete="address-line1"
-           placeholder="e.g. 10 Elm Street"
-           aria-required="true"
-           required
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine2"
-           class="o-forms__label"
-    >
-      Address line 2
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine2"
-           name="deliveryAddressLine2"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine2"
-           autocomplete="address-line2"
-           placeholder="e.g. Apartment 1"
-           value="Line 2 text"
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine3"
-           class="o-forms__label"
-    >
-      Address line 3
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine3"
-           name="deliveryAddressLine3"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine3"
-           autocomplete="address-line3"
-           placeholder
-           value
-    >
-  </p>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 1
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine1"
+             name="deliveryAddressLine1"
+             data-trackable="field-deliveryAddressLine1"
+             autocomplete="address-line1"
+             placeholder="e.g. 10 Elm Street"
+             aria-required="true"
+             required
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 2
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine2"
+             name="deliveryAddressLine2"
+             data-trackable="field-deliveryAddressLine2"
+             autocomplete="address-line2"
+             placeholder="e.g. Apartment 1"
+             value="Line 2 text"
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 3
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine3"
+             name="deliveryAddressLine3"
+             data-trackable="field-deliveryAddressLine3"
+             autocomplete="address-line3"
+             placeholder
+             value
+      >
+    </span>
+  </label>
 </div>
 `;
 
 exports[`DeliveryAddress renders with custom line 3 value 1`] = `
 <div id="deliveryAddressFields"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryAddress"
      data-validate="required"
 >
-  <p>
-    <label for="deliveryAddressLine1"
-           class="o-forms__label"
-    >
-      Address line 1
-    </label>
-    <input type="text"
-           id="deliveryAddressLine1"
-           name="deliveryAddressLine1"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine1"
-           autocomplete="address-line1"
-           placeholder="e.g. 10 Elm Street"
-           aria-required="true"
-           required
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine2"
-           class="o-forms__label"
-    >
-      Address line 2
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine2"
-           name="deliveryAddressLine2"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine2"
-           autocomplete="address-line2"
-           placeholder="e.g. Apartment 1"
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine3"
-           class="o-forms__label"
-    >
-      Address line 3
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine3"
-           name="deliveryAddressLine3"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine3"
-           autocomplete="address-line3"
-           placeholder
-           value="Line 3 text"
-    >
-  </p>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 1
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine1"
+             name="deliveryAddressLine1"
+             data-trackable="field-deliveryAddressLine1"
+             autocomplete="address-line1"
+             placeholder="e.g. 10 Elm Street"
+             aria-required="true"
+             required
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 2
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine2"
+             name="deliveryAddressLine2"
+             data-trackable="field-deliveryAddressLine2"
+             autocomplete="address-line2"
+             placeholder="e.g. Apartment 1"
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 3
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine3"
+             name="deliveryAddressLine3"
+             data-trackable="field-deliveryAddressLine3"
+             autocomplete="address-line3"
+             placeholder
+             value="Line 3 text"
+      >
+    </span>
+  </label>
 </div>
 `;
 
 exports[`DeliveryAddress renders with custom line 3 value 2`] = `
 <div id="deliveryAddressFields"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryAddress"
      data-validate="required"
 >
-  <p>
-    <label for="deliveryAddressLine1"
-           class="o-forms__label"
-    >
-      Address line 1
-    </label>
-    <input type="text"
-           id="deliveryAddressLine1"
-           name="deliveryAddressLine1"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine1"
-           autocomplete="address-line1"
-           placeholder="e.g. 10 Elm Street"
-           aria-required="true"
-           required
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine2"
-           class="o-forms__label"
-    >
-      Address line 2
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine2"
-           name="deliveryAddressLine2"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine2"
-           autocomplete="address-line2"
-           placeholder="e.g. Apartment 1"
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine3"
-           class="o-forms__label"
-    >
-      Address line 3
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine3"
-           name="deliveryAddressLine3"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine3"
-           autocomplete="address-line3"
-           placeholder
-           value="Line 3 text"
-    >
-  </p>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 1
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine1"
+             name="deliveryAddressLine1"
+             data-trackable="field-deliveryAddressLine1"
+             autocomplete="address-line1"
+             placeholder="e.g. 10 Elm Street"
+             aria-required="true"
+             required
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 2
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine2"
+             name="deliveryAddressLine2"
+             data-trackable="field-deliveryAddressLine2"
+             autocomplete="address-line2"
+             placeholder="e.g. Apartment 1"
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 3
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine3"
+             name="deliveryAddressLine3"
+             data-trackable="field-deliveryAddressLine3"
+             autocomplete="address-line3"
+             placeholder
+             value="Line 3 text"
+      >
+    </span>
+  </label>
 </div>
 `;
 
 exports[`DeliveryAddress renders with disabled input elements 1`] = `
 <div id="deliveryAddressFields"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryAddress"
      data-validate="required"
 >
-  <p>
-    <label for="deliveryAddressLine1"
-           class="o-forms__label"
-    >
-      Address line 1
-    </label>
-    <input type="text"
-           id="deliveryAddressLine1"
-           name="deliveryAddressLine1"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine1"
-           autocomplete="address-line1"
-           placeholder="e.g. 10 Elm Street"
-           aria-required="true"
-           required
-           disabled
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine2"
-           class="o-forms__label"
-    >
-      Address line 2
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine2"
-           name="deliveryAddressLine2"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine2"
-           autocomplete="address-line2"
-           placeholder="e.g. Apartment 1"
-           disabled
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine3"
-           class="o-forms__label"
-    >
-      Address line 3
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine3"
-           name="deliveryAddressLine3"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine3"
-           autocomplete="address-line3"
-           placeholder
-           disabled
-           value
-    >
-  </p>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 1
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine1"
+             name="deliveryAddressLine1"
+             data-trackable="field-deliveryAddressLine1"
+             autocomplete="address-line1"
+             placeholder="e.g. 10 Elm Street"
+             aria-required="true"
+             required
+             disabled
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 2
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine2"
+             name="deliveryAddressLine2"
+             data-trackable="field-deliveryAddressLine2"
+             autocomplete="address-line2"
+             placeholder="e.g. Apartment 1"
+             disabled
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 3
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine3"
+             name="deliveryAddressLine3"
+             data-trackable="field-deliveryAddressLine3"
+             autocomplete="address-line3"
+             placeholder
+             disabled
+             value
+      >
+    </span>
+  </label>
 </div>
 `;
 
 exports[`DeliveryAddress renders with disabled input elements 2`] = `
 <div id="deliveryAddressFields"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryAddress"
      data-validate="required"
 >
-  <p>
-    <label for="deliveryAddressLine1"
-           class="o-forms__label"
-    >
-      Address line 1
-    </label>
-    <input type="text"
-           id="deliveryAddressLine1"
-           name="deliveryAddressLine1"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine1"
-           autocomplete="address-line1"
-           placeholder="e.g. 10 Elm Street"
-           aria-required="true"
-           required
-           disabled
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine2"
-           class="o-forms__label"
-    >
-      Address line 2
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine2"
-           name="deliveryAddressLine2"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine2"
-           autocomplete="address-line2"
-           placeholder="e.g. Apartment 1"
-           disabled
-           value
-    >
-  </p>
-  <p>
-    <label for="deliveryAddressLine3"
-           class="o-forms__label"
-    >
-      Address line 3
-      <small>
-        (optional)
-      </small>
-    </label>
-    <input type="text"
-           id="deliveryAddressLine3"
-           name="deliveryAddressLine3"
-           class="o-forms__text js-field__input js-item__value"
-           data-trackable="field-deliveryAddressLine3"
-           autocomplete="address-line3"
-           placeholder
-           disabled
-           value
-    >
-  </p>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 1
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine1"
+             name="deliveryAddressLine1"
+             data-trackable="field-deliveryAddressLine1"
+             autocomplete="address-line1"
+             placeholder="e.g. 10 Elm Street"
+             aria-required="true"
+             required
+             disabled
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 2
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine2"
+             name="deliveryAddressLine2"
+             data-trackable="field-deliveryAddressLine2"
+             autocomplete="address-line2"
+             placeholder="e.g. Apartment 1"
+             disabled
+             value
+      >
+    </span>
+  </label>
+  <label class="o-forms-field">
+    <span class="o-forms-title">
+      <span class="o-forms-title__main">
+        Address line 3
+        <small>
+          (optional)
+        </small>
+      </span>
+    </span>
+    <span class="o-forms-input o-forms-input--text">
+      <input type="text"
+             id="deliveryAddressLine3"
+             name="deliveryAddressLine3"
+             data-trackable="field-deliveryAddressLine3"
+             autocomplete="address-line3"
+             placeholder
+             disabled
+             value
+      >
+    </span>
+  </label>
 </div>
 `;

--- a/components/__snapshots__/delivery-city.spec.js.snap
+++ b/components/__snapshots__/delivery-city.spec.js.snap
@@ -1,211 +1,203 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DeliveryCity renders with a custom value 1`] = `
-<div id="deliveryCityField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryCity"
-     data-validate="required"
+<label id="deliveryCityField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryCity"
-         class="o-forms__label"
-  >
-    City/town
-  </label>
-  <input type="text"
-         id="deliveryCity"
-         name="deliveryCity"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="field-deliveryCity"
-         autocomplete="address-level2"
-         placeholder="e.g. Bath"
-         aria-required="true"
-         required
-         value="foobar"
-  >
-</div>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      City/town
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryCity"
+           name="deliveryCity"
+           data-trackable="field-deliveryCity"
+           autocomplete="address-level2"
+           placeholder="e.g. Bath"
+           aria-required="true"
+           required
+           value="foobar"
+    >
+  </span>
+</label>
 `;
 
 exports[`DeliveryCity renders with a custom value 2`] = `
-<div id="deliveryCityField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryCity"
-     data-validate="required"
+<label id="deliveryCityField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryCity"
-         class="o-forms__label"
-  >
-    City/town
-  </label>
-  <input type="text"
-         id="deliveryCity"
-         name="deliveryCity"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="field-deliveryCity"
-         autocomplete="address-level2"
-         placeholder="e.g. Bath"
-         aria-required="true"
-         required
-         value="foobar"
-  >
-</div>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      City/town
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryCity"
+           name="deliveryCity"
+           data-trackable="field-deliveryCity"
+           autocomplete="address-level2"
+           placeholder="e.g. Bath"
+           aria-required="true"
+           required
+           value="foobar"
+    >
+  </span>
+</label>
 `;
 
 exports[`DeliveryCity renders with a disabled input element 1`] = `
-<div id="deliveryCityField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryCity"
-     data-validate="required"
+<label id="deliveryCityField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryCity"
-         class="o-forms__label"
-  >
-    City/town
-  </label>
-  <input type="text"
-         id="deliveryCity"
-         name="deliveryCity"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="field-deliveryCity"
-         autocomplete="address-level2"
-         placeholder="e.g. Bath"
-         aria-required="true"
-         required
-         disabled
-         value
-  >
-</div>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      City/town
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryCity"
+           name="deliveryCity"
+           data-trackable="field-deliveryCity"
+           autocomplete="address-level2"
+           placeholder="e.g. Bath"
+           aria-required="true"
+           required
+           disabled
+           value
+    >
+  </span>
+</label>
 `;
 
 exports[`DeliveryCity renders with a disabled input element 2`] = `
-<div id="deliveryCityField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryCity"
-     data-validate="required"
+<label id="deliveryCityField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryCity"
-         class="o-forms__label"
-  >
-    City/town
-  </label>
-  <input type="text"
-         id="deliveryCity"
-         name="deliveryCity"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="field-deliveryCity"
-         autocomplete="address-level2"
-         placeholder="e.g. Bath"
-         aria-required="true"
-         required
-         disabled
-         value
-  >
-</div>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      City/town
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryCity"
+           name="deliveryCity"
+           data-trackable="field-deliveryCity"
+           autocomplete="address-level2"
+           placeholder="e.g. Bath"
+           aria-required="true"
+           required
+           disabled
+           value
+    >
+  </span>
+</label>
 `;
 
 exports[`DeliveryCity renders with an error 1`] = `
-<div id="deliveryCityField"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryCity"
-     data-validate="required"
+<label id="deliveryCityField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryCity"
-         class="o-forms__label"
-  >
-    City/town
-  </label>
-  <input type="text"
-         id="deliveryCity"
-         name="deliveryCity"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="field-deliveryCity"
-         autocomplete="address-level2"
-         placeholder="e.g. Bath"
-         aria-required="true"
-         required
-         value
-  >
-</div>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      City/town
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+    <input type="text"
+           id="deliveryCity"
+           name="deliveryCity"
+           data-trackable="field-deliveryCity"
+           autocomplete="address-level2"
+           placeholder="e.g. Bath"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+</label>
 `;
 
 exports[`DeliveryCity renders with an error 2`] = `
-<div id="deliveryCityField"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryCity"
-     data-validate="required"
+<label id="deliveryCityField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryCity"
-         class="o-forms__label"
-  >
-    City/town
-  </label>
-  <input type="text"
-         id="deliveryCity"
-         name="deliveryCity"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="field-deliveryCity"
-         autocomplete="address-level2"
-         placeholder="e.g. Bath"
-         aria-required="true"
-         required
-         value
-  >
-</div>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      City/town
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+    <input type="text"
+           id="deliveryCity"
+           name="deliveryCity"
+           data-trackable="field-deliveryCity"
+           autocomplete="address-level2"
+           placeholder="e.g. Bath"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+</label>
 `;
 
 exports[`DeliveryCity renders with default props 1`] = `
-<div id="deliveryCityField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryCity"
-     data-validate="required"
+<label id="deliveryCityField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryCity"
-         class="o-forms__label"
-  >
-    City/town
-  </label>
-  <input type="text"
-         id="deliveryCity"
-         name="deliveryCity"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="field-deliveryCity"
-         autocomplete="address-level2"
-         placeholder="e.g. Bath"
-         aria-required="true"
-         required
-         value
-  >
-</div>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      City/town
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryCity"
+           name="deliveryCity"
+           data-trackable="field-deliveryCity"
+           autocomplete="address-level2"
+           placeholder="e.g. Bath"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+</label>
 `;
 
 exports[`DeliveryCity renders with default props 2`] = `
-<div id="deliveryCityField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryCity"
-     data-validate="required"
+<label id="deliveryCityField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryCity"
-         class="o-forms__label"
-  >
-    City/town
-  </label>
-  <input type="text"
-         id="deliveryCity"
-         name="deliveryCity"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="field-deliveryCity"
-         autocomplete="address-level2"
-         placeholder="e.g. Bath"
-         aria-required="true"
-         required
-         value
-  >
-</div>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      City/town
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryCity"
+           name="deliveryCity"
+           data-trackable="field-deliveryCity"
+           autocomplete="address-level2"
+           placeholder="e.g. Bath"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+</label>
 `;

--- a/components/__snapshots__/delivery-county.spec.js.snap
+++ b/components/__snapshots__/delivery-county.spec.js.snap
@@ -1,219 +1,211 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DeliveryCounty renders with a custom value 1`] = `
-<div id="deliveryCountyField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryCounty"
-     data-validate="required"
+<label id="deliveryCountyField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryCounty"
-         class="o-forms__label"
-  >
-    County
-    <small>
-      (optional)
-    </small>
-  </label>
-  <input type="text"
-         id="deliveryCounty"
-         name="deliveryCounty"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="field-deliveryCounty"
-         autocomplete="address-level3"
-         placeholder="e.g. Somerset"
-         value="foobar"
-  >
-</div>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      County
+      <small>
+        (optional)
+      </small>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryCounty"
+           name="deliveryCounty"
+           data-trackable="field-deliveryCounty"
+           autocomplete="address-level3"
+           placeholder="e.g. Somerset"
+           value="foobar"
+    >
+  </span>
+</label>
 `;
 
 exports[`DeliveryCounty renders with a custom value 2`] = `
-<div id="deliveryCountyField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryCounty"
-     data-validate="required"
+<label id="deliveryCountyField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryCounty"
-         class="o-forms__label"
-  >
-    County
-    <small>
-      (optional)
-    </small>
-  </label>
-  <input type="text"
-         id="deliveryCounty"
-         name="deliveryCounty"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="field-deliveryCounty"
-         autocomplete="address-level3"
-         placeholder="e.g. Somerset"
-         value="foobar"
-  >
-</div>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      County
+      <small>
+        (optional)
+      </small>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryCounty"
+           name="deliveryCounty"
+           data-trackable="field-deliveryCounty"
+           autocomplete="address-level3"
+           placeholder="e.g. Somerset"
+           value="foobar"
+    >
+  </span>
+</label>
 `;
 
 exports[`DeliveryCounty renders with a disabled input element 1`] = `
-<div id="deliveryCountyField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryCounty"
-     data-validate="required"
+<label id="deliveryCountyField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryCounty"
-         class="o-forms__label"
-  >
-    County
-    <small>
-      (optional)
-    </small>
-  </label>
-  <input type="text"
-         id="deliveryCounty"
-         name="deliveryCounty"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="field-deliveryCounty"
-         autocomplete="address-level3"
-         placeholder="e.g. Somerset"
-         disabled
-         value
-  >
-</div>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      County
+      <small>
+        (optional)
+      </small>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryCounty"
+           name="deliveryCounty"
+           data-trackable="field-deliveryCounty"
+           autocomplete="address-level3"
+           placeholder="e.g. Somerset"
+           disabled
+           value
+    >
+  </span>
+</label>
 `;
 
 exports[`DeliveryCounty renders with a disabled input element 2`] = `
-<div id="deliveryCountyField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryCounty"
-     data-validate="required"
+<label id="deliveryCountyField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryCounty"
-         class="o-forms__label"
-  >
-    County
-    <small>
-      (optional)
-    </small>
-  </label>
-  <input type="text"
-         id="deliveryCounty"
-         name="deliveryCounty"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="field-deliveryCounty"
-         autocomplete="address-level3"
-         placeholder="e.g. Somerset"
-         disabled
-         value
-  >
-</div>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      County
+      <small>
+        (optional)
+      </small>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryCounty"
+           name="deliveryCounty"
+           data-trackable="field-deliveryCounty"
+           autocomplete="address-level3"
+           placeholder="e.g. Somerset"
+           disabled
+           value
+    >
+  </span>
+</label>
 `;
 
 exports[`DeliveryCounty renders with an error 1`] = `
-<div id="deliveryCountyField"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryCounty"
-     data-validate="required"
+<label id="deliveryCountyField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryCounty"
-         class="o-forms__label"
-  >
-    County
-    <small>
-      (optional)
-    </small>
-  </label>
-  <input type="text"
-         id="deliveryCounty"
-         name="deliveryCounty"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="field-deliveryCounty"
-         autocomplete="address-level3"
-         placeholder="e.g. Somerset"
-         value
-  >
-</div>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      County
+      <small>
+        (optional)
+      </small>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+    <input type="text"
+           id="deliveryCounty"
+           name="deliveryCounty"
+           data-trackable="field-deliveryCounty"
+           autocomplete="address-level3"
+           placeholder="e.g. Somerset"
+           value
+    >
+  </span>
+</label>
 `;
 
 exports[`DeliveryCounty renders with an error 2`] = `
-<div id="deliveryCountyField"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryCounty"
-     data-validate="required"
+<label id="deliveryCountyField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryCounty"
-         class="o-forms__label"
-  >
-    County
-    <small>
-      (optional)
-    </small>
-  </label>
-  <input type="text"
-         id="deliveryCounty"
-         name="deliveryCounty"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="field-deliveryCounty"
-         autocomplete="address-level3"
-         placeholder="e.g. Somerset"
-         value
-  >
-</div>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      County
+      <small>
+        (optional)
+      </small>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+    <input type="text"
+           id="deliveryCounty"
+           name="deliveryCounty"
+           data-trackable="field-deliveryCounty"
+           autocomplete="address-level3"
+           placeholder="e.g. Somerset"
+           value
+    >
+  </span>
+</label>
 `;
 
 exports[`DeliveryCounty renders with default props 1`] = `
-<div id="deliveryCountyField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryCounty"
-     data-validate="required"
+<label id="deliveryCountyField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryCounty"
-         class="o-forms__label"
-  >
-    County
-    <small>
-      (optional)
-    </small>
-  </label>
-  <input type="text"
-         id="deliveryCounty"
-         name="deliveryCounty"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="field-deliveryCounty"
-         autocomplete="address-level3"
-         placeholder="e.g. Somerset"
-         value
-  >
-</div>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      County
+      <small>
+        (optional)
+      </small>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryCounty"
+           name="deliveryCounty"
+           data-trackable="field-deliveryCounty"
+           autocomplete="address-level3"
+           placeholder="e.g. Somerset"
+           value
+    >
+  </span>
+</label>
 `;
 
 exports[`DeliveryCounty renders with default props 2`] = `
-<div id="deliveryCountyField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryCounty"
-     data-validate="required"
+<label id="deliveryCountyField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryCounty"
-         class="o-forms__label"
-  >
-    County
-    <small>
-      (optional)
-    </small>
-  </label>
-  <input type="text"
-         id="deliveryCounty"
-         name="deliveryCounty"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="field-deliveryCounty"
-         autocomplete="address-level3"
-         placeholder="e.g. Somerset"
-         value
-  >
-</div>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      County
+      <small>
+        (optional)
+      </small>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryCounty"
+           name="deliveryCounty"
+           data-trackable="field-deliveryCounty"
+           autocomplete="address-level3"
+           placeholder="e.g. Somerset"
+           value
+    >
+  </span>
+</label>
 `;

--- a/components/__snapshots__/delivery-instructions.spec.js.snap
+++ b/components/__snapshots__/delivery-instructions.spec.js.snap
@@ -1,429 +1,405 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DeliveryInstructions renders with a custom value 1`] = `
-<div id="deliveryInstructionsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryInstructions"
-     data-validate="required"
+<label id="deliveryInstructionsField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryInstructions"
-         class="o-forms__label"
-  >
-    Delivery instructions
-    <small>
-      (optional)
-    </small>
-  </label>
-  <div class="ncf__terms ncf__terms--small">
-    These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
-  </div>
-  <textarea type="text"
-            id="deliveryInstructions"
-            name="deliveryInstructions"
-            class="o-forms__text js-field__input js-item__value"
-            data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery instructions
+      <small>
+        (optional)
+      </small>
+    </span>
+    <span class="o-forms-title__prompt">
+      These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--textarea">
+    <textarea id="deliveryInstructions"
+              name="deliveryInstructions"
+              data-trackable="field-deliveryInstructions"
+              placeholder="Enter instructions :
 - Door colour, letterbox location
 - Placement i.e. letterbox delivery
 - Special handling i.e. place in plastic bag"
-  >
-    foobar
-  </textarea>
+    >
+      foobar
+    </textarea>
+  </span>
   <p>
     Please note that we can only deliver to the ground floor level of your property.
   </p>
-</div>
+</label>
 `;
 
 exports[`DeliveryInstructions renders with a custom value 2`] = `
-<div id="deliveryInstructionsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryInstructions"
-     data-validate="required"
+<label id="deliveryInstructionsField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryInstructions"
-         class="o-forms__label"
-  >
-    Delivery instructions
-    <small>
-      (optional)
-    </small>
-  </label>
-  <div class="ncf__terms ncf__terms--small">
-    These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
-  </div>
-  <textarea type="text"
-            id="deliveryInstructions"
-            name="deliveryInstructions"
-            class="o-forms__text js-field__input js-item__value"
-            data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery instructions
+      <small>
+        (optional)
+      </small>
+    </span>
+    <span class="o-forms-title__prompt">
+      These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--textarea">
+    <textarea id="deliveryInstructions"
+              name="deliveryInstructions"
+              data-trackable="field-deliveryInstructions"
+              placeholder="Enter instructions :
 - Door colour, letterbox location
 - Placement i.e. letterbox delivery
 - Special handling i.e. place in plastic bag"
-  >
-    foobar
-  </textarea>
+    >
+      foobar
+    </textarea>
+  </span>
   <p>
     Please note that we can only deliver to the ground floor level of your property.
   </p>
-</div>
+</label>
 `;
 
 exports[`DeliveryInstructions renders with a disabled input element 1`] = `
-<div id="deliveryInstructionsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryInstructions"
-     data-validate="required"
+<label id="deliveryInstructionsField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryInstructions"
-         class="o-forms__label"
-  >
-    Delivery instructions
-    <small>
-      (optional)
-    </small>
-  </label>
-  <div class="ncf__terms ncf__terms--small">
-    These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
-  </div>
-  <textarea type="text"
-            id="deliveryInstructions"
-            name="deliveryInstructions"
-            class="o-forms__text js-field__input js-item__value"
-            data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery instructions
+      <small>
+        (optional)
+      </small>
+    </span>
+    <span class="o-forms-title__prompt">
+      These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--textarea">
+    <textarea id="deliveryInstructions"
+              name="deliveryInstructions"
+              data-trackable="field-deliveryInstructions"
+              placeholder="Enter instructions :
 - Door colour, letterbox location
 - Placement i.e. letterbox delivery
 - Special handling i.e. place in plastic bag"
-            disabled
-  >
-  </textarea>
+              disabled
+    >
+    </textarea>
+  </span>
   <p>
     Please note that we can only deliver to the ground floor level of your property.
   </p>
-</div>
+</label>
 `;
 
 exports[`DeliveryInstructions renders with a disabled input element 2`] = `
-<div id="deliveryInstructionsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryInstructions"
-     data-validate="required"
+<label id="deliveryInstructionsField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryInstructions"
-         class="o-forms__label"
-  >
-    Delivery instructions
-    <small>
-      (optional)
-    </small>
-  </label>
-  <div class="ncf__terms ncf__terms--small">
-    These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
-  </div>
-  <textarea type="text"
-            id="deliveryInstructions"
-            name="deliveryInstructions"
-            class="o-forms__text js-field__input js-item__value"
-            data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery instructions
+      <small>
+        (optional)
+      </small>
+    </span>
+    <span class="o-forms-title__prompt">
+      These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--textarea">
+    <textarea id="deliveryInstructions"
+              name="deliveryInstructions"
+              data-trackable="field-deliveryInstructions"
+              placeholder="Enter instructions :
 - Door colour, letterbox location
 - Placement i.e. letterbox delivery
 - Special handling i.e. place in plastic bag"
-            disabled
-  >
-  </textarea>
+              disabled
+    >
+    </textarea>
+  </span>
   <p>
     Please note that we can only deliver to the ground floor level of your property.
   </p>
-</div>
+</label>
 `;
 
 exports[`DeliveryInstructions renders with an error 1`] = `
-<div id="deliveryInstructionsField"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryInstructions"
-     data-validate="required"
+<label id="deliveryInstructionsField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryInstructions"
-         class="o-forms__label"
-  >
-    Delivery instructions
-    <small>
-      (optional)
-    </small>
-  </label>
-  <div class="ncf__terms ncf__terms--small">
-    These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
-  </div>
-  <textarea type="text"
-            id="deliveryInstructions"
-            name="deliveryInstructions"
-            class="o-forms__text js-field__input js-item__value"
-            data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery instructions
+      <small>
+        (optional)
+      </small>
+    </span>
+    <span class="o-forms-title__prompt">
+      These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--textarea o-forms-input--invalid">
+    <textarea id="deliveryInstructions"
+              name="deliveryInstructions"
+              data-trackable="field-deliveryInstructions"
+              placeholder="Enter instructions :
 - Door colour, letterbox location
 - Placement i.e. letterbox delivery
 - Special handling i.e. place in plastic bag"
-  >
-  </textarea>
+    >
+    </textarea>
+  </span>
   <p>
     Please note that we can only deliver to the ground floor level of your property.
   </p>
-</div>
+</label>
 `;
 
 exports[`DeliveryInstructions renders with an error 2`] = `
-<div id="deliveryInstructionsField"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryInstructions"
-     data-validate="required"
+<label id="deliveryInstructionsField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryInstructions"
-         class="o-forms__label"
-  >
-    Delivery instructions
-    <small>
-      (optional)
-    </small>
-  </label>
-  <div class="ncf__terms ncf__terms--small">
-    These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
-  </div>
-  <textarea type="text"
-            id="deliveryInstructions"
-            name="deliveryInstructions"
-            class="o-forms__text js-field__input js-item__value"
-            data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery instructions
+      <small>
+        (optional)
+      </small>
+    </span>
+    <span class="o-forms-title__prompt">
+      These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--textarea o-forms-input--invalid">
+    <textarea id="deliveryInstructions"
+              name="deliveryInstructions"
+              data-trackable="field-deliveryInstructions"
+              placeholder="Enter instructions :
 - Door colour, letterbox location
 - Placement i.e. letterbox delivery
 - Special handling i.e. place in plastic bag"
-  >
-  </textarea>
+    >
+    </textarea>
+  </span>
   <p>
     Please note that we can only deliver to the ground floor level of your property.
   </p>
-</div>
+</label>
 `;
 
 exports[`DeliveryInstructions renders with default props 1`] = `
-<div id="deliveryInstructionsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryInstructions"
-     data-validate="required"
+<label id="deliveryInstructionsField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryInstructions"
-         class="o-forms__label"
-  >
-    Delivery instructions
-    <small>
-      (optional)
-    </small>
-  </label>
-  <div class="ncf__terms ncf__terms--small">
-    These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
-  </div>
-  <textarea type="text"
-            id="deliveryInstructions"
-            name="deliveryInstructions"
-            class="o-forms__text js-field__input js-item__value"
-            data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery instructions
+      <small>
+        (optional)
+      </small>
+    </span>
+    <span class="o-forms-title__prompt">
+      These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--textarea">
+    <textarea id="deliveryInstructions"
+              name="deliveryInstructions"
+              data-trackable="field-deliveryInstructions"
+              placeholder="Enter instructions :
 - Door colour, letterbox location
 - Placement i.e. letterbox delivery
 - Special handling i.e. place in plastic bag"
-  >
-  </textarea>
+    >
+    </textarea>
+  </span>
   <p>
     Please note that we can only deliver to the ground floor level of your property.
   </p>
-</div>
+</label>
 `;
 
 exports[`DeliveryInstructions renders with default props 2`] = `
-<div id="deliveryInstructionsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryInstructions"
-     data-validate="required"
+<label id="deliveryInstructionsField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryInstructions"
-         class="o-forms__label"
-  >
-    Delivery instructions
-    <small>
-      (optional)
-    </small>
-  </label>
-  <div class="ncf__terms ncf__terms--small">
-    These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
-  </div>
-  <textarea type="text"
-            id="deliveryInstructions"
-            name="deliveryInstructions"
-            class="o-forms__text js-field__input js-item__value"
-            data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery instructions
+      <small>
+        (optional)
+      </small>
+    </span>
+    <span class="o-forms-title__prompt">
+      These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--textarea">
+    <textarea id="deliveryInstructions"
+              name="deliveryInstructions"
+              data-trackable="field-deliveryInstructions"
+              placeholder="Enter instructions :
 - Door colour, letterbox location
 - Placement i.e. letterbox delivery
 - Special handling i.e. place in plastic bag"
-  >
-  </textarea>
+    >
+    </textarea>
+  </span>
   <p>
     Please note that we can only deliver to the ground floor level of your property.
   </p>
-</div>
+</label>
 `;
 
 exports[`DeliveryInstructions renders with maxlength 1`] = `
-<div id="deliveryInstructionsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryInstructions"
-     data-validate="required"
+<label id="deliveryInstructionsField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryInstructions"
-         class="o-forms__label"
-  >
-    Delivery instructions
-    <small>
-      (optional)
-    </small>
-  </label>
-  <div class="ncf__terms ncf__terms--small">
-    These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
-  </div>
-  <textarea type="text"
-            id="deliveryInstructions"
-            name="deliveryInstructions"
-            maxlength="200"
-            class="o-forms__text js-field__input js-item__value"
-            data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions (Max. 200 characters):
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery instructions
+      <small>
+        (optional)
+      </small>
+    </span>
+    <span class="o-forms-title__prompt">
+      These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--textarea">
+    <textarea id="deliveryInstructions"
+              name="deliveryInstructions"
+              maxlength="200"
+              data-trackable="field-deliveryInstructions"
+              placeholder="Enter instructions (Max. 200 characters):
 - Door colour, letterbox location
 - Placement i.e. letterbox delivery
 - Special handling i.e. place in plastic bag"
-  >
-  </textarea>
+    >
+    </textarea>
+  </span>
   <p>
     Please note that we can only deliver to the ground floor level of your property.
   </p>
-</div>
+</label>
 `;
 
 exports[`DeliveryInstructions renders with maxlength 2`] = `
-<div id="deliveryInstructionsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryInstructions"
-     data-validate="required"
+<label id="deliveryInstructionsField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryInstructions"
-         class="o-forms__label"
-  >
-    Delivery instructions
-    <small>
-      (optional)
-    </small>
-  </label>
-  <div class="ncf__terms ncf__terms--small">
-    These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
-  </div>
-  <textarea type="text"
-            id="deliveryInstructions"
-            name="deliveryInstructions"
-            maxlength="200"
-            class="o-forms__text js-field__input js-item__value"
-            data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions (Max. 200 characters):
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery instructions
+      <small>
+        (optional)
+      </small>
+    </span>
+    <span class="o-forms-title__prompt">
+      These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--textarea">
+    <textarea id="deliveryInstructions"
+              name="deliveryInstructions"
+              maxlength="200"
+              data-trackable="field-deliveryInstructions"
+              placeholder="Enter instructions (Max. 200 characters):
 - Door colour, letterbox location
 - Placement i.e. letterbox delivery
 - Special handling i.e. place in plastic bag"
-  >
-  </textarea>
+    >
+    </textarea>
+  </span>
   <p>
     Please note that we can only deliver to the ground floor level of your property.
   </p>
-</div>
+</label>
 `;
 
 exports[`DeliveryInstructions renders with rows 1`] = `
-<div id="deliveryInstructionsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryInstructions"
-     data-validate="required"
+<label id="deliveryInstructionsField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryInstructions"
-         class="o-forms__label"
-  >
-    Delivery instructions
-    <small>
-      (optional)
-    </small>
-  </label>
-  <div class="ncf__terms ncf__terms--small">
-    These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
-  </div>
-  <textarea type="text"
-            id="deliveryInstructions"
-            name="deliveryInstructions"
-            rows="20"
-            class="o-forms__text js-field__input js-item__value"
-            data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery instructions
+      <small>
+        (optional)
+      </small>
+    </span>
+    <span class="o-forms-title__prompt">
+      These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--textarea">
+    <textarea id="deliveryInstructions"
+              name="deliveryInstructions"
+              rows="20"
+              data-trackable="field-deliveryInstructions"
+              placeholder="Enter instructions :
 - Door colour, letterbox location
 - Placement i.e. letterbox delivery
 - Special handling i.e. place in plastic bag"
-  >
-  </textarea>
+    >
+    </textarea>
+  </span>
   <p>
     Please note that we can only deliver to the ground floor level of your property.
   </p>
-</div>
+</label>
 `;
 
 exports[`DeliveryInstructions renders with rows 2`] = `
-<div id="deliveryInstructionsField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryInstructions"
-     data-validate="required"
+<label id="deliveryInstructionsField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryInstructions"
-         class="o-forms__label"
-  >
-    Delivery instructions
-    <small>
-      (optional)
-    </small>
-  </label>
-  <div class="ncf__terms ncf__terms--small">
-    These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
-  </div>
-  <textarea type="text"
-            id="deliveryInstructions"
-            name="deliveryInstructions"
-            rows="20"
-            class="o-forms__text js-field__input js-item__value"
-            data-trackable="field-deliveryInstructions"
-            placeholder="Enter instructions :
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery instructions
+      <small>
+        (optional)
+      </small>
+    </span>
+    <span class="o-forms-title__prompt">
+      These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--textarea">
+    <textarea id="deliveryInstructions"
+              name="deliveryInstructions"
+              rows="20"
+              data-trackable="field-deliveryInstructions"
+              placeholder="Enter instructions :
 - Door colour, letterbox location
 - Placement i.e. letterbox delivery
 - Special handling i.e. place in plastic bag"
-  >
-  </textarea>
+    >
+    </textarea>
+  </span>
   <p>
     Please note that we can only deliver to the ground floor level of your property.
   </p>
-</div>
+</label>
 `;

--- a/components/__snapshots__/delivery-postcode.spec.js.snap
+++ b/components/__snapshots__/delivery-postcode.spec.js.snap
@@ -1,225 +1,219 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Delivery Postcode render a disable input 1`] = `
-<div id="deliveryPostcodeField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryPostcode"
-     data-validate="required"
+<label id="deliveryPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryPostcode"
-         class="o-forms__label"
-  >
-    Delivery
-    <span data-reference="postcode">
-      ZipCode
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery
+      <span data-reference="postcode">
+        ZipCode
+      </span>
     </span>
-  </label>
-  <input type="text"
-         id="deliveryPostcode"
-         name="deliveryPostcode"
-         placeholder="Enter your ZipCode"
-         autocomplete="postal-code"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="delivery-postcode"
-         aria-required="true"
-         required
-         pattern="whatever"
-         disabled
-         value
-  >
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryPostcode"
+           name="deliveryPostcode"
+           placeholder="Enter your ZipCode"
+           autocomplete="postal-code"
+           data-trackable="delivery-postcode"
+           aria-required="true"
+           required
+           pattern="whatever"
+           disabled
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter a valid
     <span data-reference="postcode">
       ZipCode
     </span>
     .
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Delivery Postcode render a disable input 2`] = `
-<div id="deliveryPostcodeField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryPostcode"
-     data-validate="required"
+<label id="deliveryPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryPostcode"
-         class="o-forms__label"
-  >
-    Delivery
-    <span data-reference="postcode">
-      ZipCode
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery
+      <span data-reference="postcode">
+        ZipCode
+      </span>
     </span>
-  </label>
-  <input type="text"
-         id="deliveryPostcode"
-         name="deliveryPostcode"
-         placeholder="Enter your ZipCode"
-         autocomplete="postal-code"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="delivery-postcode"
-         aria-required="true"
-         required
-         pattern="whatever"
-         disabled
-         value
-  >
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryPostcode"
+           name="deliveryPostcode"
+           placeholder="Enter your ZipCode"
+           autocomplete="postal-code"
+           data-trackable="delivery-postcode"
+           aria-required="true"
+           required
+           pattern="whatever"
+           disabled
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter a valid
     <span data-reference="postcode">
       ZipCode
     </span>
     .
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Delivery Postcode render a postcode input with a label 1`] = `
-<div id="deliveryPostcodeField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryPostcode"
-     data-validate="required"
+<label id="deliveryPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryPostcode"
-         class="o-forms__label"
-  >
-    Delivery
-    <span data-reference="postcode">
-      ZipCode
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery
+      <span data-reference="postcode">
+        ZipCode
+      </span>
     </span>
-  </label>
-  <input type="text"
-         id="deliveryPostcode"
-         name="deliveryPostcode"
-         placeholder="Enter your ZipCode"
-         autocomplete="postal-code"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="delivery-postcode"
-         aria-required="true"
-         required
-         pattern="whatever"
-         value
-  >
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryPostcode"
+           name="deliveryPostcode"
+           placeholder="Enter your ZipCode"
+           autocomplete="postal-code"
+           data-trackable="delivery-postcode"
+           aria-required="true"
+           required
+           pattern="whatever"
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter a valid
     <span data-reference="postcode">
       ZipCode
     </span>
     .
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Delivery Postcode render a postcode input with a label 2`] = `
-<div id="deliveryPostcodeField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryPostcode"
-     data-validate="required"
+<label id="deliveryPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
 >
-  <label for="deliveryPostcode"
-         class="o-forms__label"
-  >
-    Delivery
-    <span data-reference="postcode">
-      ZipCode
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery
+      <span data-reference="postcode">
+        ZipCode
+      </span>
     </span>
-  </label>
-  <input type="text"
-         id="deliveryPostcode"
-         name="deliveryPostcode"
-         placeholder="Enter your ZipCode"
-         autocomplete="postal-code"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="delivery-postcode"
-         aria-required="true"
-         required
-         pattern="whatever"
-         value
-  >
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryPostcode"
+           name="deliveryPostcode"
+           placeholder="Enter your ZipCode"
+           autocomplete="postal-code"
+           data-trackable="delivery-postcode"
+           aria-required="true"
+           required
+           pattern="whatever"
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter a valid
     <span data-reference="postcode">
       ZipCode
     </span>
     .
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Delivery Postcode render different styles 1`] = `
-<div id="deliveryPostcodeField"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error n-ui-hide"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryPostcode"
-     data-validate="required"
+<label id="deliveryPostcodeField"
+       class="o-forms-field n-ui-hide"
+       data-validate="required"
 >
-  <label for="deliveryPostcode"
-         class="o-forms__label"
-  >
-    Delivery
-    <span data-reference="postcode">
-      ZipCode
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery
+      <span data-reference="postcode">
+        ZipCode
+      </span>
     </span>
-  </label>
-  <input type="text"
-         id="deliveryPostcode"
-         name="deliveryPostcode"
-         placeholder="Enter your ZipCode"
-         autocomplete="postal-code"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="delivery-postcode"
-         aria-required="true"
-         required
-         pattern="whatever"
-         value
-  >
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+    <input type="text"
+           id="deliveryPostcode"
+           name="deliveryPostcode"
+           placeholder="Enter your ZipCode"
+           autocomplete="postal-code"
+           data-trackable="delivery-postcode"
+           aria-required="true"
+           required
+           pattern="whatever"
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter a valid
     <span data-reference="postcode">
       ZipCode
     </span>
     .
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Delivery Postcode render different styles 2`] = `
-<div id="deliveryPostcodeField"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error n-ui-hide"
-     data-ui-item="form-field"
-     data-ui-item-name="deliveryPostcode"
-     data-validate="required"
+<label id="deliveryPostcodeField"
+       class="o-forms-field n-ui-hide"
+       data-validate="required"
 >
-  <label for="deliveryPostcode"
-         class="o-forms__label"
-  >
-    Delivery
-    <span data-reference="postcode">
-      ZipCode
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery
+      <span data-reference="postcode">
+        ZipCode
+      </span>
     </span>
-  </label>
-  <input type="text"
-         id="deliveryPostcode"
-         name="deliveryPostcode"
-         placeholder="Enter your ZipCode"
-         autocomplete="postal-code"
-         class="o-forms__text js-field__input js-item__value"
-         data-trackable="delivery-postcode"
-         aria-required="true"
-         required
-         pattern="whatever"
-         value
-  >
-  <div class="o-forms__errortext">
+  </span>
+  <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+    <input type="text"
+           id="deliveryPostcode"
+           name="deliveryPostcode"
+           placeholder="Enter your ZipCode"
+           autocomplete="postal-code"
+           data-trackable="delivery-postcode"
+           aria-required="true"
+           required
+           pattern="whatever"
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     Please enter a valid
     <span data-reference="postcode">
       ZipCode
     </span>
     .
-  </div>
-</div>
+  </span>
+</label>
 `;

--- a/components/__snapshots__/email.spec.js.snap
+++ b/components/__snapshots__/email.spec.js.snap
@@ -1,465 +1,437 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Email with confirmation render a email input for B2B 1`] = `
-<div id="emailField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-validate="required,email"
+<label id="emailField"
+       class="o-forms-field"
+       data-validate="required,email"
 >
-  <label for="email"
-         class="o-forms__label"
-  >
-    Work email address
-  </label>
-  <small id="email-description"
-         class="o-forms__additional-info"
-  >
-    Please enter an email address
-  </small>
-  <input type="email"
-         id="email"
-         name="email"
-         placeholder="Enter your email address"
-         autocomplete="email"
-         class="no-mouseflow o-forms__text js-field__input js-item__value"
-         data-trackable="field-email"
-         aria-required="true"
-         aria-describedby="email-description"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Work email address
+    </span>
+    <span class="o-forms-title__prompt">
+      Please enter an email address
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     This email address is not valid
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Email with confirmation render a email input for B2B 2`] = `
-<div id="emailField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-validate="required,email"
+<label id="emailField"
+       class="o-forms-field"
+       data-validate="required,email"
 >
-  <label for="email"
-         class="o-forms__label"
-  >
-    Work email address
-  </label>
-  <small id="email-description"
-         class="o-forms__additional-info"
-  >
-    Please enter an email address
-  </small>
-  <input type="email"
-         id="email"
-         name="email"
-         placeholder="Enter your email address"
-         autocomplete="email"
-         class="no-mouseflow o-forms__text js-field__input js-item__value"
-         data-trackable="field-email"
-         aria-required="true"
-         aria-describedby="email-description"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Work email address
+    </span>
+    <span class="o-forms-title__prompt">
+      Please enter an email address
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     This email address is not valid
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Email with confirmation render a email input with default params 1`] = `
-<div id="emailField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-validate="required,email"
+<label id="emailField"
+       class="o-forms-field"
+       data-validate="required,email"
 >
-  <label for="email"
-         class="o-forms__label"
-  >
-    Email address
-  </label>
-  <small id="email-description"
-         class="o-forms__additional-info"
-  >
-    Please enter an email address
-  </small>
-  <input type="email"
-         id="email"
-         name="email"
-         placeholder="Enter your email address"
-         autocomplete="email"
-         class="no-mouseflow o-forms__text js-field__input js-item__value"
-         data-trackable="field-email"
-         aria-required="true"
-         aria-describedby="email-description"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Email address
+    </span>
+    <span class="o-forms-title__prompt">
+      Please enter an email address
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     This email address is not valid
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Email with confirmation render a email input with default params 2`] = `
-<div id="emailField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-validate="required,email"
+<label id="emailField"
+       class="o-forms-field"
+       data-validate="required,email"
 >
-  <label for="email"
-         class="o-forms__label"
-  >
-    Email address
-  </label>
-  <small id="email-description"
-         class="o-forms__additional-info"
-  >
-    Please enter an email address
-  </small>
-  <input type="email"
-         id="email"
-         name="email"
-         placeholder="Enter your email address"
-         autocomplete="email"
-         class="no-mouseflow o-forms__text js-field__input js-item__value"
-         data-trackable="field-email"
-         aria-required="true"
-         aria-describedby="email-description"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Email address
+    </span>
+    <span class="o-forms-title__prompt">
+      Please enter an email address
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     This email address is not valid
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Email with confirmation render a email input with default value 1`] = `
-<div id="emailField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-validate="required,email"
+<label id="emailField"
+       class="o-forms-field"
+       data-validate="required,email"
 >
-  <label for="email"
-         class="o-forms__label"
-  >
-    Email address
-  </label>
-  <small id="email-description"
-         class="o-forms__additional-info"
-  >
-    Please enter an email address
-  </small>
-  <input type="email"
-         id="email"
-         name="email"
-         placeholder="Enter your email address"
-         autocomplete="email"
-         class="no-mouseflow o-forms__text js-field__input js-item__value"
-         data-trackable="field-email"
-         aria-required="true"
-         aria-describedby="email-description"
-         required
-         value="test@example.com"
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Email address
+    </span>
+    <span class="o-forms-title__prompt">
+      Please enter an email address
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           value="test@example.com"
+    >
+  </span>
+  <span class="o-forms-input__error">
     This email address is not valid
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Email with confirmation render a email input with default value 2`] = `
-<div id="emailField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-validate="required,email"
+<label id="emailField"
+       class="o-forms-field"
+       data-validate="required,email"
 >
-  <label for="email"
-         class="o-forms__label"
-  >
-    Email address
-  </label>
-  <small id="email-description"
-         class="o-forms__additional-info"
-  >
-    Please enter an email address
-  </small>
-  <input type="email"
-         id="email"
-         name="email"
-         placeholder="Enter your email address"
-         autocomplete="email"
-         class="no-mouseflow o-forms__text js-field__input js-item__value"
-         data-trackable="field-email"
-         aria-required="true"
-         aria-describedby="email-description"
-         required
-         value="test@example.com"
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Email address
+    </span>
+    <span class="o-forms-title__prompt">
+      Please enter an email address
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           value="test@example.com"
+    >
+  </span>
+  <span class="o-forms-input__error">
     This email address is not valid
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Email with confirmation render a email input with disabled fields 1`] = `
-<div id="emailField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-validate="required,email"
+<label id="emailField"
+       class="o-forms-field"
+       data-validate="required,email"
 >
-  <label for="email"
-         class="o-forms__label"
-  >
-    Email address
-  </label>
-  <small id="email-description"
-         class="o-forms__additional-info"
-  >
-    Please enter an email address
-  </small>
-  <input type="email"
-         id="email"
-         name="email"
-         placeholder="Enter your email address"
-         autocomplete="email"
-         class="no-mouseflow o-forms__text js-field__input js-item__value"
-         data-trackable="field-email"
-         aria-required="true"
-         aria-describedby="email-description"
-         required
-         disabled
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Email address
+    </span>
+    <span class="o-forms-title__prompt">
+      Please enter an email address
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           disabled
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     This email address is not valid
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Email with confirmation render a email input with disabled fields 2`] = `
-<div id="emailField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-validate="required,email"
+<label id="emailField"
+       class="o-forms-field"
+       data-validate="required,email"
 >
-  <label for="email"
-         class="o-forms__label"
-  >
-    Email address
-  </label>
-  <small id="email-description"
-         class="o-forms__additional-info"
-  >
-    Please enter an email address
-  </small>
-  <input type="email"
-         id="email"
-         name="email"
-         placeholder="Enter your email address"
-         autocomplete="email"
-         class="no-mouseflow o-forms__text js-field__input js-item__value"
-         data-trackable="field-email"
-         aria-required="true"
-         aria-describedby="email-description"
-         required
-         disabled
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Email address
+    </span>
+    <span class="o-forms-title__prompt">
+      Please enter an email address
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           disabled
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     This email address is not valid
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Email with confirmation render a email input with email error 1`] = `
-<div id="emailField"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
-     data-validate="required,email"
+<label id="emailField"
+       class="o-forms-field"
+       data-validate="required,email"
 >
-  <label for="email"
-         class="o-forms__label"
-  >
-    Email address
-  </label>
-  <small id="email-description"
-         class="o-forms__additional-info"
-  >
-    Please enter an email address
-  </small>
-  <input type="email"
-         id="email"
-         name="email"
-         placeholder="Enter your email address"
-         autocomplete="email"
-         class="no-mouseflow o-forms__text js-field__input js-item__value"
-         data-trackable="field-email"
-         aria-required="true"
-         aria-describedby="email-description"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Email address
+    </span>
+    <span class="o-forms-title__prompt">
+      Please enter an email address
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     This email address is not valid
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Email with confirmation render a email input with email error 2`] = `
-<div id="emailField"
-     class="o-forms o-forms--wide ncf__field js-field o-forms--error"
-     data-validate="required,email"
+<label id="emailField"
+       class="o-forms-field"
+       data-validate="required,email"
 >
-  <label for="email"
-         class="o-forms__label"
-  >
-    Email address
-  </label>
-  <small id="email-description"
-         class="o-forms__additional-info"
-  >
-    Please enter an email address
-  </small>
-  <input type="email"
-         id="email"
-         name="email"
-         placeholder="Enter your email address"
-         autocomplete="email"
-         class="no-mouseflow o-forms__text js-field__input js-item__value"
-         data-trackable="field-email"
-         aria-required="true"
-         aria-describedby="email-description"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Email address
+    </span>
+    <span class="o-forms-title__prompt">
+      Please enter an email address
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     This email address is not valid
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Email with confirmation render a email input with given description 1`] = `
-<div id="emailField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-validate="required,email"
+<label id="emailField"
+       class="o-forms-field"
+       data-validate="required,email"
 >
-  <label for="email"
-         class="o-forms__label"
-  >
-    Email address
-  </label>
-  <small id="email-description"
-         class="o-forms__additional-info"
-  >
-    some description
-  </small>
-  <input type="email"
-         id="email"
-         name="email"
-         placeholder="Enter your email address"
-         autocomplete="email"
-         class="no-mouseflow o-forms__text js-field__input js-item__value"
-         data-trackable="field-email"
-         aria-required="true"
-         aria-describedby="email-description"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Email address
+    </span>
+    <span class="o-forms-title__prompt">
+      some description
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     This email address is not valid
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Email with confirmation render a email input with given description 2`] = `
-<div id="emailField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-validate="required,email"
+<label id="emailField"
+       class="o-forms-field"
+       data-validate="required,email"
 >
-  <label for="email"
-         class="o-forms__label"
-  >
-    Email address
-  </label>
-  <small id="email-description"
-         class="o-forms__additional-info"
-  >
-    some description
-  </small>
-  <input type="email"
-         id="email"
-         name="email"
-         placeholder="Enter your email address"
-         autocomplete="email"
-         class="no-mouseflow o-forms__text js-field__input js-item__value"
-         data-trackable="field-email"
-         aria-required="true"
-         aria-describedby="email-description"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Email address
+    </span>
+    <span class="o-forms-title__prompt">
+      some description
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     This email address is not valid
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Email with confirmation render a email input with read only fields 1`] = `
-<div id="emailField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-validate="required,email"
+<label id="emailField"
+       class="o-forms-field"
+       data-validate="required,email"
 >
-  <label for="email"
-         class="o-forms__label"
-  >
-    Email address
-  </label>
-  <small id="email-description"
-         class="o-forms__additional-info"
-  >
-    Please enter an email address
-  </small>
-  <input type="email"
-         id="email"
-         name="email"
-         placeholder="Enter your email address"
-         autocomplete="email"
-         class="no-mouseflow o-forms__text js-field__input js-item__value o-forms__field-disabled"
-         data-trackable="field-email"
-         aria-required="true"
-         aria-describedby="email-description"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Email address
+    </span>
+    <span class="o-forms-title__prompt">
+      Please enter an email address
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     This email address is not valid
-  </div>
-</div>
+  </span>
+</label>
 `;
 
 exports[`Email with confirmation render a email input with read only fields 2`] = `
-<div id="emailField"
-     class="o-forms o-forms--wide ncf__field js-field"
-     data-validate="required,email"
+<label id="emailField"
+       class="o-forms-field"
+       data-validate="required,email"
 >
-  <label for="email"
-         class="o-forms__label"
-  >
-    Email address
-  </label>
-  <small id="email-description"
-         class="o-forms__additional-info"
-  >
-    Please enter an email address
-  </small>
-  <input type="email"
-         id="email"
-         name="email"
-         placeholder="Enter your email address"
-         autocomplete="email"
-         class="no-mouseflow o-forms__text js-field__input js-item__value o-forms__field-disabled"
-         data-trackable="field-email"
-         aria-required="true"
-         aria-describedby="email-description"
-         required
-         value
-  >
-  <div class="o-forms__errortext">
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Email address
+    </span>
+    <span class="o-forms-title__prompt">
+      Please enter an email address
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           value
+    >
+  </span>
+  <span class="o-forms-input__error">
     This email address is not valid
-  </div>
-</div>
+  </span>
+</label>
 `;

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -19,19 +19,15 @@ export function AcceptTerms ({
 	isPrintProduct = false,
 	specialTerms = null
 }) {
-	const divClassName = classNames([
-		'o-forms',
-		'o-forms--wide',
-		'ncf__field',
-		'js-field',
-		{ 'o-forms--error': hasError }
+	const inputWrapperClassName = classNames([
+		'o-forms-input',
+		'o-forms-input--checkbox',
+		{ 'o-forms-input--invalid': hasError }
 	]);
 
 	const divProps = {
 		id: 'acceptTermsField',
-		className: divClassName,
-		'data-ui-item': 'multi',
-		'data-ui-item-name': 'acceptTerms',
+		className: 'o-forms-field',
 		'data-validate': 'required,checked',
 		...(isSignup && { 'data-trackable': 'sign-up-terms' }),
 		...(isRegister && { 'data-trackable': 'register-up-terms' })
@@ -42,7 +38,6 @@ export function AcceptTerms ({
 		type: 'checkbox',
 		name: 'termsAcceptance',
 		value: 'true',
-		className: 'o-forms__checkbox js-item__value js-field__input',
 		'data-trackable': 'field-terms',
 		'aria-required': 'true',
 		required: true,
@@ -114,22 +109,24 @@ export function AcceptTerms ({
 
 	return (
 		<div {...divProps}>
+			<span className={inputWrapperClassName}>
+				<label>
+					<input {...inputProps} />
+					<span className="o-forms-input__label" aria-hidden="true">
+						{ b2bTerms }
 
-			<input {...inputProps} />
+						{ defaultTerms }
 
-			<label htmlFor="termsAcceptance" className="o-forms__label ncf__terms">
-				{ b2bTerms }
+						{ corpSignupTerms }
 
-				{ defaultTerms }
+						{ transitionTerms }
 
-				{ corpSignupTerms }
+						{ signupTerms }
+					</span>
+				</label>
+			</span>
 
-				{ transitionTerms }
-
-				{ signupTerms }
-			</label>
-
-			<div className="o-forms__errortext">Please accept our terms &amp; conditions</div>
+			<span className="o-forms-input__error">Please accept our terms &amp; conditions</span>
 
 		</div>
 	);

--- a/components/billing-country.jsx
+++ b/components/billing-country.jsx
@@ -11,17 +11,14 @@ export function BillingCountry ({
 	isDisabled = false,
 	value
 }) {
-	const className = classNames([
-		'o-forms',
-		'o-forms--wide',
-		'ncf__field',
-		'js-field',
-		'js-unknown-user-field',
-		{ 'o-forms--error': hasError }
+	const selectWrapperClassName = classNames([
+		'o-forms-input',
+		'o-forms-input--select',
+		{ 'o-forms-input--invalid': hasError }
 	]);
 	const props = {
 		id: inputId,
-		className: 'o-forms__select js-field__input js-item__value',
+		className: 'js-field__input js-item__value',
 		'aria-required': true,
 		required: true,
 		name: inputId,
@@ -46,11 +43,15 @@ export function BillingCountry ({
 	);
 
 	return (
-		<div id={fieldId} className={className} data-ui-item="select" data-ui-item-name="billingCountry" data-ui-item-store-previous="true" data-validate="required">
-			<label htmlFor={inputId} className="o-forms__label">Billing Country</label>
-			{createSelect(countries)}
-			<div className="o-forms__errortext">Please select your country</div>
-		</div>
+		<label id={fieldId} className="o-forms-field" data-validate="required">
+			<span className="o-forms-title">
+				<span className="o-forms-title__main">Billing Country</span>
+			</span>
+			<span className={selectWrapperClassName}>
+				{createSelect(countries)}
+				<span className="o-forms-input__error">Please select your country</span>
+			</span>
+		</label>
 	);
 }
 

--- a/components/billing-postcode.jsx
+++ b/components/billing-postcode.jsx
@@ -10,52 +10,51 @@ export function BillingPostcode ({
 	hasError = false,
 	isHidden = false,
 	fieldId = 'billingPostcodeField',
-	// This is clearly wrong but has been implemented this way in HBS.
-	// We will need to get rid of these fields anyway:
-	// https://github.com/Financial-Times/n-conversion-forms/issues/263
-	fieldName = 'deliveryPostcode',
 	inputId = 'billingPostcode',
 	inputName = 'billingPostcode',
 }) {
 
 	const BillingPostcodeFieldClassNames = classNames([
-		'o-forms o-forms--wide ncf__field js-field',
-		{
-			'o-forms--error': hasError,
-			'n-ui-hide': isHidden
-		}
+		'o-forms-field',
+		{ 'n-ui-hide': isHidden }
 	]);
 
-	return (<div
-		id={fieldId}
-		className={BillingPostcodeFieldClassNames}
-		data-ui-item="form-field"
-		data-ui-item-name={fieldName}
-		data-validate="required"
-	>
+	const inputWrapperClassNames = classNames([
+		'o-forms-input',
+		'o-forms-input--text',
+		{ 'o-forms-input--invalid': hasError }
+	]);
 
-		<label htmlFor={inputId} className="o-forms__label">
-			Billing <span data-reference="postcode">{postcodeReference}</span>
+	return (
+		<label
+			id={fieldId}
+			className={BillingPostcodeFieldClassNames}
+			data-validate="required"
+		>
+			<span className="o-forms-title">
+				<span className="o-forms-title__main">
+					Billing <span data-reference="postcode">{postcodeReference}</span>
+				</span>
+			</span>
+
+			<span className={inputWrapperClassNames}>
+				<input type="text"
+					id={inputId}
+					name={inputName}
+					defaultValue={value}
+					placeholder={`Enter your ${postcodeReference}`}
+					autoComplete="postal-code"
+					data-trackable="billing-postcode"
+					aria-required="true"
+					required
+					pattern={pattern}
+					disabled={isDisabled} />
+			</span>
+
+			<span className="o-forms-input__error">
+				Please enter a valid <span data-reference="postcode">{postcodeReference}</span>.
+			</span>
 		</label>
-
-		<input type="text"
-			id={inputId}
-			name={inputName}
-			defaultValue={`${value}`}
-			placeholder={`Enter your ${postcodeReference}`}
-			autoComplete="postal-code"
-			className="o-forms__text js-field__input js-item__value"
-			data-trackable="billing-postcode"
-			aria-required="true"
-			required
-			pattern={pattern}
-			disabled={isDisabled} />
-
-		<div className="o-forms__errortext">
-			Please enter a valid <span data-reference="postcode">{postcodeReference}</span>.
-		</div>
-
-	</div>
 	);
 }
 
@@ -67,7 +66,6 @@ BillingPostcode.propTypes = {
 	hasError: PropTypes.bool,
 	isHidden: PropTypes.bool,
 	fieldId: PropTypes.string,
-	fieldName: PropTypes.string,
 	inputId: PropTypes.string,
 	inputName: PropTypes.string,
 };

--- a/components/company-name.jsx
+++ b/components/company-name.jsx
@@ -10,21 +10,11 @@ export function CompanyName ({
 	value = '',
 	isDisabled = false
 }) {
-	const divClassName = classNames([
-		'o-forms',
-		'o-forms--wide',
-		'ncf__field',
-		'js-field',
-		{ 'o-forms--error': hasError }
+	const inputWrapperClassNames = classNames([
+		'o-forms-input',
+		'o-forms-input--text',
+		{ 'o-forms-input--invalid': hasError }
 	]);
-
-	const divProps = {
-		id: fieldId,
-		className: divClassName,
-		'data-ui-item': 'form-field',
-		'data-ui-item-name': 'companyName',
-		'data-validate': 'required'
-	}
 
 	const inputProps = {
 		type: 'text',
@@ -32,22 +22,25 @@ export function CompanyName ({
 		name: inputName,
 		placeholder: 'Enter your company name',
 		autoComplete: 'organization',
-		className: 'o-forms__text js-field__input js-item__value',
 		'data-trackable': 'company-name',
 		'aria-required': 'true',
 		required: true,
 		disabled: isDisabled,
 		defaultValue: value
-	}
+	};
 
 	return (
-		<div {...divProps}>
-			<label htmlFor="companyName" className="o-forms__label">Company name</label>
+		<label id={fieldId} className="o-forms-field" data-validate="required">
+			<span className="o-forms-title">
+				<span className="o-forms-title__main">Company name</span>
+			</span>
 
-			<input {...inputProps} />
+			<span className={inputWrapperClassNames}>
+				<input {...inputProps} />
+			</span>
 
-			<div className="o-forms__errortext">Please enter your company name.</div>
-		</div>
+			<span className="o-forms-input__error">Please enter your company name.</span>
+		</label>
 	);
 }
 

--- a/components/company-name.spec.js
+++ b/components/company-name.spec.js
@@ -21,12 +21,12 @@ describe('CompanyName', () => {
 		expect(CompanyName).toRenderAs(context, props);
 	});
 
-	it('renders a field with custom div id', () => {
+	it('renders a field with custom field id', () => {
 		const props = { fieldId: 'customFieldId' };
 
 		const component = mount(CompanyName(props));
 
-		const element = component.find('div#customFieldId');
+		const element = component.find('#customFieldId');
 
 		expect(element.exists()).toBe(true);
 	});

--- a/components/country.jsx
+++ b/components/country.jsx
@@ -9,28 +9,22 @@ export function Country ({
 	hasError = false,
 	inputId = 'country',
 	isB2b = false,
-	isBillingCountry = false,
 	isDisabled = false,
 	value
 }) {
-	const className = classNames([
-		'o-forms',
-		'o-forms--wide',
-		'ncf__field',
-		'js-field',
-		'js-unknown-user-field',
-		{ 'o-forms--error': hasError }
+	const selectWrapperClassName = classNames([
+		'o-forms-input',
+		'o-forms-input--select',
+		{ 'o-forms-input--invalid': hasError }
 	]);
-	const itemName = isBillingCountry ? 'billingCountry' : 'country';
-	const label = `${isBillingCountry ? 'Billing Country' : 'Country'}${isB2b ? '/Region' : ''}`;
+	const label = `Country${isB2b ? '/Region' : ''}`;
 	const error = `Please select your country${isB2b ? '/region' : ''}`;
-	const props = {
+	const selectProps = {
 		id: inputId,
-		className: 'o-forms__select js-field__input js-item__value',
 		'aria-required': true,
 		required: true,
-		name: isBillingCountry ? 'billingCountry' : 'country',
-		'data-trackable': isBillingCountry ? 'field-billing-country' : 'field-country',
+		name: 'country',
+		'data-trackable': 'field-country',
 		disabled: isDisabled,
 	};
 	const countries = getCountries({ filter: filterList, value });
@@ -44,18 +38,22 @@ export function Country ({
 		</optgroup>
 	);
 	const createSelect = countries => (
-		<select {...props}>
+		<select {...selectProps}>
 			<option value="">Please select a country{isB2b ? '/region' : ''}</option>
 			{countries.map(country => country.label ? createOptGroup(country) : createOption(country))}
 		</select>
 	);
 
 	return (
-		<div id={fieldId} className={className} data-ui-item="select" data-ui-item-name={itemName} data-ui-item-store-previous="true" data-validate="required">
-			<label htmlFor={inputId} className="o-forms__label">{label}</label>
-			{createSelect(countries)}
-			<div className="o-forms__errortext">{error}</div>
-		</div>
+		<label id={fieldId} className="o-forms-field js-unknown-user-field" data-validate="required">
+			<span className="o-forms-title">
+				<span className="o-forms-title__main">{label}</span>
+			</span>
+			<span className={selectWrapperClassName}>
+				{createSelect(countries)}
+			</span>
+			<span className="o-forms-input__error">{error}</span>
+		</label>
 	);
 }
 
@@ -69,7 +67,6 @@ Country.propTypes = {
 	hasError: PropTypes.bool,
 	inputId: PropTypes.string,
 	isB2b: PropTypes.bool,
-	isBillingCountry: PropTypes.bool,
 	isDisabled: PropTypes.bool,
 	value: PropTypes.string
 };

--- a/components/country.spec.js
+++ b/components/country.spec.js
@@ -55,14 +55,6 @@ describe('Country', () => {
 		expect(Country).toRenderAs(context, props);
 	});
 
-	it('renders with isBillingCountry', () => {
-		const props = {
-			isBillingCountry: true
-		};
-
-		expect(Country).toRenderAs(context, props);
-	});
-
 	it('renders with isDisabled', () => {
 		const props = {
 			isDisabled: true

--- a/components/decision-maker.jsx
+++ b/components/decision-maker.jsx
@@ -6,21 +6,19 @@ export function DecisionMaker ({
 	hasError = false,
 	value = 'yes'
 }) {
-	const fieldsetClassName = classNames([
-		'o-forms',
-		'o-forms--wide',
-		'o-forms--inline',
-		'ncf__field',
-		'js-field',
-		{ 'o-forms--error': hasError }
+	const radioButtonsWrapperClassNames = classNames([
+		'o-forms-input',
+		'o-forms-input--radio-box',
+		'o-forms-input--inline',
+		{ 'o-forms-input--invalid': hasError }
 	]);
 
 	const decisionMakerYesInputProps = {
 		type: 'radio',
 		id: 'decisionMakerYes',
 		name: 'decisionMaker',
+		'aria-label': 'Yes',
 		value: 'yes',
-		className: 'o-forms__radio-button',
 		...((value === 'yes') && { defaultChecked: true })
 	};
 
@@ -28,34 +26,38 @@ export function DecisionMaker ({
 		type: 'radio',
 		id: 'decisionMakerNo',
 		name: 'decisionMaker',
+		'aria-label': 'No',
 		value: 'no',
-		className: 'o-forms__radio-button o-forms__radio-button--negative',
 		...((value === 'no') && { defaultChecked: true })
 	};
 
 	return (
-		<fieldset
+		<div
 			id="decisionMakerField"
-			className={fieldsetClassName}
-			data-ui-item="form-field"
-			data-ui-item-name="decisionMaker"
+			role="group"
+			aria-labelledby="decisionMakerFieldLabel"
+			className="o-forms-field"
 			data-validate="required"
 		>
-			{/* Duplicate legend so it is the first element of a fieldset for A11Y	 */}
-			<legend className="o-normalise-visually-hidden">Are you a manager with direct reports?</legend>
+			<span className="o-forms-title">
+				<span className="o-forms-title__main" id="decisionMakerFieldLabel">Are you a manager with direct reports?</span>
+			</span>
 
-			<div className="o-forms__inline-container ncf__field--min-content">
-				<div className="o-forms__label">Are you a manager with direct reports?</div>
-				<div className="o-forms__group o-forms__group--inline-together">
-					<input {...decisionMakerYesInputProps} />
-					<label htmlFor="decisionMakerYes" className="o-forms__label">Yes</label>
-					<input {...decisionMakerNoInputProps} />
-					<label htmlFor="decisionMakerNo" className="o-forms__label">No</label>
+			<span className={radioButtonsWrapperClassNames}>
+				<div className="o-forms-input--radio-box__container">
+					<label>
+						<input {...decisionMakerYesInputProps} />
+						<span className="o-forms-input__label" aria-hidden="true">Yes</span>
+					</label>
+					<label>
+						<input {...decisionMakerNoInputProps} />
+						<span className="o-forms-input__label o-forms-input__label--negative" aria-hidden="true">No</span>
+					</label>
 				</div>
-			</div>
+			</span>
 
-			<div className="o-forms__errortext">Please select an option</div>
-		</fieldset>
+			<span className="o-forms-input__error">Please select an option</span>
+		</div>
 	);
 }
 

--- a/components/delivery-address.jsx
+++ b/components/delivery-address.jsx
@@ -9,66 +9,67 @@ export function DeliveryAddress ({
 	line3 = '',
 	isDisabled = false
 }) {
-	const divClassName = classNames([
-		'o-forms',
-		'o-forms--wide',
-		'ncf__field',
-		'js-field',
-		{ 'o-forms--error': hasError }
+	const inputWrapperClassNames = classNames([
+		'o-forms-input',
+		'o-forms-input--text',
+		{ 'o-forms-input--invalid': hasError }
 	]);
 
 	return (
-		<div
-			id="deliveryAddressFields"
-			className={divClassName}
-			data-ui-item="form-field"
-			data-ui-item-name="deliveryAddress"
-			data-validate="required"
-		>
-			<p>
-				<label htmlFor="deliveryAddressLine1" className="o-forms__label">Address line 1</label>
-				<input
-					type="text"
-					id="deliveryAddressLine1"
-					name="deliveryAddressLine1"
-					className="o-forms__text js-field__input js-item__value"
-					data-trackable="field-deliveryAddressLine1"
-					autoComplete="address-line1"
-					placeholder="e.g. 10 Elm Street"
-					aria-required="true"
-					required
-					disabled={isDisabled}
-					defaultValue={line1}
-				/>
-			</p>
-			<p>
-				<label htmlFor="deliveryAddressLine2" className="o-forms__label">Address line 2 <small>(optional)</small></label>
-				<input
-					type="text"
-					id="deliveryAddressLine2"
-					name="deliveryAddressLine2"
-					className="o-forms__text js-field__input js-item__value"
-					data-trackable="field-deliveryAddressLine2"
-					autoComplete="address-line2"
-					placeholder="e.g. Apartment 1"
-					disabled={isDisabled}
-					defaultValue={line2}
-				/>
-			</p>
-			<p>
-				<label htmlFor="deliveryAddressLine3" className="o-forms__label">Address line 3 <small>(optional)</small></label>
-				<input
-					type="text"
-					id="deliveryAddressLine3"
-					name="deliveryAddressLine3"
-					className="o-forms__text js-field__input js-item__value"
-					data-trackable="field-deliveryAddressLine3"
-					autoComplete="address-line3"
-					placeholder=""
-					disabled={isDisabled}
-					defaultValue={line3}
-				/>
-			</p>
+		<div id="deliveryAddressFields" data-validate="required">
+			<label className="o-forms-field">
+				<span className="o-forms-title">
+					<span className="o-forms-title__main">Address line 1</span>
+				</span>
+				<span className={inputWrapperClassNames}>
+					<input
+						type="text"
+						id="deliveryAddressLine1"
+						name="deliveryAddressLine1"
+						data-trackable="field-deliveryAddressLine1"
+						autoComplete="address-line1"
+						placeholder="e.g. 10 Elm Street"
+						aria-required="true"
+						required
+						disabled={isDisabled}
+						defaultValue={line1}
+					/>
+				</span>
+			</label>
+			<label className="o-forms-field">
+				<span className="o-forms-title">
+					<span className="o-forms-title__main">Address line 2 <small>(optional)</small></span>
+				</span>
+				<span className={inputWrapperClassNames}>
+					<input
+						type="text"
+						id="deliveryAddressLine2"
+						name="deliveryAddressLine2"
+						data-trackable="field-deliveryAddressLine2"
+						autoComplete="address-line2"
+						placeholder="e.g. Apartment 1"
+						disabled={isDisabled}
+						defaultValue={line2}
+					/>
+				</span>
+			</label>
+			<label className="o-forms-field">
+				<span className="o-forms-title">
+					<span className="o-forms-title__main">Address line 3 <small>(optional)</small></span>
+				</span>
+				<span className={inputWrapperClassNames}>
+					<input
+						type="text"
+						id="deliveryAddressLine3"
+						name="deliveryAddressLine3"
+						data-trackable="field-deliveryAddressLine3"
+						autoComplete="address-line3"
+						placeholder=""
+						disabled={isDisabled}
+						defaultValue={line3}
+					/>
+				</span>
+			</label>
 		</div>
 	);
 }

--- a/components/delivery-city.jsx
+++ b/components/delivery-city.jsx
@@ -7,38 +7,32 @@ export function DeliveryCity ({
 	value = '',
 	isDisabled = false
 }) {
-	const divClassName = classNames([
-		'o-forms',
-		'o-forms--wide',
-		'ncf__field',
-		'js-field',
-		{ 'o-forms--error': hasError }
+	const inputWrapperClassName = classNames([
+		'o-forms-input',
+		'o-forms-input--text',
+		{ 'o-forms-input--invalid': hasError }
 	]);
 
 	return (
-		<div
-			id="deliveryCityField"
-			className={divClassName}
-			data-ui-item="form-field"
-			data-ui-item-name="deliveryCity"
-			data-validate="required"
-		>
-			<label htmlFor="deliveryCity" className="o-forms__label">City/town</label>
-
-			<input
-				type="text"
-				id="deliveryCity"
-				name="deliveryCity"
-				className="o-forms__text js-field__input js-item__value"
-				data-trackable="field-deliveryCity"
-				autoComplete="address-level2"
-				placeholder="e.g. Bath"
-				aria-required="true"
-				required
-				disabled={isDisabled}
-				defaultValue={value}
-			/>
-		</div>
+		<label id="deliveryCityField" className="o-forms-field" data-validate="required">
+			<span className="o-forms-title">
+				<span className="o-forms-title__main">City/town</span>
+			</span>
+			<span className={inputWrapperClassName}>
+				<input
+					type="text"
+					id="deliveryCity"
+					name="deliveryCity"
+					data-trackable="field-deliveryCity"
+					autoComplete="address-level2"
+					placeholder="e.g. Bath"
+					aria-required="true"
+					required
+					disabled={isDisabled}
+					defaultValue={value}
+				/>
+			</span>
+		</label>
 	);
 }
 

--- a/components/delivery-county.jsx
+++ b/components/delivery-county.jsx
@@ -8,36 +8,34 @@ export function DeliveryCounty ({
 	isDisabled = false
 
 }) {
-	const divClassName = classNames([
-		'o-forms',
-		'o-forms--wide',
-		'ncf__field',
-		'js-field',
-		{ 'o-forms--error': hasError }
+	const inputWrapperClassName = classNames([
+		'o-forms-input',
+		'o-forms-input--text',
+		{ 'o-forms-input--invalid': hasError }
 	]);
 
 	return (
-		<div
+		<label
 			id="deliveryCountyField"
-			className={divClassName}
-			data-ui-item="form-field"
-			data-ui-item-name="deliveryCounty"
+			className="o-forms-field"
 			data-validate="required"
 		>
-			<label htmlFor="deliveryCounty" className="o-forms__label">County <small>(optional)</small></label>
-
-			<input
-				type="text"
-				id="deliveryCounty"
-				name="deliveryCounty"
-				className="o-forms__text js-field__input js-item__value"
-				data-trackable="field-deliveryCounty"
-				autoComplete="address-level3"
-				placeholder="e.g. Somerset"
-				disabled={isDisabled}
-				defaultValue={value}
-			/>
-		</div>
+			<span className="o-forms-title">
+				<span className="o-forms-title__main">County <small>(optional)</small></span>
+			</span>
+			<span className={inputWrapperClassName}>
+				<input
+					type="text"
+					id="deliveryCounty"
+					name="deliveryCounty"
+					data-trackable="field-deliveryCounty"
+					autoComplete="address-level3"
+					placeholder="e.g. Somerset"
+					disabled={isDisabled}
+					defaultValue={value}
+				/>
+			</span>
+		</label>
 	);
 }
 

--- a/components/delivery-instructions.jsx
+++ b/components/delivery-instructions.jsx
@@ -11,24 +11,20 @@ export function DeliveryInstructions ({
 	isDisabled = false,
 	value = ''
 }) {
-	const divClassName = classNames([
-		'o-forms',
-		'o-forms--wide',
-		'ncf__field',
-		'js-field',
-		{ 'o-forms--error': hasError }
+	const textAreaWrapperClassNames = classNames([
+		'o-forms-input',
+		'o-forms-input--textarea',
+		{ 'o-forms-input--invalid': hasError }
 	]);
 
 	const maxLengthText = maxlength ? `(Max. ${maxlength} characters)` : '';
 	const placeholder = `Enter instructions ${maxLengthText}:\u000a- Door colour, letterbox location\u000a- Placement i.e. letterbox delivery\u000a- Special handling i.e. place in plastic bag`;
 
 	const textAreaProps = {
-		type: 'text',
 		id: inputId,
 		name: inputId,
 		...(maxlength && { maxLength: maxlength }),
 		...(rows && { rows }),
-		className: 'o-forms__text js-field__input js-item__value',
 		'data-trackable': 'field-deliveryInstructions',
 		placeholder,
 		disabled: isDisabled,
@@ -36,23 +32,20 @@ export function DeliveryInstructions ({
 	};
 
 	return (
-		<div
-			id={fieldId}
-			className={divClassName}
-			data-ui-item="form-field"
-			data-ui-item-name="deliveryInstructions"
-			data-validate="required"
-		>
-			<label htmlFor="deliveryInstructions" className="o-forms__label">Delivery instructions <small>(optional)</small></label>
+		<label id={fieldId} className="o-forms-field" data-validate="required">
+			<span className="o-forms-title">
+				<span className="o-forms-title__main">Delivery instructions <small>(optional)</small></span>
+				<span className="o-forms-title__prompt">
+					These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
+				</span>
+			</span>
 
-			<div className="ncf__terms ncf__terms--small">
-				These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
-			</div>
-
-			<textarea {...textAreaProps} />
+			<span className={textAreaWrapperClassNames}>
+				<textarea {...textAreaProps} />
+			</span>
 
 			<p>Please note that we can only deliver to the ground floor level of your property.</p>
-		</div>
+		</label>
 	);
 }
 

--- a/components/delivery-postcode.jsx
+++ b/components/delivery-postcode.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 export function DeliveryPostcode ({
 	postcodeReference,
@@ -9,47 +10,49 @@ export function DeliveryPostcode ({
 	hasError = false,
 	isHidden = false
 }) {
-	let DeliveryPostcodeFieldClassNames = 'o-forms o-forms--wide ncf__field js-field';
+	const inputWrapperClassNames = classNames([
+		'o-forms-input',
+		'o-forms-input--text',
+		{ 'o-forms-input--invalid': hasError }
+	]);
 
-	if (hasError) {
-		DeliveryPostcodeFieldClassNames += ' o-forms--error';
-	}
-
-	if (isHidden) {
-		DeliveryPostcodeFieldClassNames += ' n-ui-hide';
-	}
+	let deliveryPostcodeFieldClassNames = classNames([
+		'o-forms-field',
+		{ 'n-ui-hide': isHidden }
+	]);
 
 	return (
-		<div
+		<label
 			id="deliveryPostcodeField"
-			className={DeliveryPostcodeFieldClassNames}
-			data-ui-item="form-field"
-			data-ui-item-name="deliveryPostcode"
+			className={deliveryPostcodeFieldClassNames}
 			data-validate="required"
 		>
 
-			<label htmlFor="deliveryPostcode" className="o-forms__label">
-				Delivery <span data-reference="postcode">{postcodeReference}</span>
-			</label>
+			<span className="o-forms-title">
+				<span className="o-forms-title__main">
+					Delivery <span data-reference="postcode">{postcodeReference}</span>
+				</span>
+			</span>
 
-			<input type="text"
-				id="deliveryPostcode"
-				name="deliveryPostcode"
-				defaultValue={`${value}`}
-				placeholder={`Enter your ${postcodeReference}`}
-				autoComplete="postal-code"
-				className="o-forms__text js-field__input js-item__value"
-				data-trackable="delivery-postcode"
-				aria-required="true"
-				required
-				pattern={pattern}
-				disabled={isDisabled} />
+			<span className={inputWrapperClassNames}>
+				<input type="text"
+					id="deliveryPostcode"
+					name="deliveryPostcode"
+					defaultValue={`${value}`}
+					placeholder={`Enter your ${postcodeReference}`}
+					autoComplete="postal-code"
+					data-trackable="delivery-postcode"
+					aria-required="true"
+					required
+					pattern={pattern}
+					disabled={isDisabled} />
+			</span>
 
-			<div className="o-forms__errortext">
+			<span className="o-forms-input__error">
 				Please enter a valid <span data-reference="postcode">{postcodeReference}</span>.
-			</div>
+			</span>
 
-		</div>
+		</label>
 	);
 }
 

--- a/components/email.jsx
+++ b/components/email.jsx
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 
 export function Email ({
 	dataTrackable='field-email',
-	describedBy = 'email-description',
 	description = 'Please enter an email address',
 	errorText='This email address is not valid',
 	fieldId = 'emailField',
@@ -14,45 +13,43 @@ export function Email ({
 	isDisabled = false,
 	label = '',
 	placeHolder = 'Enter your email address',
-	readonly = false,
 	value = ''
 }) {
 	const labelText = label || (isB2b ? 'Work email address' : 'Email address');
-	const fieldClassName = classNames([
-		'o-forms o-forms--wide ncf__field js-field',
-		{ 'o-forms--error': hasError }
-	]);
-	const inputClassName = classNames([
-		'no-mouseflow o-forms__text js-field__input js-item__value',
-		{ 'o-forms__field-disabled': readonly }
+	const inputWrapperClassNames = classNames([
+		'o-forms-input',
+		'o-forms-input--text',
+		{ 'o-forms-input--invalid': hasError }
 	]);
 
 	return (
-		<div
+		<label
 			id={fieldId}
-			className={fieldClassName}
+			className="o-forms-field"
 			data-validate="required,email"
 		>
-			<label htmlFor={inputId} className="o-forms__label">{labelText}</label>
-			{description &&
-				<small id="email-description" className="o-forms__additional-info">{description}</small>
-			}
-			<input
-				type="email"
-				id={inputId}
-				name={inputId}
-				placeholder={placeHolder}
-				autoComplete="email"
-				className={inputClassName}
-				data-trackable={dataTrackable}
-				aria-required="true"
-				aria-describedby={describedBy}
-				required
-				disabled={isDisabled}
-				defaultValue={value}
-			/>
-			<div className="o-forms__errortext">{errorText}</div>
-		</div>
+			<span className="o-forms-title">
+				<span className="o-forms-title__main">{labelText}</span>
+				{description &&
+					<span className="o-forms-title__prompt">{description}</span>
+				}
+			</span>
+			<span className={inputWrapperClassNames}>
+				<input
+					type="email"
+					id={inputId}
+					name={inputId}
+					placeholder={placeHolder}
+					autoComplete="email"
+					data-trackable={dataTrackable}
+					aria-required="true"
+					required
+					disabled={isDisabled}
+					defaultValue={value}
+				/>
+			</span>
+			<span className="o-forms-input__error">{errorText}</span>
+		</label>
 	);
 }
 

--- a/main.scss
+++ b/main.scss
@@ -1,3 +1,4 @@
+$system-code: 'n-conversion-forms';
 @import 'o-icons/main';
 @import 'o-colors/main';
 @import 'o-normalise/main';
@@ -18,15 +19,24 @@
 @import './styles/customer-care';
 
 @include oFonts();
-@include oFormsBaseFeatures();
-@include oFormsRadioCheckboxFeatures();
-@include oFormsRadioButtonsStyledFeature();
-@include oFormsSuffixFeature();
-@include oFormsSectionFeature();
-@include oFormsInlineFeature();
-@include oFormsWideFeature();
+@include oForms($opts: (
+	'elements': (
+		'text',
+		'password',
+		'checkbox',
+		'select',
+		'radio-box',
+		'radio-round'
+	),
+	'features': (
+		'disabled',
+		'inline',
+		'right',
+		'suffix',
+		'error-summary'
+	)
+));
 @include oMessage();
-@include oFormsRadioCheckboxRightModifier();
 @include oSteppedProgress();
 
 // Custom styles

--- a/partials/accept-terms.html
+++ b/partials/accept-terms.html
@@ -1,56 +1,59 @@
-<div id="acceptTermsField" class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}" data-ui-item="multi" data-ui-item-name="acceptTerms" data-validate="required,checked" {{#if isSignup}}data-trackable="sign-up-terms"{{/if}}{{#if isRegister}}data-trackable="register-up-terms"{{/if}}>
+<div id="acceptTermsField" class="o-forms-field" data-validate="required,checked" {{#if isSignup}}data-trackable="sign-up-terms"{{/if}}{{#if isRegister}}data-trackable="register-up-terms"{{/if}}>
 
-	<input type="checkbox" id="termsAcceptance" name="termsAcceptance" value="true" class="o-forms__checkbox js-item__value js-field__input" data-trackable="field-terms" aria-required="true" required {{#if isChecked}}checked{{/if}}>
+	<span class="o-forms-input o-forms-input--checkbox{{#if hasError}} o-forms-input--invalid{{/if}}">
+		<label>
+			<input type="checkbox" id="termsAcceptance" name="termsAcceptance" value="true" data-trackable="field-terms" aria-required="true" required {{#if isChecked}}checked{{/if}} />
+			<span class="o-forms-input__label" aria-hidden="true">
+				{{#if isB2b }}
+				<p id="terms-b2b">
+					By submitting this form, you indicate your consent to also being contacted by Financial Times by email, post, or phone about our other products, services or special offers unless you untick this box.
+				</p>
+				{{else}}
+				<p id="terms-default">
+					I confirm I am {{#if ageRestriction}}{{ageRestriction}}{{else}}16{{/if}} years or older and have read and agree to the
+					<a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener" data-trackable="terms-and-conditions">Terms &amp; Conditions</a>.
+				</p>
+				{{/if}}
 
-	<label for="termsAcceptance" class="o-forms__label ncf__terms">
-		{{#if isB2b }}
-		<p id="terms-b2b">
-			By submitting this form, you indicate your consent to also being contacted by Financial Times by email, post, or phone about our other products, services or special offers unless you untick this box.
-		</p>
-		{{else}}
-		<p id="terms-default">
-			I confirm I am {{#if ageRestriction}}{{ageRestriction}}{{else}}16{{/if}} years or older and have read and agree to the
-			<a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener" data-trackable="terms-and-conditions">Terms &amp; Conditions</a>.
-		</p>
-		{{/if}}
+				{{#if isCorpSignup}}
+				<p class="terms-corp-signup">Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.</p>
+				<p class="terms-corp-signup">Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.</p>
+				<p class="terms-corp-signup">myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.</p>
 
-		{{#if isCorpSignup}}
-		<p class="terms-corp-signup">Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.</p>
-		<p class="terms-corp-signup">Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.</p>
-		<p class="terms-corp-signup">myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.</p>
+					{{#if isTrial}}
+					<p class="terms-corp-signup">This trial is to demonstrate the value of a group subscription and we’ll contact you during your trial.</p>
+					{{/if}}
+				{{/if}}
 
-			{{#if isTrial}}
-			<p class="terms-corp-signup">This trial is to demonstrate the value of a group subscription and we’ll contact you during your trial.</p>
-			{{/if}}
-		{{/if}}
+				{{#if isTransition}}
 
-		{{#if isTransition}}
+				<p class="terms-transition">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="_blank" rel="noopener">customer service through chat, phone or email</a>.</p>
+				{{#ifEquals transitionType 'immediate'}}
+				<p class="terms-transition terms-transition--immediate">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</p>
+				{{else}}
+				<p class="terms-transition  terms-transition--other">By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.</p>
+				{{/ifEquals}}
+				<p class="terms-transition">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="_blank" rel="noopener">Terms &amp; Conditions</a>.</p>
 
-		<p class="terms-transition">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="_blank" rel="noopener">customer service through chat, phone or email</a>.</p>
-		{{#ifEquals transitionType 'immediate'}}
-		<p class="terms-transition terms-transition--immediate">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</p>
-		{{else}}
-		<p class="terms-transition  terms-transition--other">By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.</p>
-		{{/ifEquals}}
-		<p class="terms-transition">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="_blank" rel="noopener">Terms &amp; Conditions</a>.</p>
+				{{/if}}
 
-		{{/if}}
+				{{#if isSignup}}
+					{{#if isPrintProduct}}
+				<p class="terms-print">Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).</p>
+				<p class="terms-print">Find out more about your delivery start date in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">Terms &amp; Conditions</a>.</p>
+					{{else}}
+				<p class="terms-signup">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">customer service through chat, phone or email</a>.</p>
+				<p class="terms-signup">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</p>
+				<p class="terms-signup">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">Terms &amp; Conditions</a>.</p>
+					{{/if}}
+					{{#if specialTerms}}
+				<p id="terms-special">{{specialTerms}}</p>
+					{{/if}}
+				{{/if}}
+			</span>
+		</label>
+	</span>
 
-		{{#if isSignup}}
-			{{#if isPrintProduct}}
-		<p class="terms-print">Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).</p>
-		<p class="terms-print">Find out more about your delivery start date in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">Terms &amp; Conditions</a>.</p>
-			{{else}}
-		<p class="terms-signup">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">customer service through chat, phone or email</a>.</p>
-		<p class="terms-signup">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</p>
-		<p class="terms-signup">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener">Terms &amp; Conditions</a>.</p>
-			{{/if}}
-			{{#if specialTerms}}
-		<p id="terms-special">{{specialTerms}}</p>
-			{{/if}}
-		{{/if}}
-	</label>
-
-	<div class="o-forms__errortext">Please accept our terms &amp; conditions</div>
+	<span class="o-forms-input__error">Please accept our terms &amp; conditions</span>
 
 </div>

--- a/partials/billing-country.html
+++ b/partials/billing-country.html
@@ -1,28 +1,30 @@
-<div id="billingCountryField" class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field{{#if hasError}} o-forms--error{{/if}}" data-ui-item="select" data-ui-item-name="billingCountry" data-ui-item-store-previous="true" data-validate="required">
+<label id="billingCountryField" class="o-forms-field" data-validate="required">
+	<span class="o-forms-title">
+		<span class="o-forms-title__main">Billing Country</span>
+	</span>
 
-	<label for="billingCountry" class="o-forms__label">Billing Country</label>
+	<span class="o-forms-input o-forms-input--select{{#if hasError}} o-forms-input--invalid{{/if}}">
+		{{#ncf-countries value=value filterList=filterList}}
+		<select id="billingCountry" class="js-field__input js-item__value" aria-required="true" required
+				name="billingCountry"
+				data-trackable="field-billing-country"
+				{{#if isDisabled}}disabled{{/if}}>
 
-	{{#ncf-countries value=value filterList=filterList}}
-	<select id="billingCountry" class="o-forms__select js-field__input js-item__value" aria-required="true" required
-			name="billingCountry"
-			data-trackable="field-billing-country"
-			{{#if isDisabled}}disabled{{/if}}>
-
-		<option value disabled>Please select a country</option>
-		{{#each countries as |country|}}
-			{{#if this.label}}
-			<optgroup label="{{country.label}}">
-				{{#each country.countries as |country|}}
+			<option value disabled>Please select a country</option>
+			{{#each countries as |country|}}
+				{{#if this.label}}
+				<optgroup label="{{country.label}}">
+					{{#each country.countries as |country|}}
+					<option value="{{country.code}}"{{#if selected}} selected{{/if}}>{{country.name}}</option>
+					{{/each}}
+				</optgroup>
+				{{else}}
 				<option value="{{country.code}}"{{#if selected}} selected{{/if}}>{{country.name}}</option>
-				{{/each}}
-			</optgroup>
-			{{else}}
-			<option value="{{country.code}}"{{#if selected}} selected{{/if}}>{{country.name}}</option>
-			{{/if}}
-		{{/each}}
-	</select>
-	{{/ncf-countries}}
+				{{/if}}
+			{{/each}}
+		</select>
+		{{/ncf-countries}}
 
-	<div class="o-forms__errortext">Please select your country</div>
-
-</div>
+		<span class="o-forms-input__error">Please select your country</span>
+	</span>
+</label>

--- a/partials/billing-postcode.html
+++ b/partials/billing-postcode.html
@@ -1,25 +1,25 @@
-<div id="billingPostcodeField"
-		class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}{{#if isHidden}} n-ui-hide{{/if}}"
-		data-ui-item="form-field"
-		data-ui-item-name="deliveryPostcode"
-		data-validate="required">
+<label id="billingPostcodeField"
+	class="o-forms-field{{#if isHidden}} n-ui-hide{{/if}}"
+	data-validate="required">
 
-	<label for="billingPostcode" class="o-forms__label">
-		Billing <span data-reference="postcode">{{postcodeReference}}</span>
-	</label>
+	<span class="o-forms-title">
+		<span class="o-forms-title__main">
+			Billing <span data-reference="postcode">{{postcodeReference}}</span>
+		</span>
+	</span>
 
-	<input type="text"
+	<span class="o-forms-input o-forms-input--text{{#if hasError}} o-forms-input--invalid{{/if}}">
+		<input type="text"
 			id="billingPostcode"
 			name="billingPostcode"
 			placeholder="Enter your {{postcodeReference}}"
 			autocomplete="postal-code"
-			class="o-forms__text js-field__input js-item__value"
 			data-trackable="billing-postcode"
 			aria-required="true" required
 			{{#if pattern}}pattern="{{pattern}}"{{/if}}
 			{{#if isDisabled}}disabled{{/if}}
-			value="{{value}}">
+			value="{{value}}" />
+	</span>
 
-	<div class="o-forms__errortext">Please enter a valid <span data-reference="postcode">{{postcodeReference}}</span>.</div>
-
-</div>
+	<span class="o-forms-input__error">Please enter a valid <span data-reference="postcode">{{postcodeReference}}</span>.</span>
+</label>

--- a/partials/company-name.html
+++ b/partials/company-name.html
@@ -1,15 +1,18 @@
-<div id="companyNameField" class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}" data-ui-item="form-field" data-ui-item-name="companyName" data-validate="required">
+<label id="companyNameField" class="o-forms-field" data-validate="required">
 
-	<label for="companyName" class="o-forms__label">Company name</label>
+	<span class="o-forms-title">
+		<span class="o-forms-title__main">Company name</span>
+	</span>
 
-	<input type="text" id="companyName" name="company" placeholder="Enter your company name"
-				autocomplete="organization"
-				class="o-forms__text js-field__input js-item__value"
-				data-trackable="company-name"
-				aria-required="true" required
-				{{#if isDisabled}}disabled{{/if}}
-				value="{{value}}">
+	<span class="o-forms-input o-forms-input--text{{#if hasError}} o-forms-input--invalid{{/if}}">
+		<input type="text" id="companyName" name="company" placeholder="Enter your company name"
+			autocomplete="organization"
+			data-trackable="company-name"
+			aria-required="true" required
+			{{#if isDisabled}}disabled{{/if}}
+			value="{{value}}" />
+	</span>
 
-	<div class="o-forms__errortext">Please enter your company name.</div>
+	<span class="o-forms-input__error">Please enter your company name.</span>
 
-</div>
+</label>

--- a/partials/country.html
+++ b/partials/country.html
@@ -1,37 +1,30 @@
-{{!--
-	isBillingCountry is now deprecated
-	use billing-country instead
---}}
-<div id="countryField" class="o-forms o-forms--wide ncf__field js-field js-unknown-user-field{{#if hasError}} o-forms--error{{/if}}" data-ui-item="select" data-ui-item-name="{{#if isBillingCountry}}billingCountry{{else}}country{{/if}}" data-ui-item-store-previous="true" data-validate="required">
-
-	<label for="country" class="o-forms__label">{{#if isBillingCountry}}Billing Country{{else}}Country{{/if}}{{#if isB2b}}/Region{{/if}}</label>
+<label id="countryField" class="o-forms-field js-unknown-user-field" data-validate="required">
+	<span class="o-forms-title">
+		<span class="o-forms-title__main">Country{{#if isB2b}}/Region{{/if}}</span>
+	</span>
 
 	{{#ncf-countries value=value filterList=filterList}}
-	<select id="country" class="o-forms__select js-field__input js-item__value" aria-required="true" required
-		{{#if isBillingCountry}}
-		name="billingCountry"
-		data-trackable="field-billing-country"
-		{{else}}
-		name="country"
-		data-trackable="field-country"
-		{{/if}}
-		{{#if isDisabled}}disabled{{/if}}>
+	<span class="o-forms-input o-forms-input--select{{#if hasError}} o-forms-input--invalid{{/if}}">
+		<select id="country" aria-required="true" required
+			name="country"
+			data-trackable="field-country"
+			{{#if isDisabled}}disabled{{/if}}>
 
-		<option value>Please select a country{{#if isB2b}}/region{{/if}}</option>
-		{{#each countries as |country|}}
-			{{#if this.label}}
-			<optgroup label="{{country.label}}">
-				{{#each country.countries as |country|}}
+			<option value>Please select a country{{#if isB2b}}/region{{/if}}</option>
+			{{#each countries as |country|}}
+				{{#if this.label}}
+				<optgroup label="{{country.label}}">
+					{{#each country.countries as |country|}}
+					<option value="{{country.code}}"{{#if selected}} selected{{/if}}>{{country.name}}</option>
+					{{/each}}
+				</optgroup>
+				{{else}}
 				<option value="{{country.code}}"{{#if selected}} selected{{/if}}>{{country.name}}</option>
-				{{/each}}
-			</optgroup>
-			{{else}}
-			<option value="{{country.code}}"{{#if selected}} selected{{/if}}>{{country.name}}</option>
-			{{/if}}
-		{{/each}}
-	</select>
+				{{/if}}
+			{{/each}}
+		</select>
+	</span>
 	{{/ncf-countries}}
 
-	<div class="o-forms__errortext">Please select your country{{#if isB2b}}/region{{/if}}</div>
-
-</div>
+	<span class="o-forms-input__error">Please select your country{{#if isB2b}}/region{{/if}}</span>
+</label>

--- a/partials/decision-maker.html
+++ b/partials/decision-maker.html
@@ -1,15 +1,20 @@
-<fieldset id="decisionMakerField" class="o-forms o-forms--wide o-forms--inline ncf__field js-field{{#if hasError}} o-forms--error{{/if}}" data-ui-item="form-field" data-ui-item-name="decisionMaker" data-validate="required">
-	{{!-- Duplicate legend so it is the first element of a fieldset for A11Y --}}
-	<legend class="o-normalise-visually-hidden">Are you a manager with direct reports?</legend>
-	<div class="o-forms__inline-container ncf__field--min-content">
-		<div class="o-forms__label">Are you a manager with direct reports?</div>
-		<div class="o-forms__group o-forms__group--inline-together">
-			<input type="radio" id="decisionMakerYes" name="decisionMaker" value="yes" class="o-forms__radio-button"{{#ifEquals value "yes"}} checked{{/ifEquals}}>
-			<label for="decisionMakerYes" class="o-forms__label">Yes</label>
-			<input type="radio" id="decisionMakerNo" name="decisionMaker" value="no" class="o-forms__radio-button o-forms__radio-button--negative"{{#ifEquals value "no"}} checked{{/ifEquals}}>
-			<label for="decisionMakerNo" class="o-forms__label">No</label>
-		</div>
-	</div>
+<div id="decisionMakerField" role="group" aria-labelledby="decisionMakerFieldLabel" class="o-forms-field" data-validate="required">
+	<span class="o-forms-title">
+		<span class="o-forms-title__main" id="decisionMakerFieldLabel">Are you a manager with direct reports?</span>
+	</span>
 
-	<div class="o-forms__errortext">Please select an option</div>
-</fieldset>
+	<span class="o-forms-input o-forms-input--radio-box o-forms-input--inline{{#if hasError}} o-forms-input--invalid{{/if}}">
+		<div class="o-forms-input--radio-box__container">
+			<label>
+				<input type="radio" id="decisionMakerYes" name="decisionMaker" aria-label="Yes" value="yes"{{#ifEquals value "yes"}} checked{{/ifEquals}} />
+				<span class="o-forms-input__label" aria-hidden="true">Yes</span>
+			</label>
+			<label>
+				<input type="radio" id="decisionMakerNo" name="decisionMaker" aria-label="No" value="no"{{#ifEquals value "no"}} checked{{/ifEquals}} />
+				<span class="o-forms-input__label o-forms-input__label--negative" aria-hidden="true">No</span>
+			</label>
+		</div>
+	</span>
+
+	<span class="o-forms-input__error">Please select an option</span>
+</div>

--- a/partials/delivery-address.html
+++ b/partials/delivery-address.html
@@ -1,38 +1,42 @@
-<div id="deliveryAddressFields"
-		class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}"
-		data-ui-item="form-field"
-		data-ui-item-name="deliveryAddress"
-		data-validate="required">
-
-	<p>
-		<label for="deliveryAddressLine1" class="o-forms__label">Address line 1</label>
-		<input type="text" id="deliveryAddressLine1" name="deliveryAddressLine1"
-				class="o-forms__text js-field__input js-item__value"
+<div id="deliveryAddressFields" data-validate="required">
+	<label class="o-forms-field">
+		<span class="o-forms-title">
+			<span class="o-forms-title__main">Address line 1</span>
+		</span>
+		<span class="o-forms-input o-forms-input--text{{#if hasError}} o-forms-input--invalid{{/if}}">
+			<input type="text" id="deliveryAddressLine1" name="deliveryAddressLine1"
 				data-trackable="field-deliveryAddressLine1"
 				autocomplete="address-line1"
 				placeholder="e.g. 10 Elm Street"
 				aria-required="true" required
 				{{#if isDisabled}}disabled{{/if}}
-				value="{{line1}}">
-	</p>
-	<p>
-		<label for="deliveryAddressLine2" class="o-forms__label">Address line 2 <small>(optional)</small></label>
-		<input type="text" id="deliveryAddressLine2" name="deliveryAddressLine2"
-					class="o-forms__text js-field__input js-item__value"
-					data-trackable="field-deliveryAddressLine2"
-					autocomplete="address-line2"
-					placeholder="e.g. Apartment 1"
-					{{#if isDisabled}}disabled{{/if}}
-					value="{{line2}}">
-	</p>
-	<p>
-		<label for="deliveryAddressLine3" class="o-forms__label">Address line 3 <small>(optional)</small></label>
-		<input type="text" id="deliveryAddressLine3" name="deliveryAddressLine3"
-					class="o-forms__text js-field__input js-item__value"
-					data-trackable="field-deliveryAddressLine3"
-					autocomplete="address-line3"
-					placeholder=""
-					{{#if isDisabled}}disabled{{/if}}
-					value="{{line3}}">
-	</p>
+				value="{{line1}}" />
+		</span>
+	</label>
+	<label class="o-forms-field">
+		<span class="o-forms-title">
+			<span class="o-forms-title__main">Address line 2 <small>(optional)</small></span>
+		</span>
+		<span class="o-forms-input o-forms-input--text{{#if hasError}} o-forms-input--invalid{{/if}}">
+			<input type="text" id="deliveryAddressLine2" name="deliveryAddressLine2"
+				data-trackable="field-deliveryAddressLine2"
+				autocomplete="address-line2"
+				placeholder="e.g. Apartment 1"
+				{{#if isDisabled}}disabled{{/if}}
+				value="{{line2}}" />
+		</span>
+	</label>
+	<label class="o-forms-field">
+		<span class="o-forms-title">
+			<span class="o-forms-title__main">Address line 3 <small>(optional)</small></span>
+		</span>
+		<span class="o-forms-input o-forms-input--text{{#if hasError}} o-forms-input--invalid{{/if}}">
+			<input type="text" id="deliveryAddressLine3" name="deliveryAddressLine3"
+				data-trackable="field-deliveryAddressLine3"
+				autocomplete="address-line3"
+				placeholder=""
+				{{#if isDisabled}}disabled{{/if}}
+				value="{{line3}}" />
+		</span>
+	</label>
 </div>

--- a/partials/delivery-city.html
+++ b/partials/delivery-city.html
@@ -1,17 +1,14 @@
-<div id="deliveryCityField"
-		class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}"
-		data-ui-item="form-field"
-		data-ui-item-name="deliveryCity"
-		data-validate="required">
-
-	<label for="deliveryCity" class="o-forms__label">City/town</label>
-	<input type="text" id="deliveryCity" name="deliveryCity"
-				class="o-forms__text js-field__input js-item__value"
-				data-trackable="field-deliveryCity"
-				autocomplete="address-level2"
-				placeholder="e.g. Bath"
-				aria-required="true" required
-				{{#if isDisabled}}disabled{{/if}}
-				value="{{value}}">
-
-</div>
+<label id="deliveryCityField" class="o-forms-field" data-validate="required">
+	<span class="o-forms-title">
+		<span class="o-forms-title__main">City/town</span>
+	</span>
+	<span class="o-forms-input o-forms-input--text{{#if hasError}} o-forms-input--invalid{{/if}}">
+		<input type="text" id="deliveryCity" name="deliveryCity"
+			data-trackable="field-deliveryCity"
+			autocomplete="address-level2"
+			placeholder="e.g. Bath"
+			aria-required="true" required
+			{{#if isDisabled}}disabled{{/if}}
+			value="{{value}}">
+	</span>
+</label>

--- a/partials/delivery-county.html
+++ b/partials/delivery-county.html
@@ -1,16 +1,13 @@
-<div id="deliveryCountyField"
-		class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}"
-		data-ui-item="form-field"
-		data-ui-item-name="deliveryCounty"
-		data-validate="required">
-
-	<label for="deliveryCounty" class="o-forms__label">County <small>(optional)</small></label>
-	<input type="text" id="deliveryCounty" name="deliveryCounty"
-			class="o-forms__text js-field__input js-item__value"
+<label id="deliveryCountyField" class="o-forms-field" data-validate="required">
+	<span class="o-forms-title">
+		<span class="o-forms-title__main">County <small>(optional)</small></span>
+	</span>
+	<span class="o-forms-input o-forms-input--text{{#if hasError}} o-forms-input--invalid{{/if}}">
+		<input type="text" id="deliveryCounty" name="deliveryCounty"
 			data-trackable="field-deliveryCounty"
 			autocomplete="address-level3"
 			placeholder="e.g. Somerset"
 			{{#if isDisabled}}disabled{{/if}}
-			value="{{value}}">
-
-</div>
+			value="{{value}}" />
+	</span>
+</label>

--- a/partials/delivery-instructions.html
+++ b/partials/delivery-instructions.html
@@ -1,26 +1,23 @@
-<div id="deliveryInstructionsField"
-		class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}"
-		data-ui-item="form-field"
-		data-ui-item-name="deliveryInstructions"
-		data-validate="required">
+<label id="deliveryInstructionsField" class="o-forms-field" data-validate="required">
+	<span class="o-forms-title">
+		<span class="o-forms-title__main">Delivery instructions <small>(optional)</small></span>
+		<span class="o-forms-title__prompt">
+			These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
+		</span>
+	</span>
 
-	<label for="deliveryInstructions" class="o-forms__label">
-		Delivery instructions <small>(optional)</small>
-	</label>
-	<div class="ncf__terms ncf__terms--small">
-		These may be printed on your newspaper. Don’t add sensitive information like access codes. If you do so, it is at your own risk. To provide additional secure information, login to your account via FT.com.
-	</div>
-	<textarea type="text" id="deliveryInstructions" name="deliveryInstructions"
-				{{#if maxlength}}maxlength="{{maxlength}}"{{/if}}
-				{{#if rows}}rows="{{rows}}"{{/if}}
-				class="o-forms__text js-field__input js-item__value"
-				data-trackable="field-deliveryInstructions"
-				placeholder="Enter instructions {{#if maxlength}}(Max. {{maxlength}} characters){{/if}}:
+	<span class="o-forms-input o-forms-input--textarea{{#if hasError}} o-forms-input--invalid{{/if}}">
+		<textarea id="deliveryInstructions" name="deliveryInstructions"
+			{{#if maxlength}}maxlength="{{maxlength}}"{{/if}}
+			{{#if rows}}rows="{{rows}}"{{/if}}
+			data-trackable="field-deliveryInstructions"
+			placeholder="Enter instructions {{#if maxlength}}(Max. {{maxlength}} characters){{/if}}:
 - Door colour, letterbox location
 - Placement i.e. letterbox delivery
 - Special handling i.e. place in plastic bag"
-				{{#if isDisabled}}disabled{{/if}}>{{value}}</textarea>
+			{{#if isDisabled}}disabled{{/if}}>{{value}}</textarea>
+	</span>
 	<p>
 		Please note that we can only deliver to the ground floor level of your property.
 	</p>
-</div>
+</label>

--- a/partials/delivery-postcode.html
+++ b/partials/delivery-postcode.html
@@ -1,25 +1,23 @@
-<div id="deliveryPostcodeField"
-		class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}{{#if isHidden}} n-ui-hide{{/if}}"
-		data-ui-item="form-field"
-		data-ui-item-name="deliveryPostcode"
-		data-validate="required">
+<label id="deliveryPostcodeField"
+	class="o-forms-field{{#if isHidden}} n-ui-hide{{/if}}"
+	data-validate="required">
 
-	<label for="deliveryPostcode" class="o-forms__label">
-		Delivery <span data-reference="postcode">{{postcodeReference}}</span>
-	</label>
-
-	<input type="text"
+	<span class="o-forms-title">
+		<span class="o-forms-title__main">
+			Delivery <span data-reference="postcode">{{postcodeReference}}</span>
+		</span>
+	</span>
+	<span class="o-forms-input o-forms-input--text{{#if hasError}} o-forms-input--invalid{{/if}}">
+		<input type="text"
 			id="deliveryPostcode"
 			name="deliveryPostcode"
 			placeholder= "Enter your {{postcodeReference}}"
 			autocomplete="postal-code"
-			class="o-forms__text js-field__input js-item__value"
 			data-trackable="delivery-postcode"
 			aria-required="true" required
 			{{#if pattern}}pattern="{{pattern}}"{{/if}}
 			{{#if isDisabled}}disabled{{/if}}
 			value="{{value}}">
-
-	<div class="o-forms__errortext">Please enter a valid <span data-reference="postcode">{{postcodeReference}}</span>.</div>
-
-</div>
+	</span>
+	<span class="o-forms-input__error">Please enter a valid <span data-reference="postcode">{{postcodeReference}}</span>.</span>
+</label>

--- a/partials/email.html
+++ b/partials/email.html
@@ -1,31 +1,31 @@
-<div id="emailField" class="o-forms o-forms--wide ncf__field js-field{{#if hasError}} o-forms--error{{/if}}" data-validate="required,email">
+<label id="emailField" class="o-forms-field" data-validate="required,email">
+	<span class="o-forms-title">
+		<span class="o-forms-title__main">
+			{{#if isB2b}}
+			Work email address
+			{{else}}
+			Email address
+			{{/if}}
+		</span>
+		<span class="o-forms-title__prompt">
+			{{#if description}}
+			{{description}}
+			{{else}}
+			Please enter an email address
+			{{/if}}
+		</span>
+	</span>
+	<span class="o-forms-input o-forms-input--text{{#if hasError}} o-forms-input--invalid{{/if}}">
+		<input type="email" id="email" name="email" placeholder="Enter your email address"
+			autocomplete="email"
+			data-trackable="field-email"
+			aria-required="true"
+			required
+			{{#if isDisabled}}disabled{{/if}}
+			value="{{value}}"
+		/>
+	</span>
 
-	<label for="email" class="o-forms__label">
-		{{#if isB2b}}
-		Work email address
-		{{else}}
-		Email address
-		{{/if}}
-	</label>
-	<small id="email-description" class="o-forms__additional-info">
-		{{#if description}}
-		{{description}}
-		{{else}}
-		Please enter an email address
-		{{/if}}
-	</small>
+	<span class="o-forms-input__error">This email address is not valid</span>
 
-	<input type="email" id="email" name="email" placeholder="Enter your email address"
-				autocomplete="email"
-				class="no-mouseflow o-forms__text js-field__input js-item__value{{#if readonly}} o-forms__field-disabled{{/if}}"
-				data-trackable="field-email"
-				aria-required="true"
-				aria-describedby="email-description"
-				required
-				{{#if isDisabled}}disabled{{/if}}
-				value="{{value}}"
-	/>
-
-	<div class="o-forms__errortext">This email address is not valid</div>
-
-</div>
+</label>

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -203,7 +203,7 @@ const shouldError = function (context, errorParams = { hasError: true }) {
 	it('should not have error class by default', () => {
 		const $ = context.template({});
 
-		expect($(ERROR_CLASS).length).to.equal(0);
+		expect($(`.${ERROR_CLASS}`).length).to.equal(0);
 	});
 
 	it('should have error class if hasError is passed', () => {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,7 +6,7 @@ const Handlebars = require('@financial-times/n-handlebars').handlebars;
 
 const readFile = promisify(fs.readFile);
 const PARTIAL_DIR = __dirname + '/../partials/';
-const ERROR_CLASS = 'o-forms--error';
+const ERROR_CLASS = 'o-forms-input--invalid';
 const options = [
 	{ value: 'testValue1', label: 'testLabel1' },
 	{ value: 'testValue2', label: 'testValue2' },

--- a/test/partials/country.spec.js
+++ b/test/partials/country.spec.js
@@ -25,11 +25,11 @@ describe('country template', () => {
 	});
 
 	describe('isB2b', () => {
-		it('should have the correct label', () => {
+		it('should have the correct label text', () => {
 			const $ = context.template({
 				isB2b: true
 			});
-			expect($('label').html()).to.equal('Country/Region');
+			expect($('.o-forms-title__main').html()).to.equal('Country/Region');
 		});
 
 		it('should have the correct default option', () => {
@@ -43,22 +43,7 @@ describe('country template', () => {
 			const $ = context.template({
 				isB2b: true
 			});
-			expect($('.o-forms__errortext').html()).to.equal('Please select your country/region');
-		});
-	});
-
-	/* isBillingCountry is deprecated, use billing-country partial instead */
-	describe('isBillingCountry', () => {
-		it('should be have the name country by default', () => {
-			const $ = context.template({});
-			expect($('select').attr('name')).to.equal('country');
-		});
-
-		it('should be have the name billingCountry if isBillingCountry', () => {
-			const $ = context.template({
-				isBillingCountry: true
-			});
-			expect($('select').attr('name')).to.equal('billingCountry');
+			expect($('.o-forms-input__error').html()).to.equal('Please select your country/region');
 		});
 	});
 

--- a/test/partials/delivery-address.spec.js
+++ b/test/partials/delivery-address.spec.js
@@ -3,7 +3,6 @@ const {
 	fetchPartial,
 	shouldBeDisableable,
 	shouldBeRequired,
-	shouldError
 } = require('../helpers');
 
 let context = {};
@@ -36,7 +35,17 @@ describe('delivery-address template', () => {
 
 	shouldBeRequired(context, '#deliveryAddressLine1');
 
-	shouldError(context);
+	it('should not have error class by default', () => {
+		const $ = context.template({});
+
+		expect($('.o-forms-input--invalid').length).to.equal(0);
+	});
+
+	it('should have error class if hasError is passed', () => {
+		const $ = context.template({ hasError: true });
+
+		expect($('.o-forms-input--invalid').length).to.equal(3);
+	});
 
 	shouldBeDisableable(context, 'input');
 });

--- a/test/partials/delivery-city.spec.js
+++ b/test/partials/delivery-city.spec.js
@@ -8,7 +8,7 @@ const {
 
 let context = {};
 
-describe('delivery-city-town template', () => {
+describe.only('delivery-city-town template', () => {
 	before(async () => {
 		context.template = await fetchPartial('delivery-city.html');
 	});

--- a/test/partials/email.spec.js
+++ b/test/partials/email.spec.js
@@ -26,7 +26,7 @@ describe('email template', () => {
 		const label = 'Email address';
 		const $ = context.template({});
 
-		expect($('label').text().trim()).to.equal(label);
+		expect($('.o-forms-title__main').text().trim()).to.equal(label);
 	});
 
 	it('should have the b2b label if isB2b set', () => {
@@ -35,7 +35,7 @@ describe('email template', () => {
 			isB2b: true
 		});
 
-		expect($('label').text().trim()).to.equal(label);
+		expect($('.o-forms-title__main').text().trim()).to.equal(label);
 	});
 
 	it('should have a default description', () => {

--- a/test/utils/validation.spec.js
+++ b/test/utils/validation.spec.js
@@ -3,20 +3,7 @@ const proxyquire = require('proxyquire').noCallThru();
 const sinon = require('sinon');
 const jsdom = require('jsdom');
 const { JSDOM } = jsdom;
-
 const DomHelper = require('../helpers/dom');
-
-let findInputsStub = sinon.stub();
-let validateInputStub = sinon.stub();
-let OFormsStub = sinon.stub().returns({
-	findInputs: findInputsStub,
-	validateInput: validateInputStub
-});
-
-const Validation = proxyquire('../../utils/validation', {
-	'o-forms': OFormsStub
-});
-
 
 let $form;
 let checkboxAddEventListener;
@@ -27,7 +14,7 @@ let requiredElListener;
 let sandbox;
 let validation;
 
-const createElement = (config) => {
+const createElement = config => {
 	let el = DomHelper.createElement(config, sandbox);
 	let parentNode = document.createElement('div');
 
@@ -35,11 +22,32 @@ const createElement = (config) => {
 	sandbox.stub(parentNode, 'removeChild').value(removeChildStub);
 	sandbox.stub(el, 'parentNode').value(parentNode);
 
-	return el;
+	return {
+		input: el,
+		...config
+	};
 };
 
-describe('Validation', () => {
+let validateInputStub = sinon.stub();
+let formInputsStub = [];
+let OFormsStub = {
+	default: {
+		init: sinon.stub().returns({
+			formInputs: formInputsStub
+		})
+	}
+};
 
+let InputStub = sinon.stub().returns({
+	validate: validateInputStub
+});
+
+const Validation = proxyquire('../../utils/validation', {
+	'o-forms': OFormsStub,
+	'o-forms/src/js/input': InputStub
+});
+
+describe('Validation', () => {
 	before(() => {
 		const dom = new JSDOM();
 		global.window = dom.window;
@@ -62,18 +70,43 @@ describe('Validation', () => {
 		requiredElListener = sandbox.stub();
 
 		sandbox.spy(document, 'addEventListener');
-		sandbox.spy(OFormsStub, 'constructor');
+		sandbox.spy(OFormsStub.default.init, 'constructor');
 		sandbox.stub(document, 'querySelector');
 
 		document.querySelector.withArgs('form.ncf').returns($form);
 
-		findInputsStub.returns([
-			createElement({ name: 'foo', type: 'hidden', checkValidity: checkValidityStub }),
-			createElement({ name: 'bar', checkValidity: checkValidityStub }),
-			createElement({ name: 'baz', required: true, addEventListener: requiredElListener, checkValidity: checkValidityStub }),
-			createElement({ name: 'qoo', required: true, addEventListener: requiredElListener, checkValidity: checkValidityStub }),
-			createElement({ name: 'checkbox', type: 'checkbox', addEventListener: checkboxAddEventListener, required: true, checkValidity: checkValidityStub })
-		]);
+		// Clear array before moving on to the next test
+		formInputsStub.splice(0, formInputsStub.length);
+
+		formInputsStub.push(
+			...[
+				createElement({
+					name: 'foo',
+					type: 'hidden',
+					checkValidity: checkValidityStub
+				}),
+				createElement({ name: 'bar', checkValidity: checkValidityStub }),
+				createElement({
+					name: 'baz',
+					required: true,
+					addEventListener: requiredElListener,
+					checkValidity: checkValidityStub
+				}),
+				createElement({
+					name: 'qoo',
+					required: true,
+					addEventListener: requiredElListener,
+					checkValidity: checkValidityStub
+				}),
+				createElement({
+					name: 'checkbox',
+					type: 'checkbox',
+					addEventListener: checkboxAddEventListener,
+					required: true,
+					checkValidity: checkValidityStub
+				})
+			]
+		);
 
 		validation = new Validation(document);
 		sandbox.spy(validation, 'checkFormValidity');
@@ -87,7 +120,7 @@ describe('Validation', () => {
 
 	describe('constructor', () => {
 		it('should call oForms to setup client side validation', () => {
-			expect(OFormsStub.calledWithNew()).to.be.true;
+			expect(OFormsStub.default.init.called).to.be.true;
 		});
 
 		it('should have a $form property exposing the form element', () => {
@@ -120,7 +153,9 @@ describe('Validation', () => {
 		it('should call checkElementValidity when changing a checkbox', () => {
 			expect(checkboxAddEventListener.getCalls().length).to.equal(1);
 			// we have to check `bound ` because we pass it with `.bind(this)`
-			expect(checkboxAddEventListener.getCall(0).args[1].name).to.equal('bound checkElementValidity');
+			expect(checkboxAddEventListener.getCall(0).args[1].name).to.equal(
+				'bound checkElementValidity'
+			);
 		});
 	});
 
@@ -147,13 +182,14 @@ describe('Validation', () => {
 			sandbox.stub(validation, 'checkCustomValidation').returns(false);
 			validation.checkElementValidity($el);
 
-			expect(validateInputStub.called).to.be.false;
+			expect(InputStub.called).to.be.false;
 		});
 
-		it('should call oForms.validateInput for the element.', () => {
+		it('should call input.validate for the element.', () => {
 			validation.checkElementValidity($el);
 
-			expect(validateInputStub.getCall(0).args[0]).to.equal($el);
+			expect(InputStub.calledWithNew()).to.be.true;
+			expect(InputStub.getCall(0).args[0]).to.equal($el);
 		});
 	});
 
@@ -162,15 +198,17 @@ describe('Validation', () => {
 			validation.formValid = true;
 
 			checkValidityStub.returns(false);
+
 			validation.checkFormValidity();
 
 			expect(validation.formValid).to.be.false;
 		});
 
-		it('should set the form as valid if there are invalid elements.', () => {
+		it('should set the form as valid if there are no invalid elements.', () => {
 			validation.formValid = false;
 
 			checkValidityStub.returns(true);
+
 			validation.checkFormValidity();
 
 			expect(validation.formValid).to.be.true;
@@ -247,14 +285,16 @@ describe('Validation', () => {
 			let messageStub = { foo: 'bar' };
 
 			it('adds the o-form--error class to the parent', () => {
-				sandbox.spy(field.parentNode.classList, 'add');
-				validation.showCustomFieldValidationError(field, messageStub);
+				sandbox.spy(field.input.parentNode.classList, 'add');
+				validation.showCustomFieldValidationError(field.input, messageStub);
 
-				expect(field.parentNode.classList.add.getCall(0).args[0]).to.equal('o-forms--error');
+				expect(
+					field.input.parentNode.classList.add.getCall(0).args[0]
+				).to.equal('o-forms-input--invalid');
 			});
 			it('adds the message to the parent', () => {
 				global.document.querySelector.returns(null);
-				validation.showCustomFieldValidationError(field, messageStub);
+				validation.showCustomFieldValidationError(field.input, messageStub);
 
 				expect(insertBeforeStub.getCall(0).args[0]).to.equal(messageStub);
 			});
@@ -264,18 +304,23 @@ describe('Validation', () => {
 			it('removes the message from the page', () => {
 				let fieldToRemove = createElement({ name: 'foo' });
 
-				sandbox.stub(validation.$form, 'querySelector').returns(fieldToRemove);
-				validation.clearCustomFieldValidationError(fieldToRemove);
+				sandbox
+					.stub(validation.$form, 'querySelector')
+					.returns(fieldToRemove.input);
+				validation.clearCustomFieldValidationError(fieldToRemove.input);
 
-				expect(removeChildStub.getCall(0).args[0].outerHTML).to.equal(field.outerHTML);
+				expect(removeChildStub.getCall(0).args[0].outerHTML).to.equal(
+					field.input.outerHTML
+				);
 			});
 			it('re-checks the element validity for standard validation rules', () => {
 				sandbox.spy(validation, 'checkElementValidity');
-				validation.clearCustomFieldValidationError(field);
+				validation.clearCustomFieldValidationError(field.input);
 
-				expect(validation.checkElementValidity.getCall(0).args[0]).to.equal(field);
+				expect(validation.checkElementValidity.getCall(0).args[0]).to.equal(
+					field.input
+				);
 			});
 		});
 	});
-
 });

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -1,4 +1,5 @@
-const OForms = require('o-forms');
+const OForms = require('o-forms').default;
+const Input = require('o-forms/src/js/input');
 
 class Validation {
 
@@ -8,9 +9,9 @@ class Validation {
 	 */
 	constructor ({ mutePromptBeforeLeaving } = {}) {
 		this.$form = document.querySelector('form.ncf');
-		this.oForms = new OForms(this.$form);
-		this.$formFields = this.oForms.findInputs().filter($el => $el.type !== 'hidden');
-		this.$requiredEls = this.$formFields.filter($el => $el.required);
+		this.oForms = OForms.init(this.$form);
+		this.$requiredEls = this.oForms.formInputs
+			.filter(({input}) => input.type !== 'hidden' && input.required);
 		this.formValid = false;
 		this.formChanged = false;
 		this.formSubmit = false;
@@ -53,7 +54,8 @@ class Validation {
 	 * @param {Event} event DOM event
 	 */
 	validateForm (event) {
-		this.oForms.validateForm(event);
+		this.oForms.validateFormInputs(event);
+		this.checkCustomValidation();
 	}
 
 	/**
@@ -92,10 +94,17 @@ class Validation {
 	 * @param {DOMElement} $message The error message to display.
 	 */
 	showCustomFieldValidationError ($field, $message) {
+		/**
+		 * - remove o-forms-input--valid class from $parent
+		 */
+
+		$field.setCustomValidity($message);
+
 		const $parent = $field.parentNode;
 		const $oFormsErrorText = $parent.querySelector('.o-forms__errortext');
 
-		$parent.classList.add('o-forms--error');
+		$parent.classList.remove('o-forms-input--valid');
+		$parent.classList.add('o-forms-input--invalid');
 
 		if (!document.querySelector(`#custom-validation-for-${$field.name}`)) {
 			// In order for this error to hang around after normal oForms validation happens it
@@ -116,6 +125,7 @@ class Validation {
 	 * @param {DOMElement} $field The field related to the error that now needs to be cleared.
 	 */
 	clearCustomFieldValidationError ($field) {
+		$field.setCustomValidity('');
 		const $message = this.$form.querySelector(`#custom-validation-for-${$field.name}`);
 		const $oFormsErrorText = $field.parentNode.querySelector('.o-forms__errortext');
 
@@ -140,8 +150,8 @@ class Validation {
 		if (this.customValidation.size > 0 && !this.debounceCustomValidation) {
 			this.debounceCustomValidation = true;
 
-			this.customValidation.forEach(async (validator) => {
-				await validator();
+			this.customValidation.forEach(validator => {
+				validator();
 			});
 
 			setTimeout(() => {
@@ -160,8 +170,9 @@ class Validation {
 
 		// If field fails custom validation don't `validateInput` as it may pass standard validation
 		if (passedCustomValidation) {
+			const input = new Input($el);
 			// Make sure the input element has been updated (for example if this is from a label click for a checkbox).
-			this.oForms.validateInput($el);
+			input.validate();
 		}
 	}
 


### PR DESCRIPTION
### Description
For this migration, I've cherry picked the form validation changes from PR #193.

So far, the following components have been migrated to use the correct `o-forms` mark-up:

- Accept Terms
- Billing Country
- Billing Postcode
- Company Name
- Country
- Decision Maker
- Delivery Address
- Delivery City
- Delivery County
- Delivery Instructions
- Delivery Postcode
- Email
