### PR TITLE
Origami upgrade: Remove n-ui-foundations

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -46,7 +46,8 @@
     "o-expander": "^5.0.1",
     "o-loading": "^4.0.0",
     "o-grid": "^5.0.0",
-    "o-typography": "^6.1.0"
+    "o-typography": "^6.1.0",
+    "o-normalise": "^2.0.1"
   },
   "resolutions": {
     "ftdomdelegate": "^3.0.0"

--- a/bower.json
+++ b/bower.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "o-forms": "^8.1.1",
-    "n-ui-foundations": "^3.0.1",
     "o-buttons": "^6.0.2",
     "o-message": "^4.0.0",
     "o-colors": "^5.0.2",

--- a/components/__snapshots__/billing-postcode.spec.js.snap
+++ b/components/__snapshots__/billing-postcode.spec.js.snap
@@ -216,7 +216,7 @@ exports[`Billing Postcode can render as an Error 2`] = `
 
 exports[`Billing Postcode can render as an hidden field 1`] = `
 <label id="billingPostcodeField"
-       class="o-forms-field n-ui-hide"
+       class="o-forms-field ncf__hidden"
        data-validate="required"
 >
   <span class="o-forms-title">
@@ -251,7 +251,7 @@ exports[`Billing Postcode can render as an hidden field 1`] = `
 
 exports[`Billing Postcode can render as an hidden field 2`] = `
 <label id="billingPostcodeField"
-       class="o-forms-field n-ui-hide"
+       class="o-forms-field ncf__hidden"
        data-validate="required"
 >
   <span class="o-forms-title">

--- a/components/__snapshots__/delivery-postcode.spec.js.snap
+++ b/components/__snapshots__/delivery-postcode.spec.js.snap
@@ -148,7 +148,7 @@ exports[`Delivery Postcode render a postcode input with a label 2`] = `
 
 exports[`Delivery Postcode render different styles 1`] = `
 <label id="deliveryPostcodeField"
-       class="o-forms-field n-ui-hide"
+       class="o-forms-field ncf__hidden"
        data-validate="required"
 >
   <span class="o-forms-title">
@@ -184,7 +184,7 @@ exports[`Delivery Postcode render different styles 1`] = `
 
 exports[`Delivery Postcode render different styles 2`] = `
 <label id="deliveryPostcodeField"
-       class="o-forms-field n-ui-hide"
+       class="o-forms-field ncf__hidden"
        data-validate="required"
 >
   <span class="o-forms-title">

--- a/components/__snapshots__/loader.spec.js.snap
+++ b/components/__snapshots__/loader.spec.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Loader renders with default props 1`] = `
-<div class="ncf__loader n-ui-hide"
+<div class="ncf__loader ncf__hidden"
      role="dialog"
      aria-labelledby="loader-aria-label"
      aria-describedby="loader-aria-description"
      aria-modal="true"
 >
   <div class="ncf__loader__content">
-    <div class="n-ui-hide"
+    <div class="ncf__hidden"
          id="loader-aria-label"
     >
       Loading
@@ -25,14 +25,14 @@ exports[`Loader renders with default props 1`] = `
 `;
 
 exports[`Loader renders with default props 2`] = `
-<div class="ncf__loader n-ui-hide"
+<div class="ncf__loader ncf__hidden"
      role="dialog"
      aria-labelledby="loader-aria-label"
      aria-describedby="loader-aria-description"
      aria-modal="true"
 >
   <div class="ncf__loader__content">
-    <div class="n-ui-hide"
+    <div class="ncf__hidden"
          id="loader-aria-label"
     >
       Loading
@@ -57,7 +57,7 @@ exports[`Loader renders with showLoader 1`] = `
      tabindex="1"
 >
   <div class="ncf__loader__content">
-    <div class="n-ui-hide"
+    <div class="ncf__hidden"
          id="loader-aria-label"
     >
       Loading
@@ -82,7 +82,7 @@ exports[`Loader renders with showLoader 2`] = `
      tabindex="1"
 >
   <div class="ncf__loader__content">
-    <div class="n-ui-hide"
+    <div class="ncf__hidden"
          id="loader-aria-label"
     >
       Loading
@@ -99,7 +99,7 @@ exports[`Loader renders with showLoader 2`] = `
 `;
 
 exports[`Loader renders with title 1`] = `
-<div class="ncf__loader n-ui-hide"
+<div class="ncf__loader ncf__hidden"
      role="dialog"
      aria-labelledby="loader-aria-label"
      aria-describedby="loader-aria-description"
@@ -123,7 +123,7 @@ exports[`Loader renders with title 1`] = `
 `;
 
 exports[`Loader renders with title 2`] = `
-<div class="ncf__loader n-ui-hide"
+<div class="ncf__loader ncf__hidden"
      role="dialog"
      aria-labelledby="loader-aria-label"
      aria-describedby="loader-aria-description"

--- a/components/__snapshots__/payment-type.spec.js.snap
+++ b/components/__snapshots__/payment-type.spec.js.snap
@@ -367,8 +367,8 @@ exports[`PaymentType render with enableCreditcard 1`] = `
   <div class="o-forms-input__error">
     Please enter a valid payment type
   </div>
-  <div class="ncf__payment-type-panel ncf__payment-type-panel--creditcard ncf__payment-type-panel--directdebit n-ui-hide">
-    <div class="ncf__zuora-payment-overlay n-ui-hide">
+  <div class="ncf__payment-type-panel ncf__payment-type-panel--creditcard ncf__payment-type-panel--directdebit ncf__hidden">
+    <div class="ncf__zuora-payment-overlay ncf__hidden">
     </div>
     <div id="zuora_payment"
          class="ncf__zuora-payment"
@@ -461,8 +461,8 @@ exports[`PaymentType render with enableCreditcard 2`] = `
   <div class="o-forms-input__error">
     Please enter a valid payment type
   </div>
-  <div class="ncf__payment-type-panel ncf__payment-type-panel--creditcard ncf__payment-type-panel--directdebit n-ui-hide">
-    <div class="ncf__zuora-payment-overlay n-ui-hide">
+  <div class="ncf__payment-type-panel ncf__payment-type-panel--creditcard ncf__payment-type-panel--directdebit ncf__hidden">
+    <div class="ncf__zuora-payment-overlay ncf__hidden">
     </div>
     <div id="zuora_payment"
          class="ncf__zuora-payment"
@@ -555,7 +555,7 @@ exports[`PaymentType render with enableDirectdebit 1`] = `
   <div class="o-forms-input__error">
     Please enter a valid payment type
   </div>
-  <div class="ncf__payment-type-panel ncf__payment-type-panel--directdebit n-ui-hide">
+  <div class="ncf__payment-type-panel ncf__payment-type-panel--directdebit ncf__hidden">
     <div id="directDebitGuarantee"
          class="ncf__directdebit-guarantee"
          data-o-component="o-expander"
@@ -594,8 +594,8 @@ exports[`PaymentType render with enableDirectdebit 1`] = `
       </ul>
     </div>
   </div>
-  <div class="ncf__payment-type-panel ncf__payment-type-panel--creditcard ncf__payment-type-panel--directdebit n-ui-hide">
-    <div class="ncf__zuora-payment-overlay n-ui-hide">
+  <div class="ncf__payment-type-panel ncf__payment-type-panel--creditcard ncf__payment-type-panel--directdebit ncf__hidden">
+    <div class="ncf__zuora-payment-overlay ncf__hidden">
     </div>
     <div id="zuora_payment"
          class="ncf__zuora-payment"
@@ -688,7 +688,7 @@ exports[`PaymentType render with enableDirectdebit 2`] = `
   <div class="o-forms-input__error">
     Please enter a valid payment type
   </div>
-  <div class="ncf__payment-type-panel ncf__payment-type-panel--directdebit n-ui-hide">
+  <div class="ncf__payment-type-panel ncf__payment-type-panel--directdebit ncf__hidden">
     <div id="directDebitGuarantee"
          class="ncf__directdebit-guarantee"
          data-o-component="o-expander"
@@ -727,8 +727,8 @@ exports[`PaymentType render with enableDirectdebit 2`] = `
       </ul>
     </div>
   </div>
-  <div class="ncf__payment-type-panel ncf__payment-type-panel--creditcard ncf__payment-type-panel--directdebit n-ui-hide">
-    <div class="ncf__zuora-payment-overlay n-ui-hide">
+  <div class="ncf__payment-type-panel ncf__payment-type-panel--creditcard ncf__payment-type-panel--directdebit ncf__hidden">
+    <div class="ncf__zuora-payment-overlay ncf__hidden">
     </div>
     <div id="zuora_payment"
          class="ncf__zuora-payment"

--- a/components/__snapshots__/province.spec.js.snap
+++ b/components/__snapshots__/province.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Province can apply class to hide the component 1`] = `
 <label id="provinceField"
-       class="o-forms-field n-ui-hide"
+       class="o-forms-field ncf__hidden"
        data-validate="required"
 >
   <span class="o-forms-title">
@@ -71,7 +71,7 @@ exports[`Province can apply class to hide the component 1`] = `
 
 exports[`Province can apply class to hide the component 2`] = `
 <label id="provinceField"
-       class="o-forms-field n-ui-hide"
+       class="o-forms-field ncf__hidden"
        data-validate="required"
 >
   <span class="o-forms-title">

--- a/components/__snapshots__/state.spec.js.snap
+++ b/components/__snapshots__/state.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`State can apply class to hide the component 1`] = `
 <label id="stateField"
