### PR TITLE
Upgrade o-expander from v4 to v5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -44,7 +44,7 @@
     "o-colors": "^5.0.2",
     "o-icons": "^6.0.0",
     "o-stepped-progress": "^2.0.0",
-    "o-expander": "^4.7.0",
+    "o-expander": "^5.0.1",
     "o-loading": "^4.0.0",
     "o-grid": "^5.0.0",
     "o-typography": "^6.1.0"

--- a/components/__snapshots__/payment-type.spec.js.snap
+++ b/components/__snapshots__/payment-type.spec.js.snap
@@ -570,12 +570,12 @@ exports[`PaymentType render with enableDirectdebit 1`] = `
       <p>
         Your payments are protected by the Direct Debit
         <button type="button"
-                class="ncf__directdebit-guarantee-toggle"
+                class="ncf__directdebit-guarantee-toggle o-expander__toggle"
         >
           guarantee
         </button>
       </p>
-      <ul class="ncf__directdebit-guarantee-list">
+      <ul class="ncf__directdebit-guarantee-list o-expander__content">
         <li>
           This Guarantee is offered by all banks and building societies that accept instructions to pay Direct Debits.
         </li>
@@ -703,12 +703,12 @@ exports[`PaymentType render with enableDirectdebit 2`] = `
       <p>
         Your payments are protected by the Direct Debit
         <button type="button"
-                class="ncf__directdebit-guarantee-toggle"
+                class="ncf__directdebit-guarantee-toggle o-expander__toggle"
         >
           guarantee
         </button>
       </p>
-      <ul class="ncf__directdebit-guarantee-list">
+      <ul class="ncf__directdebit-guarantee-list o-expander__content">
         <li>
           This Guarantee is offered by all banks and building societies that accept instructions to pay Direct Debits.
         </li>

--- a/components/payment-type.jsx
+++ b/components/payment-type.jsx
@@ -67,8 +67,8 @@ export function PaymentType ({
 			<div className="ncf__payment-type-panel ncf__payment-type-panel--directdebit n-ui-hide">
 				<div id="directDebitGuarantee" className="ncf__directdebit-guarantee" data-o-component="o-expander" data-o-expander-shrink-to="hidden" data-o-expander-expanded-toggle-text="guarantee" data-o-expander-collapsed-toggle-text="guarantee" role="tabpanel">
 					<p>Direct Debit is only supported in the UK</p>
-					<p>Your payments are protected by the Direct Debit <button type="button" className="ncf__directdebit-guarantee-toggle">guarantee</button></p>
-					<ul className="ncf__directdebit-guarantee-list">
+					<p>Your payments are protected by the Direct Debit <button type="button" className="ncf__directdebit-guarantee-toggle o-expander__toggle">guarantee</button></p>
+					<ul className="ncf__directdebit-guarantee-list o-expander__content">
 						<li>This Guarantee is offered by all banks and building societies that accept instructions to pay Direct Debits.</li>
 						<li>If there are any changes to the amount, date or frequency of your Direct Debit GoCardless re: The Financial Times will notify you 3 working days in advance of your account being debited or as otherwise agreed. If you request GoCardless Ltd re: The Financial Times to collect a payment, confirmation of the amount and date will be given to you at the time of the request.</li>
 						<li>If an error is made in the payment of your Direct Debit, by GoCardless Ltd re: The Financial Times or your bank or building society, you are entitled to a full and immediate refund of the amount paid from your bank or building society.</li>

--- a/partials/payment-type.html
+++ b/partials/payment-type.html
@@ -48,8 +48,8 @@
 	<div class="ncf__payment-type-panel ncf__payment-type-panel--directdebit n-ui-hide">
 		<div id="directDebitGuarantee" class="ncf__directdebit-guarantee" data-o-component="o-expander" data-o-expander-shrink-to="hidden" data-o-expander-expanded-toggle-text="guarantee" data-o-expander-collapsed-toggle-text="guarantee" role="tabpanel">
 			<p>Direct Debit is only supported in the UK</p>
-			<p>Your payments are protected by the Direct Debit <button type="button" class="ncf__directdebit-guarantee-toggle">guarantee</button></p>
-			<ul class="ncf__directdebit-guarantee-list">
+			<p>Your payments are protected by the Direct Debit <button type="button" class="ncf__directdebit-guarantee-toggle o-expander__toggle">guarantee</button></p>
+			<ul class="ncf__directdebit-guarantee-list o-expander__content">
 				<li>This Guarantee is offered by all banks and building societies that accept instructions to pay Direct Debits.</li>
 				<li>If there are any changes to the amount, date or frequency of your Direct Debit GoCardless re: The Financial Times will notify you 3 working days in advance of your account being debited or as otherwise agreed. If you request GoCardless Ltd re: The Financial Times to collect a payment, confirmation of the amount and date will be given to you at the time of the request.</li>
 				<li>If an error is made in the payment of your Direct Debit, by GoCardless Ltd re: The Financial Times or your bank or building society, you are entitled to a full and immediate refund of the amount paid from your bank or building society.</li>

--- a/styles/payment-type.scss
+++ b/styles/payment-type.scss
@@ -1,5 +1,7 @@
 @import 'o-expander/main';
 
+@include oExpander();
+
 @mixin buttonImageOverriding() {
 	color: transparent;
 	background-repeat: no-repeat;
@@ -63,12 +65,10 @@
 		text-align: center;
 
 		&-list {
-			@include oExpanderContent;
 			text-align: left;
 		}
 
 		&-toggle {
-			@include oExpanderToggle;
 			color: oColorsByName('teal');
 		}
 	}

--- a/test/utils/payment-type.spec.js
+++ b/test/utils/payment-type.spec.js
@@ -6,7 +6,9 @@ const expanderInstance = 'expanderInstance';
 const initStub = sandbox.stub().returns(expanderInstance);
 const PaymentType = proxyquire('../../utils/payment-type', {
 	'o-expander': {
-		init: initStub
+		default: {
+			init: initStub
+		}
 	}
 });
 

--- a/utils/payment-type.js
+++ b/utils/payment-type.js
@@ -27,11 +27,8 @@ class PaymentType {
 		this.$directDebitGuarantee = this.$paymentType.querySelector('.ncf #directDebitGuarantee');
 		if (this.$directDebitGuarantee) {
 			// HACK require here so server side code use the static methods
-			const expander = require('o-expander');
-			this.expander = expander.init(this.$directDebitGuarantee, {
-				contentClassName: 'ncf__directdebit-guarantee-list',
-				toggleSelector: '.ncf__directdebit-guarantee-toggle'
-			});
+			const expander = require('o-expander').default;
+			this.expander = expander.init(this.$directDebitGuarantee);
 		}
 
 		// Set up change handler to show panel and initialise the current panel


### PR DESCRIPTION
### Description
Uses the main `oExpander` mixin and classnames for styling and client-side JavaScript, instead of adding `o-expander` content into our own classnames. Includes changes to client-side code for initialising the expander, as we no longer need to pass in the classnames for the content and trigger elements.