### PR TITLE
Origami Upgrade: o-forms migration for Delivery Option component

### DIFF
--- a/components/__snapshots__/delivery-option.spec.js.snap
+++ b/components/__snapshots__/delivery-option.spec.js.snap
@@ -2,396 +2,380 @@
 
 exports[`DeliveryOption renders with a context of being single 1`] = `
 <div id="deliveryOptionField"
-     class="o-forms__group ncf__delivery-option ncf__delivery-option--single"
+     class="o-forms-field ncf__delivery-option ncf__delivery-option--single"
+     role="group"
+     aria-label="Delivery options"
 >
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="PV"
-           name="deliveryOption"
-           value="PV"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-           checked
-    >
-    <label for="PV"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Paper vouchers
+  <span class="o-forms-input o-forms-input--radio-round">
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="PV"
+             name="deliveryOption"
+             value="PV"
+             class="ncf__delivery-option__input"
+             checked
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Paper vouchers
+        </span>
+        <div class="ncf__delivery-option__description">
+          13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
+        </div>
       </span>
-      <div class="ncf__delivery-option__description">
-        13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
-      </div>
     </label>
-  </div>
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="HD"
-           name="deliveryOption"
-           value="HD"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-    >
-    <label for="HD"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Home delivery
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="HD"
+             name="deliveryOption"
+             value="HD"
+             class="ncf__delivery-option__input"
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Home delivery
+        </span>
+        <div class="ncf__delivery-option__description">
+          Free delivery to your home or office before 7am.
+        </div>
       </span>
-      <div class="ncf__delivery-option__description">
-        Free delivery to your home or office before 7am.
-      </div>
     </label>
-  </div>
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="EV"
-           name="deliveryOption"
-           value="EV"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-    >
-    <label for="EV"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Electronic vouchers
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="EV"
+             name="deliveryOption"
+             value="EV"
+             class="ncf__delivery-option__input"
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Electronic vouchers
+        </span>
+        <div class="ncf__delivery-option__description">
+          Delivered via email and card, redeemable at retailers nationwide.
+        </div>
       </span>
-      <div class="ncf__delivery-option__description">
-        Delivered via email and card, redeemable at retailers nationwide.
-      </div>
     </label>
-  </div>
+  </span>
 </div>
 `;
 
 exports[`DeliveryOption renders with a context of being single 2`] = `
 <div id="deliveryOptionField"
-     class="o-forms__group ncf__delivery-option ncf__delivery-option--single"
+     class="o-forms-field ncf__delivery-option ncf__delivery-option--single"
+     role="group"
+     aria-label="Delivery options"
 >
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="PV"
-           name="deliveryOption"
-           value="PV"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-           checked
-    >
-    <label for="PV"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Paper vouchers
+  <span class="o-forms-input o-forms-input--radio-round">
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="PV"
+             name="deliveryOption"
+             value="PV"
+             class="ncf__delivery-option__input"
+             checked
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Paper vouchers
+        </span>
+        <div class="ncf__delivery-option__description">
+          13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
+        </div>
       </span>
-      <div class="ncf__delivery-option__description">
-        13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
-      </div>
     </label>
-  </div>
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="HD"
-           name="deliveryOption"
-           value="HD"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-    >
-    <label for="HD"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Home delivery
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="HD"
+             name="deliveryOption"
+             value="HD"
+             class="ncf__delivery-option__input"
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Home delivery
+        </span>
+        <div class="ncf__delivery-option__description">
+          Free delivery to your home or office before 7am.
+        </div>
       </span>
-      <div class="ncf__delivery-option__description">
-        Free delivery to your home or office before 7am.
-      </div>
     </label>
-  </div>
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="EV"
-           name="deliveryOption"
-           value="EV"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-    >
-    <label for="EV"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Electronic vouchers
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="EV"
+             name="deliveryOption"
+             value="EV"
+             class="ncf__delivery-option__input"
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Electronic vouchers
+        </span>
+        <div class="ncf__delivery-option__description">
+          Delivered via email and card, redeemable at retailers nationwide.
+        </div>
       </span>
-      <div class="ncf__delivery-option__description">
-        Delivered via email and card, redeemable at retailers nationwide.
-      </div>
     </label>
-  </div>
+  </span>
 </div>
 `;
 
 exports[`DeliveryOption renders with minimum mandatory props 1`] = `
 <div id="deliveryOptionField"
-     class="o-forms__group ncf__delivery-option"
+     class="o-forms-field ncf__delivery-option"
+     role="group"
+     aria-label="Delivery options"
 >
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="PV"
-           name="deliveryOption"
-           value="PV"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-           checked
-    >
-    <label for="PV"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Paper vouchers
+  <span class="o-forms-input o-forms-input--radio-round">
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="PV"
+             name="deliveryOption"
+             value="PV"
+             class="ncf__delivery-option__input"
+             checked
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Paper vouchers
+        </span>
+        <div class="ncf__delivery-option__description">
+          13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
+        </div>
       </span>
-      <div class="ncf__delivery-option__description">
-        13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
-      </div>
     </label>
-  </div>
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="HD"
-           name="deliveryOption"
-           value="HD"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-    >
-    <label for="HD"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Home delivery
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="HD"
+             name="deliveryOption"
+             value="HD"
+             class="ncf__delivery-option__input"
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Home delivery
+        </span>
+        <div class="ncf__delivery-option__description">
+          Free delivery to your home or office before 7am.
+        </div>
       </span>
-      <div class="ncf__delivery-option__description">
-        Free delivery to your home or office before 7am.
-      </div>
     </label>
-  </div>
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="EV"
-           name="deliveryOption"
-           value="EV"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-    >
-    <label for="EV"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Electronic vouchers
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="EV"
+             name="deliveryOption"
+             value="EV"
+             class="ncf__delivery-option__input"
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Electronic vouchers
+        </span>
+        <div class="ncf__delivery-option__description">
+          Delivered via email and card, redeemable at retailers nationwide.
+        </div>
       </span>
-      <div class="ncf__delivery-option__description">
-        Delivered via email and card, redeemable at retailers nationwide.
-      </div>
     </label>
-  </div>
+  </span>
 </div>
 `;
 
 exports[`DeliveryOption renders with minimum mandatory props 2`] = `
 <div id="deliveryOptionField"
-     class="o-forms__group ncf__delivery-option"
+     class="o-forms-field ncf__delivery-option"
+     role="group"
+     aria-label="Delivery options"
 >
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="PV"
-           name="deliveryOption"
-           value="PV"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-           checked
-    >
-    <label for="PV"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Paper vouchers
+  <span class="o-forms-input o-forms-input--radio-round">
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="PV"
+             name="deliveryOption"
+             value="PV"
+             class="ncf__delivery-option__input"
+             checked
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Paper vouchers
+        </span>
+        <div class="ncf__delivery-option__description">
+          13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
+        </div>
       </span>
-      <div class="ncf__delivery-option__description">
-        13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
-      </div>
     </label>
-  </div>
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="HD"
-           name="deliveryOption"
-           value="HD"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-    >
-    <label for="HD"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Home delivery
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="HD"
+             name="deliveryOption"
+             value="HD"
+             class="ncf__delivery-option__input"
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Home delivery
+        </span>
+        <div class="ncf__delivery-option__description">
+          Free delivery to your home or office before 7am.
+        </div>
       </span>
-      <div class="ncf__delivery-option__description">
-        Free delivery to your home or office before 7am.
-      </div>
     </label>
-  </div>
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="EV"
-           name="deliveryOption"
-           value="EV"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-    >
-    <label for="EV"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Electronic vouchers
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="EV"
+             name="deliveryOption"
+             value="EV"
+             class="ncf__delivery-option__input"
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Electronic vouchers
+        </span>
+        <div class="ncf__delivery-option__description">
+          Delivered via email and card, redeemable at retailers nationwide.
+        </div>
       </span>
-      <div class="ncf__delivery-option__description">
-        Delivered via email and card, redeemable at retailers nationwide.
-      </div>
     </label>
-  </div>
+  </span>
 </div>
 `;
 
 exports[`DeliveryOption renders without unrecognised delivery options 1`] = `
 <div id="deliveryOptionField"
-     class="o-forms__group ncf__delivery-option"
+     class="o-forms-field ncf__delivery-option"
+     role="group"
+     aria-label="Delivery options"
 >
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="PV"
-           name="deliveryOption"
-           value="PV"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-           checked
-    >
-    <label for="PV"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Paper vouchers
+  <span class="o-forms-input o-forms-input--radio-round">
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="PV"
+             name="deliveryOption"
+             value="PV"
+             class="ncf__delivery-option__input"
+             checked
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Paper vouchers
+        </span>
+        <div class="ncf__delivery-option__description">
+          13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
+        </div>
       </span>
-      <div class="ncf__delivery-option__description">
-        13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
-      </div>
     </label>
-  </div>
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="HD"
-           name="deliveryOption"
-           value="HD"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-    >
-    <label for="HD"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Home delivery
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="HD"
+             name="deliveryOption"
+             value="HD"
+             class="ncf__delivery-option__input"
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Home delivery
+        </span>
+        <div class="ncf__delivery-option__description">
+          Free delivery to your home or office before 7am.
+        </div>
       </span>
-      <div class="ncf__delivery-option__description">
-        Free delivery to your home or office before 7am.
-      </div>
     </label>
-  </div>
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="FOOBAR"
-           name="deliveryOption"
-           value="FOOBAR"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-    >
-    <label for="FOOBAR"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-    </label>
-  </div>
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="EV"
-           name="deliveryOption"
-           value="EV"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-    >
-    <label for="EV"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Electronic vouchers
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="FOOBAR"
+             name="deliveryOption"
+             value="FOOBAR"
+             class="ncf__delivery-option__input"
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
       </span>
-      <div class="ncf__delivery-option__description">
-        Delivered via email and card, redeemable at retailers nationwide.
-      </div>
     </label>
-  </div>
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="EV"
+             name="deliveryOption"
+             value="EV"
+             class="ncf__delivery-option__input"
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Electronic vouchers
+        </span>
+        <div class="ncf__delivery-option__description">
+          Delivered via email and card, redeemable at retailers nationwide.
+        </div>
+      </span>
+    </label>
+  </span>
 </div>
 `;
 
 exports[`DeliveryOption renders without unrecognised delivery options 2`] = `
 <div id="deliveryOptionField"
-     class="o-forms__group ncf__delivery-option"
+     class="o-forms-field ncf__delivery-option"
+     role="group"
+     aria-label="Delivery options"
 >
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="PV"
-           name="deliveryOption"
-           value="PV"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-           checked
-    >
-    <label for="PV"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Paper vouchers
+  <span class="o-forms-input o-forms-input--radio-round">
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="PV"
+             name="deliveryOption"
+             value="PV"
+             class="ncf__delivery-option__input"
+             checked
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Paper vouchers
+        </span>
+        <div class="ncf__delivery-option__description">
+          13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
+        </div>
       </span>
-      <div class="ncf__delivery-option__description">
-        13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
-      </div>
     </label>
-  </div>
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="HD"
-           name="deliveryOption"
-           value="HD"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-    >
-    <label for="HD"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Home delivery
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="HD"
+             name="deliveryOption"
+             value="HD"
+             class="ncf__delivery-option__input"
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Home delivery
+        </span>
+        <div class="ncf__delivery-option__description">
+          Free delivery to your home or office before 7am.
+        </div>
       </span>
-      <div class="ncf__delivery-option__description">
-        Free delivery to your home or office before 7am.
-      </div>
     </label>
-  </div>
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="FOOBAR"
-           name="deliveryOption"
-           value="FOOBAR"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-    >
-    <label for="FOOBAR"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-    </label>
-  </div>
-  <div class="ncf__delivery-option__item">
-    <input type="radio"
-           id="EV"
-           name="deliveryOption"
-           value="EV"
-           class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"
-    >
-    <label for="EV"
-           class="o-forms__label ncf__delivery-option__label"
-    >
-      <span class="ncf__delivery-option__title">
-        Electronic vouchers
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="FOOBAR"
+             name="deliveryOption"
+             value="FOOBAR"
+             class="ncf__delivery-option__input"
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
       </span>
-      <div class="ncf__delivery-option__description">
-        Delivered via email and card, redeemable at retailers nationwide.
-      </div>
     </label>
-  </div>
+    <label class="ncf__delivery-option__item">
+      <input type="radio"
+             id="EV"
+             name="deliveryOption"
+             value="EV"
+             class="ncf__delivery-option__input"
+      >
+      <span class="o-forms-input__label ncf__delivery-option__label">
+        <span class="ncf__delivery-option__title">
+          Electronic vouchers
+        </span>
+        <div class="ncf__delivery-option__description">
+          Delivered via email and card, redeemable at retailers nationwide.
+        </div>
+      </span>
+    </label>
+  </span>
 </div>
 `;

