### PR TITLE
fix: handle when a delivery option value is not recognised.

### DIFF
--- a/components/__snapshots__/delivery-option.spec.js.snap
+++ b/components/__snapshots__/delivery-option.spec.js.snap
@@ -282,16 +282,6 @@ exports[`DeliveryOption renders without unrecognised delivery options 1`] = `
     </label>
     <label class="ncf__delivery-option__item">
       <input type="radio"
-             id="FOOBAR"
-             name="deliveryOption"
-             value="FOOBAR"
-             class="ncf__delivery-option__input"
-      >
-      <span class="o-forms-input__label ncf__delivery-option__label">
-      </span>
-    </label>
-    <label class="ncf__delivery-option__item">
-      <input type="radio"
              id="EV"
              name="deliveryOption"
              value="EV"
@@ -348,16 +338,6 @@ exports[`DeliveryOption renders without unrecognised delivery options 2`] = `
         <div class="ncf__delivery-option__description">
           Free delivery to your home or office before 7am.
         </div>
-      </span>
-    </label>
-    <label class="ncf__delivery-option__item">
-      <input type="radio"
-             id="FOOBAR"
-             name="deliveryOption"
-             value="FOOBAR"
-             class="ncf__delivery-option__input"
-      >
-      <span class="o-forms-input__label ncf__delivery-option__label">
       </span>
     </label>
     <label class="ncf__delivery-option__item">