-       class="o-forms-field n-ui-hide"
+       class="o-forms-field ncf__hidden"
        data-validate="required"
 >
   <span class="o-forms-title">
@@ -185,7 +185,7 @@ exports[`State can apply class to hide the component 1`] = `
 
 exports[`State can apply class to hide the component 2`] = `
 <label id="stateField"
-       class="o-forms-field n-ui-hide"
+       class="o-forms-field ncf__hidden"
        data-validate="required"
 >
   <span class="o-forms-title">

--- a/components/billing-postcode.jsx
+++ b/components/billing-postcode.jsx
@@ -16,7 +16,7 @@ export function BillingPostcode ({
 
 	const BillingPostcodeFieldClassNames = classNames([
 		'o-forms-field',
-		{ 'n-ui-hide': isHidden }
+		{ 'ncf__hidden': isHidden }
 	]);
 
 	const inputWrapperClassNames = classNames([

--- a/components/delivery-postcode.jsx
+++ b/components/delivery-postcode.jsx
@@ -18,7 +18,7 @@ export function DeliveryPostcode ({
 
 	let deliveryPostcodeFieldClassNames = classNames([
 		'o-forms-field',
-		{ 'n-ui-hide': isHidden }
+		{ 'ncf__hidden': isHidden }
 	]);
 
 	return (

--- a/components/loader.jsx
+++ b/components/loader.jsx
@@ -10,12 +10,12 @@ export function Loader ({
 	const label = title ? (
 		<div className="ncf__loader__content__title" id="loader-aria-label">{title}</div>
 	) : (
-		<div className="n-ui-hide" id="loader-aria-label">Loading</div>
+		<div className="ncf__hidden" id="loader-aria-label">Loading</div>
 	);
 	const className = classNames([
 		'ncf__loader',
 		{ 'is-visible': showLoader },
-		{ 'n-ui-hide': !showLoader }
+		{ 'ncf__hidden': !showLoader }
 	]);
 	const props = {
 		className,

--- a/components/message.jsx
+++ b/components/message.jsx
@@ -21,7 +21,7 @@ export function Message ({ title, message, additional = [], actions = null, name
 
 	const ncfClassNames = classNames(
 		'ncf__message',
-		{ 'n-ui-hide': isHidden }
+		{ 'ncf__hidden': isHidden }
 	);
 
 	const callToActionsList = actions ? (

--- a/components/payment-type.jsx
+++ b/components/payment-type.jsx
@@ -64,7 +64,7 @@ export function PaymentType ({
 
 	const createDirectDebitPanel = () => {
 		return enableDirectdebit && (
-			<div className="ncf__payment-type-panel ncf__payment-type-panel--directdebit n-ui-hide">
+			<div className="ncf__payment-type-panel ncf__payment-type-panel--directdebit ncf__hidden">
 				<div id="directDebitGuarantee" className="ncf__directdebit-guarantee" data-o-component="o-expander" data-o-expander-shrink-to="hidden" data-o-expander-expanded-toggle-text="guarantee" data-o-expander-collapsed-toggle-text="guarantee" role="tabpanel">
 					<p>Direct Debit is only supported in the UK</p>
 					<p>Your payments are protected by the Direct Debit <button type="button" className="ncf__directdebit-guarantee-toggle o-expander__toggle">guarantee</button></p>
@@ -82,8 +82,8 @@ export function PaymentType ({
 
 	const createZuoraPanel = () => {
 		return (enableDirectdebit || enableCreditcard) && (
-			<div className="ncf__payment-type-panel ncf__payment-type-panel--creditcard ncf__payment-type-panel--directdebit n-ui-hide">
-				<div className="ncf__zuora-payment-overlay n-ui-hide"></div>
+			<div className="ncf__payment-type-panel ncf__payment-type-panel--creditcard ncf__payment-type-panel--directdebit ncf__hidden">
+				<div className="ncf__zuora-payment-overlay ncf__hidden"></div>
 				<div id="zuora_payment" className="ncf__zuora-payment">
 					<iframe id="z_hppm_iframe" title="Zuora Payment" overflow="visible" scrolling="no" frameBorder="0" allowtransparency="true"
 						className="z_hppm_iframe" style={{display: 'block'}}>

--- a/components/province.jsx
+++ b/components/province.jsx
@@ -17,7 +17,7 @@ export function Province ({
 }) {
 	const fieldClassNames = classNames([
 		'o-forms-field',
-		{ 'n-ui-hide': isHidden }
+		{ 'ncf__hidden': isHidden }
 	]);
 
 	const inputWrapperClassNames = classNames([

--- a/components/state.jsx
+++ b/components/state.jsx
@@ -16,7 +16,7 @@ export function State ({
 }) {
 	const fieldClassNames = classNames([
 		'o-forms-field',
-		{ 'n-ui-hide': isHidden }
+		{ 'ncf__hidden': isHidden }
 	]);
 
 	const inputWrapperClassNames = classNames([

--- a/demos/main.scss
+++ b/demos/main.scss
@@ -10,8 +10,6 @@ body {
 	margin: 0;
 }
 
-.n-ui-hide { display: none; }
-
 .demo {
 	&__iframe {
 		width: 100%;

--- a/partials/billing-postcode.html
+++ b/partials/billing-postcode.html
@@ -1,5 +1,5 @@
 <label id="billingPostcodeField"
-	class="o-forms-field{{#if isHidden}} n-ui-hide{{/if}}"
+	class="o-forms-field{{#if isHidden}} ncf__hidden{{/if}}"
 	data-validate="required">
 
 	<span class="o-forms-title">

--- a/partials/delivery-postcode.html
+++ b/partials/delivery-postcode.html
@@ -1,5 +1,5 @@
 <label id="deliveryPostcodeField"
-	class="o-forms-field{{#if isHidden}} n-ui-hide{{/if}}"
+	class="o-forms-field{{#if isHidden}} ncf__hidden{{/if}}"
 	data-validate="required">
 
 	<span class="o-forms-title">

--- a/partials/loader.html
+++ b/partials/loader.html
@@ -1,4 +1,4 @@
-<div class="ncf__loader {{#if showLoader}}is-visible{{else}}n-ui-hide{{/if}}"
+<div class="ncf__loader {{#if showLoader}}is-visible{{else}}ncf__hidden{{/if}}"
 	role="dialog" aria-labelledby="loader-aria-label" aria-describedby="loader-aria-description"
 	aria-modal="true" {{#if showLoader}}tabindex="1"{{/if}}>
 	<div class="ncf__loader__content">
@@ -7,7 +7,7 @@
 				{{title}}
 			</div>
 		{{else}}
-			<div class="n-ui-hide" id="loader-aria-label">Loading</div>
+			<div class="ncf__hidden" id="loader-aria-label">Loading</div>
 		{{/if}}
 		<div class="ncf__loader__content__main" id="loader-aria-description">
 			{{#if @partial-block}}

--- a/partials/message.html
+++ b/partials/message.html
@@ -1,4 +1,4 @@
-<div class="ncf__message{{#if isHidden}} n-ui-hide{{/if}}"{{#if name}} data-message-name="{{name}}"{{/if}}>
+<div class="ncf__message{{#if isHidden}} ncf__hidden{{/if}}"{{#if name}} data-message-name="{{name}}"{{/if}}>
 	<div class="o-message o-message--inner {{#if isNotice}}o-message--notice{{else}}o-message--alert{{/if}}{{#if isError}} o-message--error{{else if isSuccess}} o-message--success{{else if isInform}} o-message--inform{{else}} o-message--neutral{{/if}}" data-o-component="o-message">
 		<div class="o-message__container">
 			<div class="o-message__content">

--- a/partials/payment-type.html
+++ b/partials/payment-type.html
@@ -45,7 +45,7 @@
 	<div class="o-forms-input__error">Please enter a valid payment type</div>
 
 	{{#if enableDirectdebit}}
-	<div class="ncf__payment-type-panel ncf__payment-type-panel--directdebit n-ui-hide">
+	<div class="ncf__payment-type-panel ncf__payment-type-panel--directdebit ncf__hidden">
 		<div id="directDebitGuarantee" class="ncf__directdebit-guarantee" data-o-component="o-expander" data-o-expander-shrink-to="hidden" data-o-expander-expanded-toggle-text="guarantee" data-o-expander-collapsed-toggle-text="guarantee" role="tabpanel">
 			<p>Direct Debit is only supported in the UK</p>
 			<p>Your payments are protected by the Direct Debit <button type="button" class="ncf__directdebit-guarantee-toggle o-expander__toggle">guarantee</button></p>
@@ -60,8 +60,8 @@
 	</div>
 	{{/if}}
 	{{#ifSome enableCreditcard enableDirectdebit }}
-	<div class="ncf__payment-type-panel ncf__payment-type-panel--creditcard ncf__payment-type-panel--directdebit n-ui-hide">
-		<div class="ncf__zuora-payment-overlay n-ui-hide"></div>
+	<div class="ncf__payment-type-panel ncf__payment-type-panel--creditcard ncf__payment-type-panel--directdebit ncf__hidden">
+		<div class="ncf__zuora-payment-overlay ncf__hidden"></div>
 		<!-- The Zuora payment interface used for credit card and direct debit -->
 		<!-- ID "zuora_payment" is used by Zuora to target the iframe -->
 		<div id="zuora_payment" class="ncf__zuora-payment">

--- a/partials/province.html
+++ b/partials/province.html
@@ -1,4 +1,4 @@
-<label id="provinceField" class="o-forms-field{{#if isHidden}} n-ui-hide{{/if}}" data-validate="required">
+<label id="provinceField" class="o-forms-field{{#if isHidden}} ncf__hidden{{/if}}" data-validate="required">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">{{#if isBillingProvince}}Billing {{/if}}Province</span>
 	</span>

--- a/partials/state.html
+++ b/partials/state.html
@@ -1,4 +1,4 @@
-<label id="stateField" class="o-forms-field{{#if isHidden}} n-ui-hide{{/if}}" data-validate="required">
+<label id="stateField" class="o-forms-field{{#if isHidden}} ncf__hidden{{/if}}" data-validate="required">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">{{#if isBillingState}}Billing {{/if}}State</span>
 	</span>

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -152,13 +152,13 @@ const shouldBeHiddable = function (context, selector, options) {
 	it('should be displayed by default', () => {
 		const $ = context.template(Object.assign({}, options));
 
-		expect($(selector).attr('class')).to.not.contain('n-ui-hide');
+		expect($(selector).attr('class')).to.not.contain('ncf__hidden');
 	});
 
 	it('should be hidden if isHidden is passed', () => {
 		const $ = context.template(Object.assign({ isHidden: true }, options));
 
-		expect($(selector).attr('class')).to.contain('n-ui-hide');
+		expect($(selector).attr('class')).to.contain('ncf__hidden');
 	});
 };
 

--- a/test/partials/loader.spec.js
+++ b/test/partials/loader.spec.js
@@ -41,14 +41,14 @@ describe('loader template', () => {
 		const $ = context.template({ showLoader: true });
 
 		expect($('.ncf__loader.is-visible').length).to.equal(1);
-		expect($('.ncf__loader.n-ui-hide').length).to.equal(0);
+		expect($('.ncf__loader.ncf__hidden').length).to.equal(0);
 	});
 
 	it('should hide loader when showLoader is not set', () => {
 		const $ = context.template();
 
 		expect($('.ncf__loader.is-visible').length).to.equal(0);
-		expect($('.ncf__loader.n-ui-hide').length).to.equal(1);
+		expect($('.ncf__loader.ncf__hidden').length).to.equal(1);
 	});
 
 	describe('a11y', () => {

--- a/test/partials/message.spec.js
+++ b/test/partials/message.spec.js
@@ -16,7 +16,7 @@ const SELECTOR_MESSAGE_CONTENT = '.o-message__content-detail';
 const SELECTOR_CONTAINER = '.o-message';
 const SELECTOR_MESSAGE_CONTAINER = '.ncf__message';
 const SELECTOR_TITLE = '.o-message__content-highlight';
-const HIDDEN_CLASS = 'n-ui-hide';
+const HIDDEN_CLASS = 'ncf__hidden';
 
 let context = {};
 

--- a/test/utils/form-element.spec.js
+++ b/test/utils/form-element.spec.js
@@ -52,18 +52,18 @@ describe('FormElement', () => {
 	});
 
 	describe('hide', () => {
-		it('should add the n-ui-hide class', () => {
+		it('should add the ncf__hidden class', () => {
 			formElement.hide();
 
-			expect(addStub.getCall(0).args[0]).to.equal('n-ui-hide');
+			expect(addStub.getCall(0).args[0]).to.equal('ncf__hidden');
 		});
 	});
 
 	describe('show', () => {
-		it('should remove the n-ui-hide class', () => {
+		it('should remove the ncf__hidden class', () => {
 			formElement.show();
 
-			expect(removeStub.getCall(0).args[0]).to.equal('n-ui-hide');
+			expect(removeStub.getCall(0).args[0]).to.equal('ncf__hidden');
 		});
 	});
 

--- a/utils/form-element.js
+++ b/utils/form-element.js
@@ -31,7 +31,7 @@ class FormElement {
 	 * Hides the form element.
 	 */
 	hide () {
-		this.$el.classList.add('n-ui-hide');
+		this.$el.classList.add('ncf__hidden');
 	}
 
 
@@ -39,7 +39,7 @@ class FormElement {
 	 * Shows the form element.
 	 */
 	show () {
-		this.$el.classList.remove('n-ui-hide');
+		this.$el.classList.remove('ncf__hidden');
 	}
 
 	/**

--- a/utils/loader.js
+++ b/utils/loader.js
@@ -18,7 +18,7 @@ class Loader {
 		}
 
 		this.VISIBLE_CLASS = 'is-visible';
-		this.HIDDEN_CLASS = 'n-ui-hide';
+		this.HIDDEN_CLASS = 'ncf__hidden';
 
 		this.element = element;
 		this.$loader = element.querySelector('.ncf__loader');

--- a/utils/payment-type.js
+++ b/utils/payment-type.js
@@ -103,9 +103,9 @@ class PaymentType {
 		for (let i = 0; i < content.length; i++) {
 			const element = content[i];
 			if (element.classList.contains(`ncf__payment-type-panel--${type}`)) {
-				element.classList.remove('n-ui-hide');
+				element.classList.remove('ncf__hidden');
 			} else {
-				element.classList.add('n-ui-hide');
+				element.classList.add('ncf__hidden');
 			}
 		}
 	}


### PR DESCRIPTION
### Description
This removes `n-ui-foundations` as a dependency.

Chose to do this because:
- There was only one package from it that we were using, which was `o-normalise`. Felt it would be simpler to add that package as a dependency ourselves.
- There was the only one utility class from n-ui-foundations we were using, which was `n-ui-hide`. However, because we were not using any mixins from `n-ui-foundations`, we would have needed the apps that use `n-conversion-forms` to apply those mixins for this class to be available. Instead we are now using our own class for hiding, `ncf__hidden`, which had already been defined.