### PR TITLE
Postcode checker adjustments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,6 @@ a11y-demo:
 
 smoke:
 	n-test smoke --host http://localhost:5005
+
+test-update-snapshots:
+	NODE_ENV=test jest --updateSnapshot

--- a/components/__snapshots__/delivery-postcode.spec.js.snap
+++ b/components/__snapshots__/delivery-postcode.spec.js.snap
@@ -146,6 +146,78 @@ exports[`Delivery Postcode render a postcode input with a label set as Zip Code 
 </label>
 `;
 
+exports[`Delivery Postcode render a postcode input with a label set as Zip Code with USA in lower case 1`] = `
+<label id="deliveryPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery
+      <span data-reference="postcode">
+        Zip Code
+      </span>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryPostcode"
+           name="deliveryPostcode"
+           placeholder="Enter your Zip Code"
+           autocomplete="postal-code"
+           data-trackable="delivery-postcode"
+           aria-required="true"
+           required
+           pattern="whatever"
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid
+      <span data-reference="postcode">
+        Zip Code
+      </span>
+      .
+    </span>
+  </span>
+</label>
+`;
+
+exports[`Delivery Postcode render a postcode input with a label set as Zip Code with USA in lower case 2`] = `
+<label id="deliveryPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery
+      <span data-reference="postcode">
+        Zip Code
+      </span>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryPostcode"
+           name="deliveryPostcode"
+           placeholder="Enter your Zip Code"
+           autocomplete="postal-code"
+           data-trackable="delivery-postcode"
+           aria-required="true"
+           required
+           pattern="whatever"
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid
+      <span data-reference="postcode">
+        Zip Code
+      </span>
+      .
+    </span>
+  </span>
+</label>
+`;
+
 exports[`Delivery Postcode render a postcode input with a label set as postal code 1`] = `
 <label id="deliveryPostcodeField"
        class="o-forms-field"

--- a/components/__snapshots__/delivery-postcode.spec.js.snap
+++ b/components/__snapshots__/delivery-postcode.spec.js.snap
@@ -9,7 +9,7 @@ exports[`Delivery Postcode render a disable input 1`] = `
     <span class="o-forms-title__main">
       Delivery
       <span data-reference="postcode">
-        ZipCode
+        postcode
       </span>
     </span>
   </span>
@@ -17,7 +17,7 @@ exports[`Delivery Postcode render a disable input 1`] = `
     <input type="text"
            id="deliveryPostcode"
            name="deliveryPostcode"
-           placeholder="Enter your ZipCode"
+           placeholder="Enter your postcode"
            autocomplete="postal-code"
            data-trackable="delivery-postcode"
            aria-required="true"
@@ -29,7 +29,7 @@ exports[`Delivery Postcode render a disable input 1`] = `
     <span class="o-forms-input__error">
       Please enter a valid
       <span data-reference="postcode">
-        ZipCode
+        postcode
       </span>
       .
     </span>
@@ -46,7 +46,7 @@ exports[`Delivery Postcode render a disable input 2`] = `
     <span class="o-forms-title__main">
       Delivery
       <span data-reference="postcode">
-        ZipCode
+        postcode
       </span>
     </span>
   </span>
@@ -54,7 +54,7 @@ exports[`Delivery Postcode render a disable input 2`] = `
     <input type="text"
            id="deliveryPostcode"
            name="deliveryPostcode"
-           placeholder="Enter your ZipCode"
+           placeholder="Enter your postcode"
            autocomplete="postal-code"
            data-trackable="delivery-postcode"
            aria-required="true"
@@ -66,7 +66,7 @@ exports[`Delivery Postcode render a disable input 2`] = `
     <span class="o-forms-input__error">
       Please enter a valid
       <span data-reference="postcode">
-        ZipCode
+        postcode
       </span>
       .
     </span>
@@ -74,7 +74,7 @@ exports[`Delivery Postcode render a disable input 2`] = `
 </label>
 `;
 
-exports[`Delivery Postcode render a postcode input with a label 1`] = `
+exports[`Delivery Postcode render a postcode input with a label set as Zip Code 1`] = `
 <label id="deliveryPostcodeField"
        class="o-forms-field"
        data-validate="required"
@@ -83,7 +83,7 @@ exports[`Delivery Postcode render a postcode input with a label 1`] = `
     <span class="o-forms-title__main">
       Delivery
       <span data-reference="postcode">
-        ZipCode
+        Zip Code
       </span>
     </span>
   </span>
@@ -91,7 +91,7 @@ exports[`Delivery Postcode render a postcode input with a label 1`] = `
     <input type="text"
            id="deliveryPostcode"
            name="deliveryPostcode"
-           placeholder="Enter your ZipCode"
+           placeholder="Enter your Zip Code"
            autocomplete="postal-code"
            data-trackable="delivery-postcode"
            aria-required="true"
@@ -102,7 +102,7 @@ exports[`Delivery Postcode render a postcode input with a label 1`] = `
     <span class="o-forms-input__error">
       Please enter a valid
       <span data-reference="postcode">
-        ZipCode
+        Zip Code
       </span>
       .
     </span>
@@ -110,7 +110,7 @@ exports[`Delivery Postcode render a postcode input with a label 1`] = `
 </label>
 `;
 
-exports[`Delivery Postcode render a postcode input with a label 2`] = `
+exports[`Delivery Postcode render a postcode input with a label set as Zip Code 2`] = `
 <label id="deliveryPostcodeField"
        class="o-forms-field"
        data-validate="required"
@@ -119,7 +119,7 @@ exports[`Delivery Postcode render a postcode input with a label 2`] = `
     <span class="o-forms-title__main">
       Delivery
       <span data-reference="postcode">
-        ZipCode
+        Zip Code
       </span>
     </span>
   </span>
@@ -127,7 +127,7 @@ exports[`Delivery Postcode render a postcode input with a label 2`] = `
     <input type="text"
            id="deliveryPostcode"
            name="deliveryPostcode"
-           placeholder="Enter your ZipCode"
+           placeholder="Enter your Zip Code"
            autocomplete="postal-code"
            data-trackable="delivery-postcode"
            aria-required="true"
@@ -138,7 +138,223 @@ exports[`Delivery Postcode render a postcode input with a label 2`] = `
     <span class="o-forms-input__error">
       Please enter a valid
       <span data-reference="postcode">
-        ZipCode
+        Zip Code
+      </span>
+      .
+    </span>
+  </span>
+</label>
+`;
+
+exports[`Delivery Postcode render a postcode input with a label set as postal code 1`] = `
+<label id="deliveryPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery
+      <span data-reference="postcode">
+        postal code
+      </span>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryPostcode"
+           name="deliveryPostcode"
+           placeholder="Enter your postal code"
+           autocomplete="postal-code"
+           data-trackable="delivery-postcode"
+           aria-required="true"
+           required
+           pattern="whatever"
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid
+      <span data-reference="postcode">
+        postal code
+      </span>
+      .
+    </span>
+  </span>
+</label>
+`;
+
+exports[`Delivery Postcode render a postcode input with a label set as postal code 2`] = `
+<label id="deliveryPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery
+      <span data-reference="postcode">
+        postal code
+      </span>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryPostcode"
+           name="deliveryPostcode"
+           placeholder="Enter your postal code"
+           autocomplete="postal-code"
+           data-trackable="delivery-postcode"
+           aria-required="true"
+           required
+           pattern="whatever"
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid
+      <span data-reference="postcode">
+        postal code
+      </span>
+      .
+    </span>
+  </span>
+</label>
+`;
+
+exports[`Delivery Postcode render a postcode input with a label set as postcode 1`] = `
+<label id="deliveryPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery
+      <span data-reference="postcode">
+        postcode
+      </span>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryPostcode"
+           name="deliveryPostcode"
+           placeholder="Enter your postcode"
+           autocomplete="postal-code"
+           data-trackable="delivery-postcode"
+           aria-required="true"
+           required
+           pattern="whatever"
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid
+      <span data-reference="postcode">
+        postcode
+      </span>
+      .
+    </span>
+  </span>
+</label>
+`;
+
+exports[`Delivery Postcode render a postcode input with a label set as postcode 2`] = `
+<label id="deliveryPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery
+      <span data-reference="postcode">
+        postcode
+      </span>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryPostcode"
+           name="deliveryPostcode"
+           placeholder="Enter your postcode"
+           autocomplete="postal-code"
+           data-trackable="delivery-postcode"
+           aria-required="true"
+           required
+           pattern="whatever"
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid
+      <span data-reference="postcode">
+        postcode
+      </span>
+      .
+    </span>
+  </span>
+</label>
+`;
+
+exports[`Delivery Postcode render a postcode input with default label 1`] = `
+<label id="deliveryPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery
+      <span data-reference="postcode">
+        postcode
+      </span>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryPostcode"
+           name="deliveryPostcode"
+           placeholder="Enter your postcode"
+           autocomplete="postal-code"
+           data-trackable="delivery-postcode"
+           aria-required="true"
+           required
+           pattern="whatever"
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid
+      <span data-reference="postcode">
+        postcode
+      </span>
+      .
+    </span>
+  </span>
+</label>
+`;
+
+exports[`Delivery Postcode render a postcode input with default label 2`] = `
+<label id="deliveryPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery
+      <span data-reference="postcode">
+        postcode
+      </span>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryPostcode"
+           name="deliveryPostcode"
+           placeholder="Enter your postcode"
+           autocomplete="postal-code"
+           data-trackable="delivery-postcode"
+           aria-required="true"
+           required
+           pattern="whatever"
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid
+      <span data-reference="postcode">
+        postcode
       </span>
       .
     </span>
@@ -155,7 +371,7 @@ exports[`Delivery Postcode render different styles 1`] = `
     <span class="o-forms-title__main">
       Delivery
       <span data-reference="postcode">
-        ZipCode
+        postcode
       </span>
     </span>
   </span>
@@ -163,7 +379,7 @@ exports[`Delivery Postcode render different styles 1`] = `
     <input type="text"
            id="deliveryPostcode"
            name="deliveryPostcode"
-           placeholder="Enter your ZipCode"
+           placeholder="Enter your postcode"
            autocomplete="postal-code"
            data-trackable="delivery-postcode"
            aria-required="true"
@@ -174,7 +390,7 @@ exports[`Delivery Postcode render different styles 1`] = `
     <span class="o-forms-input__error">
       Please enter a valid
       <span data-reference="postcode">
-        ZipCode
+        postcode
       </span>
       .
     </span>
@@ -191,7 +407,7 @@ exports[`Delivery Postcode render different styles 2`] = `
     <span class="o-forms-title__main">
       Delivery
       <span data-reference="postcode">
-        ZipCode
+        postcode
       </span>
     </span>
   </span>
@@ -199,7 +415,7 @@ exports[`Delivery Postcode render different styles 2`] = `
     <input type="text"
            id="deliveryPostcode"
            name="deliveryPostcode"
-           placeholder="Enter your ZipCode"
+           placeholder="Enter your postcode"
            autocomplete="postal-code"
            data-trackable="delivery-postcode"
            aria-required="true"
@@ -210,7 +426,7 @@ exports[`Delivery Postcode render different styles 2`] = `
     <span class="o-forms-input__error">
       Please enter a valid
       <span data-reference="postcode">
-        ZipCode
+        postcode
       </span>
       .
     </span>

--- a/components/country.jsx
+++ b/components/country.jsx
@@ -10,7 +10,8 @@ export function Country ({
 	inputId = 'country',
 	isB2b = false,
 	isDisabled = false,
-	value
+	value,
+	additonalFieldInformation
 }) {
 	const selectWrapperClassName = classNames([
 		'o-forms-input',
@@ -44,6 +45,11 @@ export function Country ({
 		</select>
 	);
 
+	const fieldErrorClassNames = classNames([
+		'o-forms-input__error',
+		{ 'additional-field-instructions__with-field-error': additonalFieldInformation }
+	]);
+
 	return (
 		<label id={fieldId} className="o-forms-field js-unknown-user-field" data-validate="required">
 			<span className="o-forms-title">
@@ -51,7 +57,10 @@ export function Country ({
 			</span>
 			<span className={selectWrapperClassName}>
 				{createSelect(countries)}
-				<span className="o-forms-input__error">{error}</span>
+				<span className={fieldErrorClassNames}>{error}</span>
+					{additonalFieldInformation ? (
+						<p className="additional-field-instructions">{additonalFieldInformation}</p>
+					) : null}
 			</span>
 		</label>
 	);
@@ -68,5 +77,6 @@ Country.propTypes = {
 	inputId: PropTypes.string,
 	isB2b: PropTypes.bool,
 	isDisabled: PropTypes.bool,
-	value: PropTypes.string
+	value: PropTypes.string,
+	additonalFieldInformation: PropTypes.string
 };

--- a/components/country.jsx
+++ b/components/country.jsx
@@ -47,7 +47,7 @@ export function Country ({
 
 	const fieldErrorClassNames = classNames([
 		'o-forms-input__error',
-		{ 'additional-field-instructions__with-field-error': additonalFieldInformation }
+		{ 'additional-field-information__with-field-error': additonalFieldInformation }
 	]);
 
 	return (
@@ -59,7 +59,7 @@ export function Country ({
 				{createSelect(countries)}
 				<span className={fieldErrorClassNames}>{error}</span>
 					{additonalFieldInformation ? (
-						<p className="additional-field-instructions">{additonalFieldInformation}</p>
+						<p className="additional-field-information">{additonalFieldInformation}</p>
 					) : null}
 			</span>
 		</label>

--- a/components/country.jsx
+++ b/components/country.jsx
@@ -78,5 +78,5 @@ Country.propTypes = {
 	isB2b: PropTypes.bool,
 	isDisabled: PropTypes.bool,
 	value: PropTypes.string,
-	additonalFieldInformation: PropTypes.array
+	additonalFieldInformation: PropTypes.node
 };

--- a/components/country.jsx
+++ b/components/country.jsx
@@ -78,5 +78,5 @@ Country.propTypes = {
 	isB2b: PropTypes.bool,
 	isDisabled: PropTypes.bool,
 	value: PropTypes.string,
-	additonalFieldInformation: PropTypes.string
+	additonalFieldInformation: PropTypes.array
 };

--- a/components/delivery-postcode.jsx
+++ b/components/delivery-postcode.jsx
@@ -2,26 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const getPostcodeLabel = (country) => {
-	if (country && country.toUpperCase() === 'USA') {
-		return 'Zip Code';
-	} else if (country && country.toUpperCase() === 'CAN') {
-		return 'postal code';
-	} else {
-		return 'postcode';
-	}
-};
+const postcodeLabel = {
+	USA: 'Zip Code',
+	CAN: 'postal code'
+}
 
 export function DeliveryPostcode ({
 	value = '',
+	country = '',
 	isDisabled = false,
 	hasError = false,
 	isHidden = false,
 	pattern,
-	country,
 	additonalFieldInformation,
 }) {
-	const postcodeReference = getPostcodeLabel(country);
+
+	const postcodeReference = postcodeLabel[country.toUpperCase()] || 'postcode';
 
 	const inputWrapperClassNames = classNames([
 		'o-forms-input',

--- a/components/delivery-postcode.jsx
+++ b/components/delivery-postcode.jsx
@@ -64,7 +64,7 @@ export function DeliveryPostcode ({
 					required
 					disabled={isDisabled}
 				/>
-			<span className={fieldErrorClassNames}>
+				<span className={fieldErrorClassNames}>
 					Please enter a valid <span data-reference="postcode">{postcodeReference}</span>.
 				</span>
 				{additonalFieldInformation ? (

--- a/components/delivery-postcode.jsx
+++ b/components/delivery-postcode.jsx
@@ -32,7 +32,7 @@ export function DeliveryPostcode ({
 
 	const fieldErrorClassNames = classNames([
 		'o-forms-input__error',
-		{ 'additional-field-instructions__with-field-error': additonalFieldInformation }
+		{ 'additional-field-information__with-field-error': additonalFieldInformation }
 	]);
 
 	return (
@@ -65,7 +65,7 @@ export function DeliveryPostcode ({
 					Please enter a valid <span data-reference="postcode">{postcodeReference}</span>.
 				</span>
 				{additonalFieldInformation ? (
-					<p className="additional-field-instructions">{additonalFieldInformation}</p>
+					<p className="additional-field-information">{additonalFieldInformation}</p>
 				) : null}
 			</span>
 		</label>

--- a/components/delivery-postcode.jsx
+++ b/components/delivery-postcode.jsx
@@ -2,14 +2,27 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+const getPostcodeLabel = (country) => {
+	if (country && country.toUpperCase() === 'USA') {
+		return 'Zip Code';
+	} else if (country && country.toUpperCase() === 'CAN') {
+		return 'postal code';
+	} else {
+		return 'postcode';
+	}
+};
+
 export function DeliveryPostcode ({
-	postcodeReference,
 	value = '',
 	pattern = '',
+	country = null,
 	isDisabled = false,
 	hasError = false,
 	isHidden = false
 }) {
+	const postcodeReference = getPostcodeLabel(country);
+
+
 	const inputWrapperClassNames = classNames([
 		'o-forms-input',
 		'o-forms-input--text',
@@ -56,7 +69,7 @@ export function DeliveryPostcode ({
 }
 
 DeliveryPostcode.propTypes = {
-	postcodeReference: PropTypes.string.isRequired,
+	country: PropTypes.string,
 	value: PropTypes.string,
 	pattern: PropTypes.string,
 	isDisabled: PropTypes.bool,

--- a/components/delivery-postcode.jsx
+++ b/components/delivery-postcode.jsx
@@ -79,5 +79,5 @@ DeliveryPostcode.propTypes = {
 	isDisabled: PropTypes.bool,
 	hasError: PropTypes.bool,
 	isHidden: PropTypes.bool,
-	additonalFieldInformation: PropTypes.array
+	additonalFieldInformation: PropTypes.node
 };

--- a/components/delivery-postcode.jsx
+++ b/components/delivery-postcode.jsx
@@ -14,14 +14,14 @@ const getPostcodeLabel = (country) => {
 
 export function DeliveryPostcode ({
 	value = '',
-	pattern = '',
-	country = null,
 	isDisabled = false,
 	hasError = false,
-	isHidden = false
+	isHidden = false,
+	pattern,
+	country,
+	additonalFieldInformation,
 }) {
 	const postcodeReference = getPostcodeLabel(country);
-
 
 	const inputWrapperClassNames = classNames([
 		'o-forms-input',
@@ -29,9 +29,14 @@ export function DeliveryPostcode ({
 		{ 'o-forms-input--invalid': hasError }
 	]);
 
-	let deliveryPostcodeFieldClassNames = classNames([
+	const deliveryPostcodeFieldClassNames = classNames([
 		'o-forms-field',
 		{ 'ncf__hidden': isHidden }
+	]);
+
+	const fieldErrorClassNames = classNames([
+		'o-forms-input__error',
+		{ 'additional-field-instructions__with-field-error': additonalFieldInformation }
 	]);
 
 	return (
@@ -57,12 +62,14 @@ export function DeliveryPostcode ({
 					data-trackable="delivery-postcode"
 					aria-required="true"
 					required
-					pattern={pattern}
 					disabled={isDisabled}
 				/>
-				<span className="o-forms-input__error">
+			<span className={fieldErrorClassNames}>
 					Please enter a valid <span data-reference="postcode">{postcodeReference}</span>.
 				</span>
+				{additonalFieldInformation ? (
+					<p className="additional-field-instructions">{additonalFieldInformation}</p>
+				) : null}
 			</span>
 		</label>
 	);
@@ -74,5 +81,6 @@ DeliveryPostcode.propTypes = {
 	pattern: PropTypes.string,
 	isDisabled: PropTypes.bool,
 	hasError: PropTypes.bool,
-	isHidden: PropTypes.bool
+	isHidden: PropTypes.bool,
+	additonalFieldInformation: PropTypes.string
 };

--- a/components/delivery-postcode.jsx
+++ b/components/delivery-postcode.jsx
@@ -82,5 +82,5 @@ DeliveryPostcode.propTypes = {
 	isDisabled: PropTypes.bool,
 	hasError: PropTypes.bool,
 	isHidden: PropTypes.bool,
-	additonalFieldInformation: PropTypes.string
+	additonalFieldInformation: PropTypes.array
 };

--- a/components/delivery-postcode.jsx
+++ b/components/delivery-postcode.jsx
@@ -62,6 +62,7 @@ export function DeliveryPostcode ({
 					data-trackable="delivery-postcode"
 					aria-required="true"
 					required
+					pattern={pattern}
 					disabled={isDisabled}
 				/>
 				<span className={fieldErrorClassNames}>

--- a/components/delivery-postcode.spec.js
+++ b/components/delivery-postcode.spec.js
@@ -12,9 +12,41 @@ describe('Delivery Postcode', () => {
 		context.template = await fetchPartialAsString('delivery-postcode.html');
 	});
 
-	it('render a postcode input with a label', () => {
+	it('render a postcode input with a label set as postcode', () => {
 		const props = {
-			postcodeReference: 'ZipCode',
+			postcodeReference: 'postcode',
+			pattern: 'whatever',
+		};
+
+		expect(DeliveryPostcode).toRenderAs(context, props);
+
+	});
+
+	it('render a postcode input with a label set as Zip Code', () => {
+		const props = {
+			country: 'USA',
+			postcodeReference: 'Zip Code',
+			pattern: 'whatever',
+		};
+
+		expect(DeliveryPostcode).toRenderAs(context, props);
+
+	});
+
+	it('render a postcode input with a label set as postal code', () => {
+		const props = {
+			country: 'CAN',
+			postcodeReference: 'postal code',
+			pattern: 'whatever',
+		};
+
+		expect(DeliveryPostcode).toRenderAs(context, props);
+
+	});
+
+	it('render a postcode input with default label', () => {
+		const props = {
+			postcodeReference: 'postcode',
 			pattern: 'whatever',
 		};
 
@@ -24,7 +56,7 @@ describe('Delivery Postcode', () => {
 
 	it('render a disable input', () => {
 		const props = {
-			postcodeReference: 'ZipCode',
+			postcodeReference: 'postcode',
 			pattern: 'whatever',
 			isDisabled: true,
 		};
@@ -35,7 +67,7 @@ describe('Delivery Postcode', () => {
 
 	it('render different styles', () => {
 		const props = {
-			postcodeReference: 'ZipCode',
+			postcodeReference: 'postcode',
 			pattern: 'whatever',
 			hasError: true,
 			isHidden: true,

--- a/components/delivery-postcode.spec.js
+++ b/components/delivery-postcode.spec.js
@@ -33,6 +33,17 @@ describe('Delivery Postcode', () => {
 
 	});
 
+	it('render a postcode input with a label set as Zip Code with USA in lower case', () => {
+		const props = {
+			country: 'usa',
+			postcodeReference: 'Zip Code',
+			pattern: 'whatever',
+		};
+
+		expect(DeliveryPostcode).toRenderAs(context, props);
+
+	});
+
 	it('render a postcode input with a label set as postal code', () => {
 		const props = {
 			country: 'CAN',

--- a/main.scss
+++ b/main.scss
@@ -16,7 +16,7 @@
 @import './styles/continue-reading';
 @import './styles/banner';
 @import './styles/customer-care';
-@import './styles/forms-additional-field-instructions';
+@import './styles/forms-additional-field-information';
 
 @include oFonts();
 @include oForms($opts: (

--- a/main.scss
+++ b/main.scss
@@ -16,6 +16,7 @@
 @import './styles/continue-reading';
 @import './styles/banner';
 @import './styles/customer-care';
+@import './styles/forms-additional-field-instructions';
 
 @include oFonts();
 @include oForms($opts: (

--- a/styles/forms-additional-field-information.scss
+++ b/styles/forms-additional-field-information.scss
@@ -1,10 +1,10 @@
-.additional-field-instructions {
+.additional-field-information {
 	margin-top: oSpacingByName('s2');
 	margin-bottom: 0;
 	@include oTypographySans($scale: -1);
 }
 
-.o-forms-input--invalid .o-forms-input__error.additional-field-instructions__with-field-error {
+.o-forms-input--invalid .o-forms-input__error.additional-field-information__with-field-error {
 	display: inherit;
 	position: inherit;
 	margin: oSpacingByName('s1') 0;

--- a/styles/forms-additional-field-instructions.scss
+++ b/styles/forms-additional-field-instructions.scss
@@ -1,0 +1,15 @@
+.additional-field-instructions {
+	margin-top: oSpacingByName('s2');
+	margin-bottom: 0;
+	@include oTypographySans($scale: -1);
+}
+
+.o-forms-input--invalid .o-forms-input__error.additional-field-instructions__with-field-error {
+	display: inherit;
+	position: inherit;
+	margin-top: oSpacingByName('s1');
+}
+
+.o-forms-input--invalid .additional-field-instructions {
+	margin-top: oSpacingByName('s2');
+}

--- a/styles/forms-additional-field-instructions.scss
+++ b/styles/forms-additional-field-instructions.scss
@@ -7,9 +7,5 @@
 .o-forms-input--invalid .o-forms-input__error.additional-field-instructions__with-field-error {
 	display: inherit;
 	position: inherit;
-	margin-top: oSpacingByName('s1');
-}
-
-.o-forms-input--invalid .additional-field-instructions {
-	margin-top: oSpacingByName('s2');
+	margin: oSpacingByName('s1') 0;
 }


### PR DESCRIPTION
### Description
I needed to make a few adjustments in order to create the postcode checker in account settings. 

These adjustments include:

Adding functionality to determine the correct reference to postcode from the country code given
Adds additional field information. Origami does not give an option to add text below the input field so I have added this functionality here. 
It also adjusts the styling of the error message so that when a client validation fails the additional field information will move down for the error message. 

[Ticket](https://trello.com/c/rZk8pnIc/71-delivery-address-post-code-check)

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Tests** written for new or updated for existing functionality