--- a/components/delivery-option.jsx
+++ b/components/delivery-option.jsx
@@ -38,7 +38,7 @@ export function DeliveryOption ({
 				{
 					options
 						.filter(({value}) => Object.keys(deliveryOptions).includes(value))
-						.map(({value, isSelected}, index) => {
+						.map(({value, isSelected}) => {
 							const inputProps = {
 								type: 'radio',
 								id: value,
@@ -51,7 +51,7 @@ export function DeliveryOption ({
 							const deliveryOptionValue = deliveryOptions[value];
 
 							return (
-								<label key={index} className="ncf__delivery-option__item">
+								<label key={value} className="ncf__delivery-option__item">
 									<input {...inputProps} />
 									<span className="o-forms-input__label ncf__delivery-option__label">
 										<span className="ncf__delivery-option__title">{deliveryOptionValue.title}</span>

--- a/components/delivery-option.jsx
+++ b/components/delivery-option.jsx
@@ -36,30 +36,32 @@ export function DeliveryOption ({
 		>
 			<span className="o-forms-input o-forms-input--radio-round">
 				{
-					options
-						.filter(({value}) => Object.keys(deliveryOptions).includes(value))
-						.map(({value, isSelected}) => {
-							const inputProps = {
-								type: 'radio',
-								id: value,
-								name: 'deliveryOption',
-								value: value,
-								className: 'ncf__delivery-option__input',
-								defaultChecked: isSelected
-							};
+					options.map(({value, isSelected}) => {
+						if (!Object.keys(deliveryOptions).includes(value)) {
+							return null;
+						}
 
-							const deliveryOptionValue = deliveryOptions[value];
+						const inputProps = {
+							type: 'radio',
+							id: value,
+							name: 'deliveryOption',
+							value: value,
+							className: 'ncf__delivery-option__input',
+							defaultChecked: isSelected
+						};
 
-							return (
-								<label key={value} className="ncf__delivery-option__item">
-									<input {...inputProps} />
-									<span className="o-forms-input__label ncf__delivery-option__label">
-										<span className="ncf__delivery-option__title">{deliveryOptionValue.title}</span>
-										<div className="ncf__delivery-option__description">{deliveryOptionValue.description}</div>
-									</span>
-								</label>
-							);
-						})
+						const deliveryOptionValue = deliveryOptions[value];
+
+						return (
+							<label key={value} className="ncf__delivery-option__item">
+								<input {...inputProps} />
+								<span className="o-forms-input__label ncf__delivery-option__label">
+									<span className="ncf__delivery-option__title">{deliveryOptionValue.title}</span>
+									<div className="ncf__delivery-option__description">{deliveryOptionValue.description}</div>
+								</span>
+							</label>
+						);
+					})
 				}
 			</span>
 		</div>

--- a/components/delivery-option.jsx
+++ b/components/delivery-option.jsx
@@ -36,28 +36,30 @@ export function DeliveryOption ({
 		>
 			<span className="o-forms-input o-forms-input--radio-round">
 				{
-					options.map(({value, isSelected}, index) => {
-						const inputProps = {
-							type: 'radio',
-							id: value,
-							name: 'deliveryOption',
-							value: value,
-							className: 'ncf__delivery-option__input',
-							defaultChecked: isSelected
-						};
+					options
+						.filter(({value}) => Object.keys(deliveryOptions).includes(value))
+						.map(({value, isSelected}, index) => {
+							const inputProps = {
+								type: 'radio',
+								id: value,
+								name: 'deliveryOption',
+								value: value,
+								className: 'ncf__delivery-option__input',
+								defaultChecked: isSelected
+							};
 
-						const deliveryOptionValue = deliveryOptions[value];
+							const deliveryOptionValue = deliveryOptions[value];
 
-						return (
-							<label key={index} className="ncf__delivery-option__item">
-								<input {...inputProps} />
-								<span className="o-forms-input__label ncf__delivery-option__label">
-									<span className="ncf__delivery-option__title">{deliveryOptionValue.title}</span>
-									<div className="ncf__delivery-option__description">{deliveryOptionValue.description}</div>
-								</span>
-							</label>
-						);
-					})
+							return (
+								<label key={index} className="ncf__delivery-option__item">
+									<input {...inputProps} />
+									<span className="o-forms-input__label ncf__delivery-option__label">
+										<span className="ncf__delivery-option__title">{deliveryOptionValue.title}</span>
+										<div className="ncf__delivery-option__description">{deliveryOptionValue.description}</div>
+									</span>
+								</label>
+							);
+						})
 				}
 			</span>
 		</div>

--- a/partials/delivery-option.html
+++ b/partials/delivery-option.html
@@ -1,31 +1,33 @@
 <div id="deliveryOptionField" class="o-forms-field ncf__delivery-option{{#if isSingle}} ncf__delivery-option--single{{/if}}" role="group" aria-label="Delivery options">
 	<span class="o-forms-input o-forms-input--radio-round">
 		{{#each options}}
-		<label class="ncf__delivery-option__item">
-			<input type="radio" id="{{this.value}}" name="deliveryOption" value="{{this.value}}" class="ncf__delivery-option__input"{{#if this.isSelected}} checked{{/if}}>
-			<span class="o-forms-input__label ncf__delivery-option__label">
-				{{#ifEquals this.value 'PV'}}
-				<span class="ncf__delivery-option__title">Paper vouchers</span>
-				<div class="ncf__delivery-option__description">
-					13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
-				</div>
-				{{/ifEquals}}
+			{{#ifEqualsSome this.value 'PV' 'HD' 'EV'}}
+			<label class="ncf__delivery-option__item">
+				<input type="radio" id="{{this.value}}" name="deliveryOption" value="{{this.value}}" class="ncf__delivery-option__input"{{#if this.isSelected}} checked{{/if}}>
+				<span class="o-forms-input__label ncf__delivery-option__label">
+					{{#ifEquals this.value 'PV'}}
+					<span class="ncf__delivery-option__title">Paper vouchers</span>
+					<div class="ncf__delivery-option__description">
+						13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
+					</div>
+					{{/ifEquals}}
 
-				{{#ifEquals this.value 'HD'}}
-				<span class="ncf__delivery-option__title">Home delivery</span>
-				<div class="ncf__delivery-option__description">
-					Free delivery to your home or office before 7am.
-				</div>
-				{{/ifEquals}}
+					{{#ifEquals this.value 'HD'}}
+					<span class="ncf__delivery-option__title">Home delivery</span>
+					<div class="ncf__delivery-option__description">
+						Free delivery to your home or office before 7am.
+					</div>
+					{{/ifEquals}}
 
-				{{#ifEquals this.value 'EV'}}
-				<span class="ncf__delivery-option__title">Electronic vouchers</span>
-				<div class="ncf__delivery-option__description">
-					Delivered via email and card, redeemable at retailers nationwide.
-				</div>
-				{{/ifEquals}}
-			</span>
-		</label>
+					{{#ifEquals this.value 'EV'}}
+					<span class="ncf__delivery-option__title">Electronic vouchers</span>
+					<div class="ncf__delivery-option__description">
+						Delivered via email and card, redeemable at retailers nationwide.
+					</div>
+					{{/ifEquals}}
+				</span>
+			</label>
+			{{/ifEqualsSome}}
 		{{/each}}
 	</span>
 </div>

--- a/test/partials/delivery-option.spec.js
+++ b/test/partials/delivery-option.spec.js
@@ -17,12 +17,16 @@ describe('delivery-option', () => {
 	});
 
 	it('should draw a single option', () => {
-		const $ = context.template({ options: [{}]});
+		const $ = context.template({ options: [{ value: 'HD' }]});
 		expect($('input').length).to.equal(1);
 	});
 
 	it('should draw multiple options', () => {
-		const $ = context.template({ options: [{}, {}, {}]});
+		const $ = context.template({ options: [
+			{ value: 'HD' },
+			{ value: 'PV' },
+			{ value: 'EV' }
+		]});
 		expect($('input').length).to.equal(3);
 	});
 


### PR DESCRIPTION
### Description
Our tests were failing around this, so I've made a change so that we don't get type errors in the JSX component when we receive a delivery option with a value we're not expecting.

This also required a small change to the handlebars partial to display the same output as the JSX component. I'm using the `ifEqualsSome` helper from `n-handlebars` for this. However, that helper is deprecated so you will see warnings. I'm not too concerned about this, because we should be switching over to JSX soon anyway.