--- a/components/delivery-option.jsx
+++ b/components/delivery-option.jsx
@@ -52,14 +52,8 @@ export function DeliveryOption ({
 							<label key={index} className="ncf__delivery-option__item">
 								<input {...inputProps} />
 								<span className="o-forms-input__label ncf__delivery-option__label">
-									{
-										deliveryOptionValue && (
-											<React.Fragment>
-												<span className="ncf__delivery-option__title">{deliveryOptionValue.title}</span>
-												<div className="ncf__delivery-option__description">{deliveryOptionValue.description}</div>
-											</React.Fragment>
-										)
-									}
+									<span className="ncf__delivery-option__title">{deliveryOptionValue.title}</span>
+									<div className="ncf__delivery-option__description">{deliveryOptionValue.description}</div>
 								</span>
 							</label>
 						);
@@ -72,7 +66,7 @@ export function DeliveryOption ({
 
 DeliveryOption.propTypes = {
 	options: PropTypes.arrayOf(PropTypes.shape({
-		value: PropTypes.string,
+		value: PropTypes.oneOf(['PV', 'HD', 'EV']),
 		isSelected: PropTypes.boolean
 	})),
 	isSingle: PropTypes.boolean

--- a/components/delivery-option.jsx
+++ b/components/delivery-option.jsx
@@ -36,17 +36,17 @@ export function DeliveryOption ({
 		>
 			<span className="o-forms-input o-forms-input--radio-round">
 				{
-					options.map((option, index) => {
+					options.map(({value, isSelected}, index) => {
 						const inputProps = {
 							type: 'radio',
-							id: option.value,
+							id: value,
 							name: 'deliveryOption',
-							value: option.value,
+							value: value,
 							className: 'ncf__delivery-option__input',
-							...(option.isSelected && { defaultChecked: true })
+							...(isSelected && { defaultChecked: true })
 						};
 
-						const deliveryOptionValue = deliveryOptions[option.value];
+						const deliveryOptionValue = deliveryOptions[value];
 
 						return (
 							<label key={index} className="ncf__delivery-option__item">

--- a/components/delivery-option.jsx
+++ b/components/delivery-option.jsx
@@ -43,7 +43,7 @@ export function DeliveryOption ({
 							name: 'deliveryOption',
 							value: value,
 							className: 'ncf__delivery-option__input',
-							...(isSelected && { defaultChecked: true })
+							defaultChecked: isSelected
 						};
 
 						const deliveryOptionValue = deliveryOptions[value];

--- a/components/delivery-option.jsx
+++ b/components/delivery-option.jsx
@@ -7,7 +7,7 @@ export function DeliveryOption ({
 	isSingle = false
 }) {
 	const divClassName = classNames([
-		'o-forms__group',
+		'o-forms-field',
 		'ncf__delivery-option',
 		{ 'ncf__delivery-option--single': isSingle }
 	]);
@@ -31,37 +31,41 @@ export function DeliveryOption ({
 		<div
 			id="deliveryOptionField"
 			className={divClassName}
+			role="group"
+			aria-label="Delivery options"
 		>
-			{
-				options.map((option, index) => {
-					const inputProps = {
-						type: 'radio',
-						id: option.value,
-						name: 'deliveryOption',
-						value: option.value,
-						className: 'o-forms__radio o-forms__radio--right ncf__delivery-option__input',
-						...(option.isSelected && { defaultChecked: true })
-					};
+			<span className="o-forms-input o-forms-input--radio-round">
+				{
+					options.map((option, index) => {
+						const inputProps = {
+							type: 'radio',
+							id: option.value,
+							name: 'deliveryOption',
+							value: option.value,
+							className: 'ncf__delivery-option__input',
+							...(option.isSelected && { defaultChecked: true })
+						};
 
-					const deliveryOptionValue = deliveryOptions[option.value];
+						const deliveryOptionValue = deliveryOptions[option.value];
 
-					return (
-						<div key={index} className="ncf__delivery-option__item">
-							<input {...inputProps} />
-							<label htmlFor={option.value} className="o-forms__label ncf__delivery-option__label">
-								{
-									deliveryOptionValue && (
-										<React.Fragment>
-											<span className="ncf__delivery-option__title">{deliveryOptionValue.title}</span>
-											<div className="ncf__delivery-option__description">{deliveryOptionValue.description}</div>
-										</React.Fragment>
-									)
-								}
+						return (
+							<label key={index} className="ncf__delivery-option__item">
+								<input {...inputProps} />
+								<span className="o-forms-input__label ncf__delivery-option__label">
+									{
+										deliveryOptionValue && (
+											<React.Fragment>
+												<span className="ncf__delivery-option__title">{deliveryOptionValue.title}</span>
+												<div className="ncf__delivery-option__description">{deliveryOptionValue.description}</div>
+											</React.Fragment>
+										)
+									}
+								</span>
 							</label>
-						</div>
-					);
-				})
-			}
+						);
+					})
+				}
+			</span>
 		</div>
 	);
 }

--- a/demos/init-jsx.js
+++ b/demos/init-jsx.js
@@ -23,7 +23,20 @@ function initDemo () {
 			<ncf.DeliveryCity />
 			<ncf.DeliveryCounty />
 			<ncf.DeliveryInstructions />
-			<ncf.DeliveryOption />
+			<ncf.DeliveryOption options={[
+				{
+					value: 'PV',
+					isSelected: true
+				},
+				{
+					value: 'HD',
+					isSelected: false
+				},
+				{
+					value: 'EV',
+					isSelected: false
+				}
+			]} />
 			<ncf.DeliveryPostcode postcodeReference={'delivery postcode'}/>
 			<ncf.DeliveryStartDate />
 			<ncf.Email />

--- a/partials/delivery-option.html
+++ b/partials/delivery-option.html
@@ -1,29 +1,31 @@
-<div id="deliveryOptionField" class="o-forms__group ncf__delivery-option{{#if isSingle}} ncf__delivery-option--single{{/if}}">
-	{{#each options}}
-	<div class="ncf__delivery-option__item">
-		<input type="radio" id="{{this.value}}" name="deliveryOption" value="{{this.value}}" class="o-forms__radio o-forms__radio--right ncf__delivery-option__input"{{#if this.isSelected}} checked{{/if}}>
-		<label for="{{this.value}}" class="o-forms__label ncf__delivery-option__label">
-			{{#ifEquals this.value 'PV'}}
-			<span class="ncf__delivery-option__title">Paper vouchers</span>
-			<div class="ncf__delivery-option__description">
-				13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
-			</div>
-			{{/ifEquals}}
+<div id="deliveryOptionField" class="o-forms-field ncf__delivery-option{{#if isSingle}} ncf__delivery-option--single{{/if}}" role="group" aria-label="Delivery options">
+	<span class="o-forms-input o-forms-input--radio-round">
+		{{#each options}}
+		<label class="ncf__delivery-option__item">
+			<input type="radio" id="{{this.value}}" name="deliveryOption" value="{{this.value}}" class="ncf__delivery-option__input"{{#if this.isSelected}} checked{{/if}}>
+			<span class="o-forms-input__label ncf__delivery-option__label">
+				{{#ifEquals this.value 'PV'}}
+				<span class="ncf__delivery-option__title">Paper vouchers</span>
+				<div class="ncf__delivery-option__description">
+					13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
+				</div>
+				{{/ifEquals}}
 
-			{{#ifEquals this.value 'HD'}}
-			<span class="ncf__delivery-option__title">Home delivery</span>
-			<div class="ncf__delivery-option__description">
-				Free delivery to your home or office before 7am.
-			</div>
-			{{/ifEquals}}
+				{{#ifEquals this.value 'HD'}}
+				<span class="ncf__delivery-option__title">Home delivery</span>
+				<div class="ncf__delivery-option__description">
+					Free delivery to your home or office before 7am.
+				</div>
+				{{/ifEquals}}
 
-			{{#ifEquals this.value 'EV'}}
-			<span class="ncf__delivery-option__title">Electronic vouchers</span>
-			<div class="ncf__delivery-option__description">
-				Delivered via email and card, redeemable at retailers nationwide.
-			</div>
-			{{/ifEquals}}
+				{{#ifEquals this.value 'EV'}}
+				<span class="ncf__delivery-option__title">Electronic vouchers</span>
+				<div class="ncf__delivery-option__description">
+					Delivered via email and card, redeemable at retailers nationwide.
+				</div>
+				{{/ifEquals}}
+			</span>
 		</label>
-	</div>
-	{{/each}}
+		{{/each}}
+	</span>
 </div>

--- a/styles/_shared.scss
+++ b/styles/_shared.scss
@@ -1,25 +1,28 @@
 @mixin bigRadioButton($className) {
-	.o-forms__radio + .o-forms__label {
+	.o-forms-input--radio-round input[type=radio] + .o-forms-input__label {
+		box-sizing: border-box;
 		padding: 14px 20px;
 		min-height: 110px;
 		border: 2px solid oColorsByName('teal');
 		text-align: left;
-		margin: 8px 0;
+		width: 100%;
 
 		// radio button styling
 		&::before {
 			border: 2px solid oColorsByName('teal');
+			left: auto;
 			top: 43px;
 			right: 14px;
 		}
 
 		&::after {
+			left: auto;
 			top: 43px;
 			right: 14px;
 		}
 	}
 
-	.o-forms__radio:checked + .o-forms__label {
+	.o-forms-input--radio-round input[type=radio]:checked + .o-forms-input__label {
 		background-color: oColorsByName('teal');
 		color: oColorsByName('white');
 
@@ -33,12 +36,8 @@
 		}
 	}
 
-	#{$className}__item {
-		margin-bottom: 10px;
-
-		&--discount {
-			margin-top: 26px;
-		}
+	#{$className}__item--discount {
+		margin-top: 26px;
 	}
 
 	#{$className}__title {

--- a/test/partials/delivery-option.spec.js
+++ b/test/partials/delivery-option.spec.js
@@ -66,7 +66,6 @@ describe('delivery-option', () => {
 		const $ = context.template({ options: [{ value }]});
 		expect($('input').attr('id')).to.equal(value);
 		expect($('input').attr('value')).to.equal(value);
-		expect($('label').attr('for')).to.equal(value);
 	});
 
 	it('should select the correct radio button', () => {


### PR DESCRIPTION
### Description
I forgot to add the Delivery Option component into the `o-forms` migration PR (#353), so here is the component with the necessary mark-up and styling changes.

There's some stupidly long selectors to override some of the default `o-forms` styling. Not ideal, and with more time I would try to see if we can improve upon them.

I've also passed delivery options in as props to this component in the JSX demo, as there were none, and so the component does not get displayed in the demo.

### PLEASE NOTE
~~**The base branch has been set to `origami-upgrade-forms` to make it easier to see the changes. If PR #353 has already been merged in by the time this PR is reviewed, please change the base branch to `origami-major-cascade` before merging.**~~