### PR TITLE
fix: use the correct font size for headers

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -129,7 +129,7 @@ $system-code: 'n-conversion-forms';
 	}
 
 	&__header {
-		@include oTypographyHeading($level: 5);
+		@include oTypographyHeading($level: 3);
 
 		&--confirmation {
 			@include oTypographySerif($scale: 3);


### PR DESCRIPTION
### Description
We picked the wrong heading level when migrating `o-typography`. This fixes that so that the correct size is used.