### PR TITLE
Add `for` attribute to label tags

### DIFF
--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -7,7 +7,7 @@ exports[`AcceptTerms renders appropriately if a registration 1`] = `
      data-trackable="register-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -45,7 +45,7 @@ exports[`AcceptTerms renders appropriately if a registration 2`] = `
      data-trackable="register-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -83,7 +83,7 @@ exports[`AcceptTerms renders appropriately if a signup 1`] = `
      data-trackable="sign-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -146,7 +146,7 @@ exports[`AcceptTerms renders appropriately if a signup 2`] = `
      data-trackable="sign-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -209,7 +209,7 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 1`]
      data-trackable="sign-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -277,7 +277,7 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 2`]
      data-trackable="sign-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -345,7 +345,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product 1`]
      data-trackable="sign-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -397,7 +397,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product 2`]
      data-trackable="sign-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -449,7 +449,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
      data-trackable="sign-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -501,7 +501,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
      data-trackable="sign-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -553,7 +553,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
      data-trackable="sign-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -605,7 +605,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
      data-trackable="sign-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -657,7 +657,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
      data-trackable="sign-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -720,7 +720,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
      data-trackable="sign-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -783,7 +783,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
      data-trackable="sign-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -846,7 +846,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
      data-trackable="sign-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -909,7 +909,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
      data-trackable="sign-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -972,7 +972,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
      data-trackable="sign-up-terms"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1034,7 +1034,7 @@ exports[`AcceptTerms renders appropriately if input is checked 1`] = `
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1072,7 +1072,7 @@ exports[`AcceptTerms renders appropriately if input is checked 2`] = `
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1110,7 +1110,7 @@ exports[`AcceptTerms renders appropriately if is B2B 1`] = `
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1138,7 +1138,7 @@ exports[`AcceptTerms renders appropriately if is B2B 2`] = `
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1166,7 +1166,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup 1`] = `
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1212,7 +1212,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup 2`] = `
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1258,7 +1258,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup and not trial 
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1304,7 +1304,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup and not trial 
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1350,7 +1350,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup and trial 1`] 
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1399,7 +1399,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup and trial 2`] 
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1448,7 +1448,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1485,7 +1485,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1522,7 +1522,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1559,7 +1559,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1596,7 +1596,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1633,7 +1633,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1670,7 +1670,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1707,7 +1707,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1744,7 +1744,7 @@ exports[`AcceptTerms renders appropriately if is transition 1`] = `
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1806,7 +1806,7 @@ exports[`AcceptTerms renders appropriately if is transition 2`] = `
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1868,7 +1868,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1930,7 +1930,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -1992,7 +1992,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -2054,7 +2054,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -2116,7 +2116,7 @@ exports[`AcceptTerms renders with an error 1`] = `
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox o-forms-input--invalid">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -2153,7 +2153,7 @@ exports[`AcceptTerms renders with an error 2`] = `
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox o-forms-input--invalid">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -2190,7 +2190,7 @@ exports[`AcceptTerms renders with default props 1`] = `
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"
@@ -2227,7 +2227,7 @@ exports[`AcceptTerms renders with default props 2`] = `
      data-validate="required,checked"
 >
   <span class="o-forms-input o-forms-input--checkbox">
-    <label>
+    <label for="termsAcceptance">
       <input type="checkbox"
              id="termsAcceptance"
              name="termsAcceptance"

--- a/components/__snapshots__/billing-country.spec.js.snap
+++ b/components/__snapshots__/billing-country.spec.js.snap
@@ -4,6 +4,7 @@ exports[`Country renders with default props 1`] = `
 <label id="billingCountryField"
        class="o-forms-field"
        data-validate="required"
+       for="billingCountry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -801,6 +802,7 @@ exports[`Country renders with default props 2`] = `
 <label id="billingCountryField"
        class="o-forms-field"
        data-validate="required"
+       for="billingCountry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -1598,6 +1600,7 @@ exports[`Country renders with hasError 1`] = `
 <label id="billingCountryField"
        class="o-forms-field"
        data-validate="required"
+       for="billingCountry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -2395,6 +2398,7 @@ exports[`Country renders with hasError 2`] = `
 <label id="billingCountryField"
        class="o-forms-field"
        data-validate="required"
+       for="billingCountry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -3192,6 +3196,7 @@ exports[`Country renders with isDisabled 1`] = `
 <label id="billingCountryField"
        class="o-forms-field"
        data-validate="required"
+       for="billingCountry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -3990,6 +3995,7 @@ exports[`Country renders with isDisabled 2`] = `
 <label id="billingCountryField"
        class="o-forms-field"
        data-validate="required"
+       for="billingCountry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -4788,6 +4794,7 @@ exports[`Country renders with large filterList 1`] = `
 <label id="billingCountryField"
        class="o-forms-field"
        data-validate="required"
+       for="billingCountry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -4879,6 +4886,7 @@ exports[`Country renders with large filterList 2`] = `
 <label id="billingCountryField"
        class="o-forms-field"
        data-validate="required"
+       for="billingCountry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -4970,6 +4978,7 @@ exports[`Country renders with small filterList 1`] = `
 <label id="billingCountryField"
        class="o-forms-field"
        data-validate="required"
+       for="billingCountry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -5004,6 +5013,7 @@ exports[`Country renders with small filterList 2`] = `
 <label id="billingCountryField"
        class="o-forms-field"
        data-validate="required"
+       for="billingCountry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -5038,6 +5048,7 @@ exports[`Country renders with value 1`] = `
 <label id="billingCountryField"
        class="o-forms-field"
        data-validate="required"
+       for="billingCountry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -5837,6 +5848,7 @@ exports[`Country renders with value 2`] = `
 <label id="billingCountryField"
        class="o-forms-field"
        data-validate="required"
+       for="billingCountry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/billing-postcode.spec.js.snap
+++ b/components/__snapshots__/billing-postcode.spec.js.snap
@@ -4,6 +4,7 @@ exports[`Billing Postcode can render a disable input 1`] = `
 <label id="billingPostcodeField"
        class="o-forms-field"
        data-validate="required"
+       for="billingPostcode"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -40,6 +41,7 @@ exports[`Billing Postcode can render a disable input 2`] = `
 <label id="billingPostcodeField"
        class="o-forms-field"
        data-validate="required"
+       for="billingPostcode"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -76,6 +78,7 @@ exports[`Billing Postcode can render a pattern attribute 1`] = `
 <label id="billingPostcodeField"
        class="o-forms-field"
        data-validate="required"
+       for="billingPostcode"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -112,6 +115,7 @@ exports[`Billing Postcode can render a pattern attribute 2`] = `
 <label id="billingPostcodeField"
        class="o-forms-field"
        data-validate="required"
+       for="billingPostcode"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -148,6 +152,7 @@ exports[`Billing Postcode can render as an Error 1`] = `
 <label id="billingPostcodeField"
        class="o-forms-field"
        data-validate="required"
+       for="billingPostcode"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -183,6 +188,7 @@ exports[`Billing Postcode can render as an Error 2`] = `
 <label id="billingPostcodeField"
        class="o-forms-field"
        data-validate="required"
+       for="billingPostcode"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -218,6 +224,7 @@ exports[`Billing Postcode can render as an hidden field 1`] = `
 <label id="billingPostcodeField"
        class="o-forms-field ncf__hidden"
        data-validate="required"
+       for="billingPostcode"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -253,6 +260,7 @@ exports[`Billing Postcode can render as an hidden field 2`] = `
 <label id="billingPostcodeField"
        class="o-forms-field ncf__hidden"
        data-validate="required"
+       for="billingPostcode"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -288,6 +296,7 @@ exports[`Billing Postcode render a postcode input with a label 1`] = `
 <label id="billingPostcodeField"
        class="o-forms-field"
        data-validate="required"
+       for="billingPostcode"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -323,6 +332,7 @@ exports[`Billing Postcode render a postcode input with a label 2`] = `
 <label id="billingPostcodeField"
        class="o-forms-field"
        data-validate="required"
+       for="billingPostcode"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/company-name.spec.js.snap
+++ b/components/__snapshots__/company-name.spec.js.snap
@@ -4,6 +4,7 @@ exports[`CompanyName renders with a custom value 1`] = `
 <label id="companyNameField"
        class="o-forms-field"
        data-validate="required"
+       for="companyName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -32,6 +33,7 @@ exports[`CompanyName renders with a custom value 2`] = `
 <label id="companyNameField"
        class="o-forms-field"
        data-validate="required"
+       for="companyName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -60,6 +62,7 @@ exports[`CompanyName renders with an error 1`] = `
 <label id="companyNameField"
        class="o-forms-field"
        data-validate="required"
+       for="companyName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -88,6 +91,7 @@ exports[`CompanyName renders with an error 2`] = `
 <label id="companyNameField"
        class="o-forms-field"
        data-validate="required"
+       for="companyName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -116,6 +120,7 @@ exports[`CompanyName renders with default props 1`] = `
 <label id="companyNameField"
        class="o-forms-field"
        data-validate="required"
+       for="companyName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -144,6 +149,7 @@ exports[`CompanyName renders with default props 2`] = `
 <label id="companyNameField"
        class="o-forms-field"
        data-validate="required"
+       for="companyName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -172,6 +178,7 @@ exports[`CompanyName renders with disabled input 1`] = `
 <label id="companyNameField"
        class="o-forms-field"
        data-validate="required"
+       for="companyName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -201,6 +208,7 @@ exports[`CompanyName renders with disabled input 2`] = `
 <label id="companyNameField"
        class="o-forms-field"
        data-validate="required"
+       for="companyName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/country.spec.js.snap
+++ b/components/__snapshots__/country.spec.js.snap
@@ -4,6 +4,7 @@ exports[`Country renders with default props 1`] = `
 <label id="countryField"
        class="o-forms-field js-unknown-user-field"
        data-validate="required"
+       for="country"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -798,6 +799,7 @@ exports[`Country renders with default props 2`] = `
 <label id="countryField"
        class="o-forms-field js-unknown-user-field"
        data-validate="required"
+       for="country"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -1592,6 +1594,7 @@ exports[`Country renders with hasError 1`] = `
 <label id="countryField"
        class="o-forms-field js-unknown-user-field"
        data-validate="required"
+       for="country"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -2386,6 +2389,7 @@ exports[`Country renders with hasError 2`] = `
 <label id="countryField"
        class="o-forms-field js-unknown-user-field"
        data-validate="required"
+       for="country"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -3180,6 +3184,7 @@ exports[`Country renders with isB2b 1`] = `
 <label id="countryField"
        class="o-forms-field js-unknown-user-field"
        data-validate="required"
+       for="country"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -3974,6 +3979,7 @@ exports[`Country renders with isB2b 2`] = `
 <label id="countryField"
        class="o-forms-field js-unknown-user-field"
        data-validate="required"
+       for="country"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -4768,6 +4774,7 @@ exports[`Country renders with isDisabled 1`] = `
 <label id="countryField"
        class="o-forms-field js-unknown-user-field"
        data-validate="required"
+       for="country"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -5563,6 +5570,7 @@ exports[`Country renders with isDisabled 2`] = `
 <label id="countryField"
        class="o-forms-field js-unknown-user-field"
        data-validate="required"
+       for="country"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -6358,6 +6366,7 @@ exports[`Country renders with large filterList 1`] = `
 <label id="countryField"
        class="o-forms-field js-unknown-user-field"
        data-validate="required"
+       for="country"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -6446,6 +6455,7 @@ exports[`Country renders with large filterList 2`] = `
 <label id="countryField"
        class="o-forms-field js-unknown-user-field"
        data-validate="required"
+       for="country"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -6534,6 +6544,7 @@ exports[`Country renders with small filterList 1`] = `
 <label id="countryField"
        class="o-forms-field js-unknown-user-field"
        data-validate="required"
+       for="country"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -6565,6 +6576,7 @@ exports[`Country renders with small filterList 2`] = `
 <label id="countryField"
        class="o-forms-field js-unknown-user-field"
        data-validate="required"
+       for="country"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -6596,6 +6608,7 @@ exports[`Country renders with value 1`] = `
 <label id="countryField"
        class="o-forms-field js-unknown-user-field"
        data-validate="required"
+       for="country"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -7392,6 +7405,7 @@ exports[`Country renders with value 2`] = `
 <label id="countryField"
        class="o-forms-field js-unknown-user-field"
        data-validate="required"
+       for="country"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/decision-maker.spec.js.snap
+++ b/components/__snapshots__/decision-maker.spec.js.snap
@@ -16,7 +16,7 @@ exports[`DecisionMaker renders with 'no' as default state for radio buttons 1`] 
   </span>
   <span class="o-forms-input o-forms-input--radio-box o-forms-input--inline">
     <div class="o-forms-input--radio-box__container">
-      <label>
+      <label for="decisionMakerYes">
         <input type="radio"
                id="decisionMakerYes"
                name="decisionMaker"
@@ -29,7 +29,7 @@ exports[`DecisionMaker renders with 'no' as default state for radio buttons 1`] 
           Yes
         </span>
       </label>
-      <label>
+      <label for="decisionMakerNo">
         <input type="radio"
                id="decisionMakerNo"
                name="decisionMaker"
@@ -67,7 +67,7 @@ exports[`DecisionMaker renders with 'no' as default state for radio buttons 2`] 
   </span>
   <span class="o-forms-input o-forms-input--radio-box o-forms-input--inline">
     <div class="o-forms-input--radio-box__container">
-      <label>
+      <label for="decisionMakerYes">
         <input type="radio"
                id="decisionMakerYes"
                name="decisionMaker"
@@ -80,7 +80,7 @@ exports[`DecisionMaker renders with 'no' as default state for radio buttons 2`] 
           Yes
         </span>
       </label>
-      <label>
+      <label for="decisionMakerNo">
         <input type="radio"
                id="decisionMakerNo"
                name="decisionMaker"
@@ -118,7 +118,7 @@ exports[`DecisionMaker renders with an error 1`] = `
   </span>
   <span class="o-forms-input o-forms-input--radio-box o-forms-input--inline o-forms-input--invalid">
     <div class="o-forms-input--radio-box__container">
-      <label>
+      <label for="decisionMakerYes">
         <input type="radio"
                id="decisionMakerYes"
                name="decisionMaker"
@@ -132,7 +132,7 @@ exports[`DecisionMaker renders with an error 1`] = `
           Yes
         </span>
       </label>
-      <label>
+      <label for="decisionMakerNo">
         <input type="radio"
                id="decisionMakerNo"
                name="decisionMaker"
@@ -169,7 +169,7 @@ exports[`DecisionMaker renders with an error 2`] = `
   </span>
   <span class="o-forms-input o-forms-input--radio-box o-forms-input--inline o-forms-input--invalid">
     <div class="o-forms-input--radio-box__container">
-      <label>
+      <label for="decisionMakerYes">
         <input type="radio"
                id="decisionMakerYes"
                name="decisionMaker"
@@ -183,7 +183,7 @@ exports[`DecisionMaker renders with an error 2`] = `
           Yes
         </span>
       </label>
-      <label>
+      <label for="decisionMakerNo">
         <input type="radio"
                id="decisionMakerNo"
                name="decisionMaker"
@@ -220,7 +220,7 @@ exports[`DecisionMaker renders with default props 1`] = `
   </span>
   <span class="o-forms-input o-forms-input--radio-box o-forms-input--inline">
     <div class="o-forms-input--radio-box__container">
-      <label>
+      <label for="decisionMakerYes">
         <input type="radio"
                id="decisionMakerYes"
                name="decisionMaker"
@@ -234,7 +234,7 @@ exports[`DecisionMaker renders with default props 1`] = `
           Yes
         </span>
       </label>
-      <label>
+      <label for="decisionMakerNo">
         <input type="radio"
                id="decisionMakerNo"
                name="decisionMaker"
@@ -271,7 +271,7 @@ exports[`DecisionMaker renders with default props 2`] = `
   </span>
   <span class="o-forms-input o-forms-input--radio-box o-forms-input--inline">
     <div class="o-forms-input--radio-box__container">
-      <label>
+      <label for="decisionMakerYes">
         <input type="radio"
                id="decisionMakerYes"
                name="decisionMaker"
@@ -285,7 +285,7 @@ exports[`DecisionMaker renders with default props 2`] = `
           Yes
         </span>
       </label>
-      <label>
+      <label for="decisionMakerNo">
         <input type="radio"
                id="decisionMakerNo"
                name="decisionMaker"

--- a/components/__snapshots__/delivery-address.spec.js.snap
+++ b/components/__snapshots__/delivery-address.spec.js.snap
@@ -4,7 +4,9 @@ exports[`DeliveryAddress renders default props 1`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field">
+  <label class="o-forms-field"
+         for="deliveryAddressLine1"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 1
@@ -23,7 +25,9 @@ exports[`DeliveryAddress renders default props 1`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine2"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 2
@@ -40,7 +44,9 @@ exports[`DeliveryAddress renders default props 1`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine3"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 3
@@ -64,7 +70,9 @@ exports[`DeliveryAddress renders default props 2`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field">
+  <label class="o-forms-field"
+         for="deliveryAddressLine1"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 1
@@ -83,7 +91,9 @@ exports[`DeliveryAddress renders default props 2`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine2"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 2
@@ -100,7 +110,9 @@ exports[`DeliveryAddress renders default props 2`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine3"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 3
@@ -124,7 +136,9 @@ exports[`DeliveryAddress renders with an error 1`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field">
+  <label class="o-forms-field"
+         for="deliveryAddressLine1"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 1
@@ -143,7 +157,9 @@ exports[`DeliveryAddress renders with an error 1`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine2"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 2
@@ -160,7 +176,9 @@ exports[`DeliveryAddress renders with an error 1`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine3"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 3
@@ -184,7 +202,9 @@ exports[`DeliveryAddress renders with an error 2`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field">
+  <label class="o-forms-field"
+         for="deliveryAddressLine1"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 1
@@ -203,7 +223,9 @@ exports[`DeliveryAddress renders with an error 2`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine2"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 2
@@ -220,7 +242,9 @@ exports[`DeliveryAddress renders with an error 2`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine3"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 3
@@ -244,7 +268,9 @@ exports[`DeliveryAddress renders with custom line 1 value 1`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field">
+  <label class="o-forms-field"
+         for="deliveryAddressLine1"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 1
@@ -263,7 +289,9 @@ exports[`DeliveryAddress renders with custom line 1 value 1`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine2"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 2
@@ -280,7 +308,9 @@ exports[`DeliveryAddress renders with custom line 1 value 1`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine3"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 3
@@ -304,7 +334,9 @@ exports[`DeliveryAddress renders with custom line 1 value 2`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field">
+  <label class="o-forms-field"
+         for="deliveryAddressLine1"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 1
@@ -323,7 +355,9 @@ exports[`DeliveryAddress renders with custom line 1 value 2`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine2"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 2
@@ -340,7 +374,9 @@ exports[`DeliveryAddress renders with custom line 1 value 2`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine3"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 3
@@ -364,7 +400,9 @@ exports[`DeliveryAddress renders with custom line 2 value 1`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field">
+  <label class="o-forms-field"
+         for="deliveryAddressLine1"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 1
@@ -383,7 +421,9 @@ exports[`DeliveryAddress renders with custom line 2 value 1`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine2"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 2
@@ -400,7 +440,9 @@ exports[`DeliveryAddress renders with custom line 2 value 1`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine3"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 3
@@ -424,7 +466,9 @@ exports[`DeliveryAddress renders with custom line 2 value 2`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field">
+  <label class="o-forms-field"
+         for="deliveryAddressLine1"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 1
@@ -443,7 +487,9 @@ exports[`DeliveryAddress renders with custom line 2 value 2`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine2"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 2
@@ -460,7 +506,9 @@ exports[`DeliveryAddress renders with custom line 2 value 2`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine3"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 3
@@ -484,7 +532,9 @@ exports[`DeliveryAddress renders with custom line 3 value 1`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field">
+  <label class="o-forms-field"
+         for="deliveryAddressLine1"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 1
@@ -503,7 +553,9 @@ exports[`DeliveryAddress renders with custom line 3 value 1`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine2"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 2
@@ -520,7 +572,9 @@ exports[`DeliveryAddress renders with custom line 3 value 1`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine3"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 3
@@ -544,7 +598,9 @@ exports[`DeliveryAddress renders with custom line 3 value 2`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field">
+  <label class="o-forms-field"
+         for="deliveryAddressLine1"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 1
@@ -563,7 +619,9 @@ exports[`DeliveryAddress renders with custom line 3 value 2`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine2"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 2
@@ -580,7 +638,9 @@ exports[`DeliveryAddress renders with custom line 3 value 2`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine3"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 3
@@ -604,7 +664,9 @@ exports[`DeliveryAddress renders with disabled input elements 1`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field">
+  <label class="o-forms-field"
+         for="deliveryAddressLine1"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 1
@@ -624,7 +686,9 @@ exports[`DeliveryAddress renders with disabled input elements 1`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine2"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 2
@@ -642,7 +706,9 @@ exports[`DeliveryAddress renders with disabled input elements 1`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine3"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 3
@@ -667,7 +733,9 @@ exports[`DeliveryAddress renders with disabled input elements 2`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field">
+  <label class="o-forms-field"
+         for="deliveryAddressLine1"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 1
@@ -687,7 +755,9 @@ exports[`DeliveryAddress renders with disabled input elements 2`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine2"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 2
@@ -705,7 +775,9 @@ exports[`DeliveryAddress renders with disabled input elements 2`] = `
       >
     </span>
   </label>
-  <label class="o-forms-field o-forms-field--optional">
+  <label class="o-forms-field o-forms-field--optional"
+         for="deliveryAddressLine3"
+  >
     <span class="o-forms-title">
       <span class="o-forms-title__main">
         Address line 3

--- a/components/__snapshots__/delivery-city.spec.js.snap
+++ b/components/__snapshots__/delivery-city.spec.js.snap
@@ -4,6 +4,7 @@ exports[`DeliveryCity renders with a custom value 1`] = `
 <label id="deliveryCityField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryCity"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -29,6 +30,7 @@ exports[`DeliveryCity renders with a custom value 2`] = `
 <label id="deliveryCityField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryCity"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -54,6 +56,7 @@ exports[`DeliveryCity renders with a disabled input element 1`] = `
 <label id="deliveryCityField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryCity"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -80,6 +83,7 @@ exports[`DeliveryCity renders with a disabled input element 2`] = `
 <label id="deliveryCityField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryCity"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -106,6 +110,7 @@ exports[`DeliveryCity renders with an error 1`] = `
 <label id="deliveryCityField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryCity"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -131,6 +136,7 @@ exports[`DeliveryCity renders with an error 2`] = `
 <label id="deliveryCityField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryCity"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -156,6 +162,7 @@ exports[`DeliveryCity renders with default props 1`] = `
 <label id="deliveryCityField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryCity"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -181,6 +188,7 @@ exports[`DeliveryCity renders with default props 2`] = `
 <label id="deliveryCityField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryCity"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/delivery-county.spec.js.snap
+++ b/components/__snapshots__/delivery-county.spec.js.snap
@@ -4,6 +4,7 @@ exports[`DeliveryCounty renders with a custom value 1`] = `
 <label id="deliveryCountyField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryCounty"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -27,6 +28,7 @@ exports[`DeliveryCounty renders with a custom value 2`] = `
 <label id="deliveryCountyField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryCounty"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -50,6 +52,7 @@ exports[`DeliveryCounty renders with a disabled input element 1`] = `
 <label id="deliveryCountyField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryCounty"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -74,6 +77,7 @@ exports[`DeliveryCounty renders with a disabled input element 2`] = `
 <label id="deliveryCountyField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryCounty"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -98,6 +102,7 @@ exports[`DeliveryCounty renders with an error 1`] = `
 <label id="deliveryCountyField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryCounty"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -121,6 +126,7 @@ exports[`DeliveryCounty renders with an error 2`] = `
 <label id="deliveryCountyField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryCounty"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -144,6 +150,7 @@ exports[`DeliveryCounty renders with default props 1`] = `
 <label id="deliveryCountyField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryCounty"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -167,6 +174,7 @@ exports[`DeliveryCounty renders with default props 2`] = `
 <label id="deliveryCountyField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryCounty"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/delivery-instructions.spec.js.snap
+++ b/components/__snapshots__/delivery-instructions.spec.js.snap
@@ -4,6 +4,7 @@ exports[`DeliveryInstructions renders with a custom value 1`] = `
 <label id="deliveryInstructionsField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryInstructions"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -32,6 +33,7 @@ exports[`DeliveryInstructions renders with a custom value 2`] = `
 <label id="deliveryInstructionsField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryInstructions"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -60,6 +62,7 @@ exports[`DeliveryInstructions renders with a disabled input element 1`] = `
 <label id="deliveryInstructionsField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryInstructions"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -88,6 +91,7 @@ exports[`DeliveryInstructions renders with a disabled input element 2`] = `
 <label id="deliveryInstructionsField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryInstructions"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -116,6 +120,7 @@ exports[`DeliveryInstructions renders with an error 1`] = `
 <label id="deliveryInstructionsField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryInstructions"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -143,6 +148,7 @@ exports[`DeliveryInstructions renders with an error 2`] = `
 <label id="deliveryInstructionsField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryInstructions"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -170,6 +176,7 @@ exports[`DeliveryInstructions renders with default props 1`] = `
 <label id="deliveryInstructionsField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryInstructions"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -197,6 +204,7 @@ exports[`DeliveryInstructions renders with default props 2`] = `
 <label id="deliveryInstructionsField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryInstructions"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -224,6 +232,7 @@ exports[`DeliveryInstructions renders with maxlength 1`] = `
 <label id="deliveryInstructionsField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryInstructions"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -252,6 +261,7 @@ exports[`DeliveryInstructions renders with maxlength 2`] = `
 <label id="deliveryInstructionsField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryInstructions"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -280,6 +290,7 @@ exports[`DeliveryInstructions renders with rows 1`] = `
 <label id="deliveryInstructionsField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryInstructions"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -308,6 +319,7 @@ exports[`DeliveryInstructions renders with rows 2`] = `
 <label id="deliveryInstructionsField"
        class="o-forms-field o-forms-field--optional"
        data-validate="required"
+       for="deliveryInstructions"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/delivery-option.spec.js.snap
+++ b/components/__snapshots__/delivery-option.spec.js.snap
@@ -7,7 +7,9 @@ exports[`DeliveryOption renders with a context of being single 1`] = `
      aria-label="Delivery options"
 >
   <span class="o-forms-input o-forms-input--radio-round">
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="PV"
+    >
       <input type="radio"
              id="PV"
              name="deliveryOption"
@@ -24,7 +26,9 @@ exports[`DeliveryOption renders with a context of being single 1`] = `
         </div>
       </span>
     </label>
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="HD"
+    >
       <input type="radio"
              id="HD"
              name="deliveryOption"
@@ -40,7 +44,9 @@ exports[`DeliveryOption renders with a context of being single 1`] = `
         </div>
       </span>
     </label>
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="EV"
+    >
       <input type="radio"
              id="EV"
              name="deliveryOption"
@@ -67,7 +73,9 @@ exports[`DeliveryOption renders with a context of being single 2`] = `
      aria-label="Delivery options"
 >
   <span class="o-forms-input o-forms-input--radio-round">
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="PV"
+    >
       <input type="radio"
              id="PV"
              name="deliveryOption"
@@ -84,7 +92,9 @@ exports[`DeliveryOption renders with a context of being single 2`] = `
         </div>
       </span>
     </label>
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="HD"
+    >
       <input type="radio"
              id="HD"
              name="deliveryOption"
@@ -100,7 +110,9 @@ exports[`DeliveryOption renders with a context of being single 2`] = `
         </div>
       </span>
     </label>
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="EV"
+    >
       <input type="radio"
              id="EV"
              name="deliveryOption"
@@ -127,7 +139,9 @@ exports[`DeliveryOption renders with minimum mandatory props 1`] = `
      aria-label="Delivery options"
 >
   <span class="o-forms-input o-forms-input--radio-round">
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="PV"
+    >
       <input type="radio"
              id="PV"
              name="deliveryOption"
@@ -144,7 +158,9 @@ exports[`DeliveryOption renders with minimum mandatory props 1`] = `
         </div>
       </span>
     </label>
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="HD"
+    >
       <input type="radio"
              id="HD"
              name="deliveryOption"
@@ -160,7 +176,9 @@ exports[`DeliveryOption renders with minimum mandatory props 1`] = `
         </div>
       </span>
     </label>
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="EV"
+    >
       <input type="radio"
              id="EV"
              name="deliveryOption"
@@ -187,7 +205,9 @@ exports[`DeliveryOption renders with minimum mandatory props 2`] = `
      aria-label="Delivery options"
 >
   <span class="o-forms-input o-forms-input--radio-round">
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="PV"
+    >
       <input type="radio"
              id="PV"
              name="deliveryOption"
@@ -204,7 +224,9 @@ exports[`DeliveryOption renders with minimum mandatory props 2`] = `
         </div>
       </span>
     </label>
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="HD"
+    >
       <input type="radio"
              id="HD"
              name="deliveryOption"
@@ -220,7 +242,9 @@ exports[`DeliveryOption renders with minimum mandatory props 2`] = `
         </div>
       </span>
     </label>
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="EV"
+    >
       <input type="radio"
              id="EV"
              name="deliveryOption"
@@ -247,7 +271,9 @@ exports[`DeliveryOption renders without unrecognised delivery options 1`] = `
      aria-label="Delivery options"
 >
   <span class="o-forms-input o-forms-input--radio-round">
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="PV"
+    >
       <input type="radio"
              id="PV"
              name="deliveryOption"
@@ -264,7 +290,9 @@ exports[`DeliveryOption renders without unrecognised delivery options 1`] = `
         </div>
       </span>
     </label>
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="HD"
+    >
       <input type="radio"
              id="HD"
              name="deliveryOption"
@@ -280,7 +308,9 @@ exports[`DeliveryOption renders without unrecognised delivery options 1`] = `
         </div>
       </span>
     </label>
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="EV"
+    >
       <input type="radio"
              id="EV"
              name="deliveryOption"
@@ -307,7 +337,9 @@ exports[`DeliveryOption renders without unrecognised delivery options 2`] = `
      aria-label="Delivery options"
 >
   <span class="o-forms-input o-forms-input--radio-round">
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="PV"
+    >
       <input type="radio"
              id="PV"
              name="deliveryOption"
@@ -324,7 +356,9 @@ exports[`DeliveryOption renders without unrecognised delivery options 2`] = `
         </div>
       </span>
     </label>
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="HD"
+    >
       <input type="radio"
              id="HD"
              name="deliveryOption"
@@ -340,7 +374,9 @@ exports[`DeliveryOption renders without unrecognised delivery options 2`] = `
         </div>
       </span>
     </label>
-    <label class="ncf__delivery-option__item">
+    <label class="ncf__delivery-option__item"
+           for="EV"
+    >
       <input type="radio"
              id="EV"
              name="deliveryOption"

--- a/components/__snapshots__/delivery-postcode.spec.js.snap
+++ b/components/__snapshots__/delivery-postcode.spec.js.snap
@@ -4,6 +4,7 @@ exports[`Delivery Postcode render a disable input 1`] = `
 <label id="deliveryPostcodeField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryPostcode"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -41,6 +42,7 @@ exports[`Delivery Postcode render a disable input 2`] = `
 <label id="deliveryPostcodeField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryPostcode"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -78,6 +80,7 @@ exports[`Delivery Postcode render a postcode input with a label 1`] = `
 <label id="deliveryPostcodeField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryPostcode"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -114,6 +117,7 @@ exports[`Delivery Postcode render a postcode input with a label 2`] = `
 <label id="deliveryPostcodeField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryPostcode"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -150,6 +154,7 @@ exports[`Delivery Postcode render different styles 1`] = `
 <label id="deliveryPostcodeField"
        class="o-forms-field ncf__hidden"
        data-validate="required"
+       for="deliveryPostcode"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -186,6 +191,7 @@ exports[`Delivery Postcode render different styles 2`] = `
 <label id="deliveryPostcodeField"
        class="o-forms-field ncf__hidden"
        data-validate="required"
+       for="deliveryPostcode"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/delivery-start-date.spec.js.snap
+++ b/components/__snapshots__/delivery-start-date.spec.js.snap
@@ -4,6 +4,7 @@ exports[`DeliveryStartDate renders with a custom date 1`] = `
 <label id="deliveryStartDateField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryStartDate"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -42,6 +43,7 @@ exports[`DeliveryStartDate renders with a custom date 2`] = `
 <label id="deliveryStartDateField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryStartDate"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -80,6 +82,7 @@ exports[`DeliveryStartDate renders with a custom input max value 1`] = `
 <label id="deliveryStartDateField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryStartDate"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -118,6 +121,7 @@ exports[`DeliveryStartDate renders with a custom input max value 2`] = `
 <label id="deliveryStartDateField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryStartDate"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -156,6 +160,7 @@ exports[`DeliveryStartDate renders with a custom input min value 1`] = `
 <label id="deliveryStartDateField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryStartDate"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -194,6 +199,7 @@ exports[`DeliveryStartDate renders with a custom input min value 2`] = `
 <label id="deliveryStartDateField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryStartDate"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -232,6 +238,7 @@ exports[`DeliveryStartDate renders with a custom input value 1`] = `
 <label id="deliveryStartDateField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryStartDate"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -269,6 +276,7 @@ exports[`DeliveryStartDate renders with a custom input value 2`] = `
 <label id="deliveryStartDateField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryStartDate"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -306,6 +314,7 @@ exports[`DeliveryStartDate renders with a disabled input 1`] = `
 <label id="deliveryStartDateField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryStartDate"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -344,6 +353,7 @@ exports[`DeliveryStartDate renders with a disabled input 2`] = `
 <label id="deliveryStartDateField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryStartDate"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -382,6 +392,7 @@ exports[`DeliveryStartDate renders with an error 1`] = `
 <label id="deliveryStartDateField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryStartDate"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -419,6 +430,7 @@ exports[`DeliveryStartDate renders with an error 2`] = `
 <label id="deliveryStartDateField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryStartDate"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -456,6 +468,7 @@ exports[`DeliveryStartDate renders with default props 1`] = `
 <label id="deliveryStartDateField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryStartDate"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -493,6 +506,7 @@ exports[`DeliveryStartDate renders with default props 2`] = `
 <label id="deliveryStartDateField"
        class="o-forms-field"
        data-validate="required"
+       for="deliveryStartDate"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/email.spec.js.snap
+++ b/components/__snapshots__/email.spec.js.snap
@@ -4,6 +4,7 @@ exports[`Email with confirmation render a email input for B2B 1`] = `
 <label id="emailField"
        class="o-forms-field"
        data-validate="required,email"
+       for="email"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -35,6 +36,7 @@ exports[`Email with confirmation render a email input for B2B 2`] = `
 <label id="emailField"
        class="o-forms-field"
        data-validate="required,email"
+       for="email"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -66,6 +68,7 @@ exports[`Email with confirmation render a email input with default params 1`] = 
 <label id="emailField"
        class="o-forms-field"
        data-validate="required,email"
+       for="email"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -97,6 +100,7 @@ exports[`Email with confirmation render a email input with default params 2`] = 
 <label id="emailField"
        class="o-forms-field"
        data-validate="required,email"
+       for="email"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -128,6 +132,7 @@ exports[`Email with confirmation render a email input with default value 1`] = `
 <label id="emailField"
        class="o-forms-field"
        data-validate="required,email"
+       for="email"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -159,6 +164,7 @@ exports[`Email with confirmation render a email input with default value 2`] = `
 <label id="emailField"
        class="o-forms-field"
        data-validate="required,email"
+       for="email"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -190,6 +196,7 @@ exports[`Email with confirmation render a email input with disabled fields 1`] =
 <label id="emailField"
        class="o-forms-field"
        data-validate="required,email"
+       for="email"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -222,6 +229,7 @@ exports[`Email with confirmation render a email input with disabled fields 2`] =
 <label id="emailField"
        class="o-forms-field"
        data-validate="required,email"
+       for="email"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -254,6 +262,7 @@ exports[`Email with confirmation render a email input with email error 1`] = `
 <label id="emailField"
        class="o-forms-field"
        data-validate="required,email"
+       for="email"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -285,6 +294,7 @@ exports[`Email with confirmation render a email input with email error 2`] = `
 <label id="emailField"
        class="o-forms-field"
        data-validate="required,email"
+       for="email"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -316,6 +326,7 @@ exports[`Email with confirmation render a email input with given description 1`]
 <label id="emailField"
        class="o-forms-field"
        data-validate="required,email"
+       for="email"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -347,6 +358,7 @@ exports[`Email with confirmation render a email input with given description 2`]
 <label id="emailField"
        class="o-forms-field"
        data-validate="required,email"
+       for="email"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -378,6 +390,7 @@ exports[`Email with confirmation render a email input with read only fields 1`] 
 <label id="emailField"
        class="o-forms-field"
        data-validate="required,email"
+       for="email"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -409,6 +422,7 @@ exports[`Email with confirmation render a email input with read only fields 2`] 
 <label id="emailField"
        class="o-forms-field"
        data-validate="required,email"
+       for="email"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/first-name.spec.js.snap
+++ b/components/__snapshots__/first-name.spec.js.snap
@@ -4,6 +4,7 @@ exports[`First name render a disabled field 1`] = `
 <label id="firstNameField"
        class="o-forms-field"
        data-validate="required"
+       for="firstName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -33,6 +34,7 @@ exports[`First name render a disabled field 2`] = `
 <label id="firstNameField"
        class="o-forms-field"
        data-validate="required"
+       for="firstName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -62,6 +64,7 @@ exports[`First name render a field with default settings 1`] = `
 <label id="firstNameField"
        class="o-forms-field"
        data-validate="required"
+       for="firstName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -90,6 +93,7 @@ exports[`First name render a field with default settings 2`] = `
 <label id="firstNameField"
        class="o-forms-field"
        data-validate="required"
+       for="firstName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -118,6 +122,7 @@ exports[`First name render a field with error 1`] = `
 <label id="firstNameField"
        class="o-forms-field"
        data-validate="required"
+       for="firstName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -146,6 +151,7 @@ exports[`First name render a field with error 2`] = `
 <label id="firstNameField"
        class="o-forms-field"
        data-validate="required"
+       for="firstName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -174,6 +180,7 @@ exports[`First name render a field with value 1`] = `
 <label id="firstNameField"
        class="o-forms-field"
        data-validate="required"
+       for="firstName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -202,6 +209,7 @@ exports[`First name render a field with value 2`] = `
 <label id="firstNameField"
        class="o-forms-field"
        data-validate="required"
+       for="firstName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/industry.spec.js.snap
+++ b/components/__snapshots__/industry.spec.js.snap
@@ -4,6 +4,7 @@ exports[`Industry can render a disable select 1`] = `
 <label id="industryField"
        class="o-forms-field"
        data-validate="required"
+       for="industry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -123,6 +124,7 @@ exports[`Industry can render a disable select 2`] = `
 <label id="industryField"
        class="o-forms-field"
        data-validate="required"
+       for="industry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -242,6 +244,7 @@ exports[`Industry can render an error message 1`] = `
 <label id="industryField"
        class="o-forms-field"
        data-validate="required"
+       for="industry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -360,6 +363,7 @@ exports[`Industry can render an error message 2`] = `
 <label id="industryField"
        class="o-forms-field"
        data-validate="required"
+       for="industry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -478,6 +482,7 @@ exports[`Industry can render an initial selected value 1`] = `
 <label id="industryField"
        class="o-forms-field"
        data-validate="required"
+       for="industry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -598,6 +603,7 @@ exports[`Industry can render an initial selected value 2`] = `
 <label id="industryField"
        class="o-forms-field"
        data-validate="required"
+       for="industry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -718,6 +724,7 @@ exports[`Industry render a select with a label 1`] = `
 <label id="industryField"
        class="o-forms-field"
        data-validate="required"
+       for="industry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -836,6 +843,7 @@ exports[`Industry render a select with a label 2`] = `
 <label id="industryField"
        class="o-forms-field"
        data-validate="required"
+       for="industry"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/job-title.spec.js.snap
+++ b/components/__snapshots__/job-title.spec.js.snap
@@ -4,6 +4,7 @@ exports[`JobTitle can render a disable input 1`] = `
 <label id="jobTitleField"
        class="o-forms-field"
        data-validate="required"
+       for="jobTitle"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -32,6 +33,7 @@ exports[`JobTitle can render a disable input 2`] = `
 <label id="jobTitleField"
        class="o-forms-field"
        data-validate="required"
+       for="jobTitle"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -60,6 +62,7 @@ exports[`JobTitle can render an error message 1`] = `
 <label id="jobTitleField"
        class="o-forms-field"
        data-validate="required"
+       for="jobTitle"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -87,6 +90,7 @@ exports[`JobTitle can render an error message 2`] = `
 <label id="jobTitleField"
        class="o-forms-field"
        data-validate="required"
+       for="jobTitle"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -114,6 +118,7 @@ exports[`JobTitle can render an initial selected value 1`] = `
 <label id="jobTitleField"
        class="o-forms-field"
        data-validate="required"
+       for="jobTitle"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -141,6 +146,7 @@ exports[`JobTitle can render an initial selected value 2`] = `
 <label id="jobTitleField"
        class="o-forms-field"
        data-validate="required"
+       for="jobTitle"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -168,6 +174,7 @@ exports[`JobTitle render a select with a label 1`] = `
 <label id="jobTitleField"
        class="o-forms-field"
        data-validate="required"
+       for="jobTitle"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -195,6 +202,7 @@ exports[`JobTitle render a select with a label 2`] = `
 <label id="jobTitleField"
        class="o-forms-field"
        data-validate="required"
+       for="jobTitle"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/last-name.spec.js.snap
+++ b/components/__snapshots__/last-name.spec.js.snap
@@ -4,6 +4,7 @@ exports[`Last name render a disabled field 1`] = `
 <label id="lastNameField"
        class="o-forms-field"
        data-validate="required"
+       for="lastName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -33,6 +34,7 @@ exports[`Last name render a disabled field 2`] = `
 <label id="lastNameField"
        class="o-forms-field"
        data-validate="required"
+       for="lastName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -62,6 +64,7 @@ exports[`Last name render a field with default error 1`] = `
 <label id="lastNameField"
        class="o-forms-field"
        data-validate="required"
+       for="lastName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -90,6 +93,7 @@ exports[`Last name render a field with default error 2`] = `
 <label id="lastNameField"
        class="o-forms-field"
        data-validate="required"
+       for="lastName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -118,6 +122,7 @@ exports[`Last name render a field with default settings 1`] = `
 <label id="lastNameField"
        class="o-forms-field"
        data-validate="required"
+       for="lastName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -146,6 +151,7 @@ exports[`Last name render a field with default settings 2`] = `
 <label id="lastNameField"
        class="o-forms-field"
        data-validate="required"
+       for="lastName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -174,6 +180,7 @@ exports[`Last name render a field with value 1`] = `
 <label id="lastNameField"
        class="o-forms-field"
        data-validate="required"
+       for="lastName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -202,6 +209,7 @@ exports[`Last name render a field with value 2`] = `
 <label id="lastNameField"
        class="o-forms-field"
        data-validate="required"
+       for="lastName"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/payment-type.spec.js.snap
+++ b/components/__snapshots__/payment-type.spec.js.snap
@@ -8,7 +8,7 @@ exports[`PaymentType render with default props 1`] = `
 >
   <div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard ncf__hidden">
-      <label>
+      <label for="creditcard">
         <input type="radio"
                name="paymentType"
                value="creditcard"
@@ -23,7 +23,7 @@ exports[`PaymentType render with default props 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--paypal ncf__hidden">
-      <label>
+      <label for="paypal">
         <input type="radio"
                name="paymentType"
                value="paypal"
@@ -38,7 +38,7 @@ exports[`PaymentType render with default props 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--directdebit ncf__hidden">
-      <label>
+      <label for="directdebit">
         <input type="radio"
                name="paymentType"
                value="directdebit"
@@ -53,7 +53,7 @@ exports[`PaymentType render with default props 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--applepay ncf__hidden">
-      <label>
+      <label for="applepay">
         <input type="radio"
                name="paymentType"
                value="applepay"
@@ -82,7 +82,7 @@ exports[`PaymentType render with default props 2`] = `
 >
   <div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard ncf__hidden">
-      <label>
+      <label for="creditcard">
         <input type="radio"
                name="paymentType"
                value="creditcard"
@@ -97,7 +97,7 @@ exports[`PaymentType render with default props 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--paypal ncf__hidden">
-      <label>
+      <label for="paypal">
         <input type="radio"
                name="paymentType"
                value="paypal"
@@ -112,7 +112,7 @@ exports[`PaymentType render with default props 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--directdebit ncf__hidden">
-      <label>
+      <label for="directdebit">
         <input type="radio"
                name="paymentType"
                value="directdebit"
@@ -127,7 +127,7 @@ exports[`PaymentType render with default props 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--applepay ncf__hidden">
-      <label>
+      <label for="applepay">
         <input type="radio"
                name="paymentType"
                value="applepay"
@@ -156,7 +156,7 @@ exports[`PaymentType render with enableApplepay 1`] = `
 >
   <div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard ncf__hidden">
-      <label>
+      <label for="creditcard">
         <input type="radio"
                name="paymentType"
                value="creditcard"
@@ -171,7 +171,7 @@ exports[`PaymentType render with enableApplepay 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--paypal ncf__hidden">
-      <label>
+      <label for="paypal">
         <input type="radio"
                name="paymentType"
                value="paypal"
@@ -186,7 +186,7 @@ exports[`PaymentType render with enableApplepay 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--directdebit ncf__hidden">
-      <label>
+      <label for="directdebit">
         <input type="radio"
                name="paymentType"
                value="directdebit"
@@ -201,7 +201,7 @@ exports[`PaymentType render with enableApplepay 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--applepay">
-      <label>
+      <label for="applepay">
         <input type="radio"
                name="paymentType"
                value="applepay"
@@ -230,7 +230,7 @@ exports[`PaymentType render with enableApplepay 2`] = `
 >
   <div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard ncf__hidden">
-      <label>
+      <label for="creditcard">
         <input type="radio"
                name="paymentType"
                value="creditcard"
@@ -245,7 +245,7 @@ exports[`PaymentType render with enableApplepay 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--paypal ncf__hidden">
-      <label>
+      <label for="paypal">
         <input type="radio"
                name="paymentType"
                value="paypal"
@@ -260,7 +260,7 @@ exports[`PaymentType render with enableApplepay 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--directdebit ncf__hidden">
-      <label>
+      <label for="directdebit">
         <input type="radio"
                name="paymentType"
                value="directdebit"
@@ -275,7 +275,7 @@ exports[`PaymentType render with enableApplepay 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--applepay">
-      <label>
+      <label for="applepay">
         <input type="radio"
                name="paymentType"
                value="applepay"
@@ -304,7 +304,7 @@ exports[`PaymentType render with enableCreditcard 1`] = `
 >
   <div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard">
-      <label>
+      <label for="creditcard">
         <input type="radio"
                name="paymentType"
                value="creditcard"
@@ -319,7 +319,7 @@ exports[`PaymentType render with enableCreditcard 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--paypal ncf__hidden">
-      <label>
+      <label for="paypal">
         <input type="radio"
                name="paymentType"
                value="paypal"
@@ -334,7 +334,7 @@ exports[`PaymentType render with enableCreditcard 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--directdebit ncf__hidden">
-      <label>
+      <label for="directdebit">
         <input type="radio"
                name="paymentType"
                value="directdebit"
@@ -349,7 +349,7 @@ exports[`PaymentType render with enableCreditcard 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--applepay ncf__hidden">
-      <label>
+      <label for="applepay">
         <input type="radio"
                name="paymentType"
                value="applepay"
@@ -398,7 +398,7 @@ exports[`PaymentType render with enableCreditcard 2`] = `
 >
   <div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard">
-      <label>
+      <label for="creditcard">
         <input type="radio"
                name="paymentType"
                value="creditcard"
@@ -413,7 +413,7 @@ exports[`PaymentType render with enableCreditcard 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--paypal ncf__hidden">
-      <label>
+      <label for="paypal">
         <input type="radio"
                name="paymentType"
                value="paypal"
@@ -428,7 +428,7 @@ exports[`PaymentType render with enableCreditcard 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--directdebit ncf__hidden">
-      <label>
+      <label for="directdebit">
         <input type="radio"
                name="paymentType"
                value="directdebit"
@@ -443,7 +443,7 @@ exports[`PaymentType render with enableCreditcard 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--applepay ncf__hidden">
-      <label>
+      <label for="applepay">
         <input type="radio"
                name="paymentType"
                value="applepay"
@@ -492,7 +492,7 @@ exports[`PaymentType render with enableDirectdebit 1`] = `
 >
   <div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard ncf__hidden">
-      <label>
+      <label for="creditcard">
         <input type="radio"
                name="paymentType"
                value="creditcard"
@@ -507,7 +507,7 @@ exports[`PaymentType render with enableDirectdebit 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--paypal ncf__hidden">
-      <label>
+      <label for="paypal">
         <input type="radio"
                name="paymentType"
                value="paypal"
@@ -522,7 +522,7 @@ exports[`PaymentType render with enableDirectdebit 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--directdebit">
-      <label>
+      <label for="directdebit">
         <input type="radio"
                name="paymentType"
                value="directdebit"
@@ -537,7 +537,7 @@ exports[`PaymentType render with enableDirectdebit 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--applepay ncf__hidden">
-      <label>
+      <label for="applepay">
         <input type="radio"
                name="paymentType"
                value="applepay"
@@ -625,7 +625,7 @@ exports[`PaymentType render with enableDirectdebit 2`] = `
 >
   <div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard ncf__hidden">
-      <label>
+      <label for="creditcard">
         <input type="radio"
                name="paymentType"
                value="creditcard"
@@ -640,7 +640,7 @@ exports[`PaymentType render with enableDirectdebit 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--paypal ncf__hidden">
-      <label>
+      <label for="paypal">
         <input type="radio"
                name="paymentType"
                value="paypal"
@@ -655,7 +655,7 @@ exports[`PaymentType render with enableDirectdebit 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--directdebit">
-      <label>
+      <label for="directdebit">
         <input type="radio"
                name="paymentType"
                value="directdebit"
@@ -670,7 +670,7 @@ exports[`PaymentType render with enableDirectdebit 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--applepay ncf__hidden">
-      <label>
+      <label for="applepay">
         <input type="radio"
                name="paymentType"
                value="applepay"
@@ -758,7 +758,7 @@ exports[`PaymentType render with enablePaypal 1`] = `
 >
   <div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard ncf__hidden">
-      <label>
+      <label for="creditcard">
         <input type="radio"
                name="paymentType"
                value="creditcard"
@@ -773,7 +773,7 @@ exports[`PaymentType render with enablePaypal 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--paypal">
-      <label>
+      <label for="paypal">
         <input type="radio"
                name="paymentType"
                value="paypal"
@@ -788,7 +788,7 @@ exports[`PaymentType render with enablePaypal 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--directdebit ncf__hidden">
-      <label>
+      <label for="directdebit">
         <input type="radio"
                name="paymentType"
                value="directdebit"
@@ -803,7 +803,7 @@ exports[`PaymentType render with enablePaypal 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--applepay ncf__hidden">
-      <label>
+      <label for="applepay">
         <input type="radio"
                name="paymentType"
                value="applepay"
@@ -832,7 +832,7 @@ exports[`PaymentType render with enablePaypal 2`] = `
 >
   <div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard ncf__hidden">
-      <label>
+      <label for="creditcard">
         <input type="radio"
                name="paymentType"
                value="creditcard"
@@ -847,7 +847,7 @@ exports[`PaymentType render with enablePaypal 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--paypal">
-      <label>
+      <label for="paypal">
         <input type="radio"
                name="paymentType"
                value="paypal"
@@ -862,7 +862,7 @@ exports[`PaymentType render with enablePaypal 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--directdebit ncf__hidden">
-      <label>
+      <label for="directdebit">
         <input type="radio"
                name="paymentType"
                value="directdebit"
@@ -877,7 +877,7 @@ exports[`PaymentType render with enablePaypal 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--applepay ncf__hidden">
-      <label>
+      <label for="applepay">
         <input type="radio"
                name="paymentType"
                value="applepay"
@@ -906,7 +906,7 @@ exports[`PaymentType render with value 1`] = `
 >
   <div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard ncf__hidden">
-      <label>
+      <label for="creditcard">
         <input type="radio"
                name="paymentType"
                value="creditcard"
@@ -921,7 +921,7 @@ exports[`PaymentType render with value 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--paypal ncf__hidden">
-      <label>
+      <label for="paypal">
         <input type="radio"
                name="paymentType"
                value="paypal"
@@ -937,7 +937,7 @@ exports[`PaymentType render with value 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--directdebit ncf__hidden">
-      <label>
+      <label for="directdebit">
         <input type="radio"
                name="paymentType"
                value="directdebit"
@@ -952,7 +952,7 @@ exports[`PaymentType render with value 1`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--applepay ncf__hidden">
-      <label>
+      <label for="applepay">
         <input type="radio"
                name="paymentType"
                value="applepay"
@@ -981,7 +981,7 @@ exports[`PaymentType render with value 2`] = `
 >
   <div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard ncf__hidden">
-      <label>
+      <label for="creditcard">
         <input type="radio"
                name="paymentType"
                value="creditcard"
@@ -996,7 +996,7 @@ exports[`PaymentType render with value 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--paypal ncf__hidden">
-      <label>
+      <label for="paypal">
         <input type="radio"
                name="paymentType"
                value="paypal"
@@ -1012,7 +1012,7 @@ exports[`PaymentType render with value 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--directdebit ncf__hidden">
-      <label>
+      <label for="directdebit">
         <input type="radio"
                name="paymentType"
                value="directdebit"
@@ -1027,7 +1027,7 @@ exports[`PaymentType render with value 2`] = `
       </label>
     </div>
     <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--applepay ncf__hidden">
-      <label>
+      <label for="applepay">
         <input type="radio"
                name="paymentType"
                value="applepay"

--- a/components/__snapshots__/phone.spec.js.snap
+++ b/components/__snapshots__/phone.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Phone render a disabled phone input 1`] = `
 <label id="primaryTelephoneField"
+       for="primaryTelephone"
        class="o-forms-field"
        data-validate="required,number"
 >
@@ -38,6 +39,7 @@ exports[`Phone render a disabled phone input 1`] = `
 
 exports[`Phone render a disabled phone input 2`] = `
 <label id="primaryTelephoneField"
+       for="primaryTelephone"
        class="o-forms-field"
        data-validate="required,number"
 >
@@ -74,6 +76,7 @@ exports[`Phone render a disabled phone input 2`] = `
 
 exports[`Phone render a phone input with a label 1`] = `
 <label id="primaryTelephoneField"
+       for="primaryTelephone"
        class="o-forms-field"
        data-validate="required,number"
 >
@@ -109,6 +112,7 @@ exports[`Phone render a phone input with a label 1`] = `
 
 exports[`Phone render a phone input with a label 2`] = `
 <label id="primaryTelephoneField"
+       for="primaryTelephone"
        class="o-forms-field"
        data-validate="required,number"
 >
@@ -144,6 +148,7 @@ exports[`Phone render a phone input with a label 2`] = `
 
 exports[`Phone render a phone input with a label for B2B 1`] = `
 <label id="primaryTelephoneField"
+       for="primaryTelephone"
        class="o-forms-field"
        data-validate="required,number"
 >
@@ -179,6 +184,7 @@ exports[`Phone render a phone input with a label for B2B 1`] = `
 
 exports[`Phone render a phone input with a label for B2B 2`] = `
 <label id="primaryTelephoneField"
+       for="primaryTelephone"
        class="o-forms-field"
        data-validate="required,number"
 >
@@ -214,6 +220,7 @@ exports[`Phone render a phone input with a label for B2B 2`] = `
 
 exports[`Phone render a phone input with error styling 1`] = `
 <label id="primaryTelephoneField"
+       for="primaryTelephone"
        class="o-forms-field"
        data-validate="required,number"
 >
@@ -249,6 +256,7 @@ exports[`Phone render a phone input with error styling 1`] = `
 
 exports[`Phone render a phone input with error styling 2`] = `
 <label id="primaryTelephoneField"
+       for="primaryTelephone"
        class="o-forms-field"
        data-validate="required,number"
 >

--- a/components/__snapshots__/position.spec.js.snap
+++ b/components/__snapshots__/position.spec.js.snap
@@ -4,6 +4,7 @@ exports[`Position can render a disable select 1`] = `
 <label id="positionField"
        class="o-forms-field"
        data-validate="required"
+       for="position"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -96,6 +97,7 @@ exports[`Position can render a disable select 2`] = `
 <label id="positionField"
        class="o-forms-field"
        data-validate="required"
+       for="position"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -188,6 +190,7 @@ exports[`Position can render an error message 1`] = `
 <label id="positionField"
        class="o-forms-field"
        data-validate="required"
+       for="position"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -279,6 +282,7 @@ exports[`Position can render an error message 2`] = `
 <label id="positionField"
        class="o-forms-field"
        data-validate="required"
+       for="position"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -370,6 +374,7 @@ exports[`Position can render an initial selected value 1`] = `
 <label id="positionField"
        class="o-forms-field"
        data-validate="required"
+       for="position"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -463,6 +468,7 @@ exports[`Position can render an initial selected value 2`] = `
 <label id="positionField"
        class="o-forms-field"
        data-validate="required"
+       for="position"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -556,6 +562,7 @@ exports[`Position render a select with a label 1`] = `
 <label id="positionField"
        class="o-forms-field"
        data-validate="required"
+       for="position"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -647,6 +654,7 @@ exports[`Position render a select with a label 2`] = `
 <label id="positionField"
        class="o-forms-field"
        data-validate="required"
+       for="position"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/province.spec.js.snap
+++ b/components/__snapshots__/province.spec.js.snap
@@ -4,6 +4,7 @@ exports[`Province can apply class to hide the component 1`] = `
 <label id="provinceField"
        class="o-forms-field ncf__hidden"
        data-validate="required"
+       for="province"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -73,6 +74,7 @@ exports[`Province can apply class to hide the component 2`] = `
 <label id="provinceField"
        class="o-forms-field ncf__hidden"
        data-validate="required"
+       for="province"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -142,6 +144,7 @@ exports[`Province can render a disabled select 1`] = `
 <label id="provinceField"
        class="o-forms-field"
        data-validate="required"
+       for="province"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -212,6 +215,7 @@ exports[`Province can render a disabled select 2`] = `
 <label id="provinceField"
        class="o-forms-field"
        data-validate="required"
+       for="province"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -282,6 +286,7 @@ exports[`Province can render an error message 1`] = `
 <label id="provinceField"
        class="o-forms-field"
        data-validate="required"
+       for="province"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -351,6 +356,7 @@ exports[`Province can render an error message 2`] = `
 <label id="provinceField"
        class="o-forms-field"
        data-validate="required"
+       for="province"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -420,6 +426,7 @@ exports[`Province can render an initial selected value 1`] = `
 <label id="provinceField"
        class="o-forms-field"
        data-validate="required"
+       for="province"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -491,6 +498,7 @@ exports[`Province can render an initial selected value 2`] = `
 <label id="provinceField"
        class="o-forms-field"
        data-validate="required"
+       for="province"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -562,6 +570,7 @@ exports[`Province render a select with a label 1`] = `
 <label id="provinceField"
        class="o-forms-field"
        data-validate="required"
+       for="province"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -631,6 +640,7 @@ exports[`Province render a select with a label 2`] = `
 <label id="provinceField"
        class="o-forms-field"
        data-validate="required"
+       for="province"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/responsibility.spec.js.snap
+++ b/components/__snapshots__/responsibility.spec.js.snap
@@ -4,6 +4,7 @@ exports[`Responsibility can render a disable select 1`] = `
 <label id="responsibilityField"
        class="o-forms-field"
        data-validate="required"
+       for="responsibility"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -114,6 +115,7 @@ exports[`Responsibility can render a disable select 2`] = `
 <label id="responsibilityField"
        class="o-forms-field"
        data-validate="required"
+       for="responsibility"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -224,6 +226,7 @@ exports[`Responsibility can render an error message 1`] = `
 <label id="responsibilityField"
        class="o-forms-field"
        data-validate="required"
+       for="responsibility"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -333,6 +336,7 @@ exports[`Responsibility can render an error message 2`] = `
 <label id="responsibilityField"
        class="o-forms-field"
        data-validate="required"
+       for="responsibility"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -442,6 +446,7 @@ exports[`Responsibility can render an initial selected value 1`] = `
 <label id="responsibilityField"
        class="o-forms-field"
        data-validate="required"
+       for="responsibility"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -553,6 +558,7 @@ exports[`Responsibility can render an initial selected value 2`] = `
 <label id="responsibilityField"
        class="o-forms-field"
        data-validate="required"
+       for="responsibility"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -664,6 +670,7 @@ exports[`Responsibility render a select with a label 1`] = `
 <label id="responsibilityField"
        class="o-forms-field"
        data-validate="required"
+       for="responsibility"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -773,6 +780,7 @@ exports[`Responsibility render a select with a label 2`] = `
 <label id="responsibilityField"
        class="o-forms-field"
        data-validate="required"
+       for="responsibility"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/__snapshots__/state.spec.js.snap
+++ b/components/__snapshots__/state.spec.js.snap
@@ -4,6 +4,7 @@ exports[`State can apply class to hide the component 1`] = `
 <label id="stateField"
        class="o-forms-field ncf__hidden"
        data-validate="required"
+       for="state"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -187,6 +188,7 @@ exports[`State can apply class to hide the component 2`] = `
 <label id="stateField"
        class="o-forms-field ncf__hidden"
        data-validate="required"
+       for="state"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -370,6 +372,7 @@ exports[`State can render a disabled select 1`] = `
 <label id="stateField"
        class="o-forms-field"
        data-validate="required"
+       for="state"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -554,6 +557,7 @@ exports[`State can render a disabled select 2`] = `
 <label id="stateField"
        class="o-forms-field"
        data-validate="required"
+       for="state"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -738,6 +742,7 @@ exports[`State can render an error message 1`] = `
 <label id="stateField"
        class="o-forms-field"
        data-validate="required"
+       for="state"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -921,6 +926,7 @@ exports[`State can render an error message 2`] = `
 <label id="stateField"
        class="o-forms-field"
        data-validate="required"
+       for="state"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -1104,6 +1110,7 @@ exports[`State can render an initial selected value 1`] = `
 <label id="stateField"
        class="o-forms-field"
        data-validate="required"
+       for="state"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -1289,6 +1296,7 @@ exports[`State can render an initial selected value 2`] = `
 <label id="stateField"
        class="o-forms-field"
        data-validate="required"
+       for="state"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -1474,6 +1482,7 @@ exports[`State render a select with a label 1`] = `
 <label id="stateField"
        class="o-forms-field"
        data-validate="required"
+       for="state"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -1657,6 +1666,7 @@ exports[`State render a select with a label 2`] = `
 <label id="stateField"
        class="o-forms-field"
        data-validate="required"
+       for="state"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -110,7 +110,7 @@ export function AcceptTerms ({
 	return (
 		<div {...divProps}>
 			<span className={inputWrapperClassName}>
-				<label>
+				<label htmlFor={inputProps.id}>
 					<input {...inputProps} />
 					{ b2bTerms }
 

--- a/components/billing-country.jsx
+++ b/components/billing-country.jsx
@@ -43,7 +43,12 @@ export function BillingCountry ({
 	);
 
 	return (
-		<label id={fieldId} className="o-forms-field" data-validate="required">
+		<label
+			id={fieldId}
+			className="o-forms-field"
+			data-validate="required"
+			htmlFor={inputId}
+		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">Billing Country</span>
 			</span>

--- a/components/billing-postcode.jsx
+++ b/components/billing-postcode.jsx
@@ -30,6 +30,7 @@ export function BillingPostcode ({
 			id={fieldId}
 			className={BillingPostcodeFieldClassNames}
 			data-validate="required"
+			htmlFor={inputId}
 		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">

--- a/components/company-name.jsx
+++ b/components/company-name.jsx
@@ -30,7 +30,12 @@ export function CompanyName ({
 	};
 
 	return (
-		<label id={fieldId} className="o-forms-field" data-validate="required">
+		<label
+			id={fieldId}
+			className="o-forms-field"
+			data-validate="required"
+			htmlFor={inputProps.id}
+		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">Company name</span>
 			</span>

--- a/components/country.jsx
+++ b/components/country.jsx
@@ -45,7 +45,12 @@ export function Country ({
 	);
 
 	return (
-		<label id={fieldId} className="o-forms-field js-unknown-user-field" data-validate="required">
+		<label
+			id={fieldId}
+			className="o-forms-field js-unknown-user-field"
+			data-validate="required"
+			htmlFor={selectProps.id}
+		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">{label}</span>
 			</span>

--- a/components/decision-maker.jsx
+++ b/components/decision-maker.jsx
@@ -45,11 +45,11 @@ export function DecisionMaker ({
 
 			<span className={radioButtonsWrapperClassNames}>
 				<div className="o-forms-input--radio-box__container">
-					<label>
+					<label htmlFor={decisionMakerYesInputProps.id}>
 						<input {...decisionMakerYesInputProps} />
 						<span className="o-forms-input__label" aria-hidden="true">Yes</span>
 					</label>
-					<label>
+					<label htmlFor={decisionMakerNoInputProps.id}>
 						<input {...decisionMakerNoInputProps} />
 						<span className="o-forms-input__label o-forms-input__label--negative" aria-hidden="true">No</span>
 					</label>

--- a/components/delivery-address.jsx
+++ b/components/delivery-address.jsx
@@ -17,7 +17,7 @@ export function DeliveryAddress ({
 
 	return (
 		<div id="deliveryAddressFields" data-validate="required">
-			<label className="o-forms-field">
+			<label className="o-forms-field" htmlFor="deliveryAddressLine1">
 				<span className="o-forms-title">
 					<span className="o-forms-title__main">Address line 1</span>
 				</span>
@@ -36,7 +36,7 @@ export function DeliveryAddress ({
 					/>
 				</span>
 			</label>
-			<label className="o-forms-field o-forms-field--optional">
+			<label className="o-forms-field o-forms-field--optional" htmlFor="deliveryAddressLine2">
 				<span className="o-forms-title">
 					<span className="o-forms-title__main">Address line 2</span>
 				</span>
@@ -53,7 +53,7 @@ export function DeliveryAddress ({
 					/>
 				</span>
 			</label>
-			<label className="o-forms-field o-forms-field--optional">
+			<label className="o-forms-field o-forms-field--optional" htmlFor="deliveryAddressLine3">
 				<span className="o-forms-title">
 					<span className="o-forms-title__main">Address line 3</span>
 				</span>

--- a/components/delivery-city.jsx
+++ b/components/delivery-city.jsx
@@ -14,7 +14,12 @@ export function DeliveryCity ({
 	]);
 
 	return (
-		<label id="deliveryCityField" className="o-forms-field" data-validate="required">
+		<label
+			id="deliveryCityField"
+			className="o-forms-field"
+			data-validate="required"
+			htmlFor="deliveryCity"
+		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">City/town</span>
 			</span>

--- a/components/delivery-county.jsx
+++ b/components/delivery-county.jsx
@@ -19,6 +19,7 @@ export function DeliveryCounty ({
 			id="deliveryCountyField"
 			className="o-forms-field o-forms-field--optional"
 			data-validate="required"
+			htmlFor="deliveryCounty"
 		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">County</span>

--- a/components/delivery-instructions.jsx
+++ b/components/delivery-instructions.jsx
@@ -33,7 +33,12 @@ export function DeliveryInstructions ({
 	};
 
 	return (
-		<label id={fieldId} className="o-forms-field o-forms-field--optional" data-validate="required">
+		<label
+			id={fieldId}
+			className="o-forms-field o-forms-field--optional"
+			data-validate="required"
+			htmlFor={inputId}
+		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">Delivery instructions</span>
 				<span className="o-forms-title__prompt">

--- a/components/delivery-option.jsx
+++ b/components/delivery-option.jsx
@@ -53,7 +53,7 @@ export function DeliveryOption ({
 						const deliveryOptionValue = deliveryOptions[value];
 
 						return (
-							<label key={value} className="ncf__delivery-option__item">
+							<label key={value} className="ncf__delivery-option__item" htmlFor={value}>
 								<input {...inputProps} />
 								<span className="o-forms-input__label ncf__delivery-option__label">
 									<span className="ncf__delivery-option__title">{deliveryOptionValue.title}</span>

--- a/components/delivery-postcode.jsx
+++ b/components/delivery-postcode.jsx
@@ -26,6 +26,7 @@ export function DeliveryPostcode ({
 			id="deliveryPostcodeField"
 			className={deliveryPostcodeFieldClassNames}
 			data-validate="required"
+			htmlFor="deliveryPostcode"
 		>
 
 			<span className="o-forms-title">

--- a/components/delivery-start-date.jsx
+++ b/components/delivery-start-date.jsx
@@ -34,6 +34,7 @@ export function DeliveryStartDate ({
 			id="deliveryStartDateField"
 			className="o-forms-field"
 			data-validate="required"
+			htmlFor={inputProps.id}
 		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">Delivery start date</span>

--- a/components/email.jsx
+++ b/components/email.jsx
@@ -27,6 +27,7 @@ export function Email ({
 			id={fieldId}
 			className="o-forms-field"
 			data-validate="required,email"
+			htmlFor={inputId}
 		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">{labelText}</span>

--- a/components/first-name.jsx
+++ b/components/first-name.jsx
@@ -28,6 +28,7 @@ export function FirstName ({
 			id={fieldId}
 			className="o-forms-field"
 			data-validate="required"
+			htmlFor={inputId}
 		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">{label}</span>

--- a/components/industry.jsx
+++ b/components/industry.jsx
@@ -25,6 +25,7 @@ export function Industry ({
 			id={fieldId}
 			className="o-forms-field"
 			data-validate="required"
+			htmlFor={selectId}
 		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">In which industry do you work?</span>

--- a/components/job-title.jsx
+++ b/components/job-title.jsx
@@ -18,7 +18,12 @@ export function JobTitle ({
 	]);
 
 	return (
-		<label id={fieldId} className="o-forms-field" data-validate="required">
+		<label
+			id={fieldId}
+			className="o-forms-field"
+			data-validate="required"
+			htmlFor={inputId}
+		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">Job title</span>
 			</span>

--- a/components/last-name.jsx
+++ b/components/last-name.jsx
@@ -24,7 +24,12 @@ export function LastName ({
 	]);
 
 	return (
-		<label id={fieldId} className="o-forms-field" data-validate="required">
+		<label
+			id={fieldId}
+			className="o-forms-field"
+			data-validate="required"
+			htmlFor={inputId}
+		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">{label}</span>
 			</span>

--- a/components/payment-type.jsx
+++ b/components/payment-type.jsx
@@ -53,7 +53,7 @@ export function PaymentType ({
 			]);
 			return (
 				<div key={type.id} className={className}>
-					<label>
+					<label htmlFor={inputProps.id}>
 						<input {...inputProps}/>
 						<span className="o-forms-input__label" aria-hidden="true">{type.label}</span>
 					</label>

--- a/components/phone.jsx
+++ b/components/phone.jsx
@@ -22,7 +22,12 @@ export function Phone ({
 	]);
 
 	return (
-		<label id={fieldId} className="o-forms-field" data-validate="required,number">
+		<label
+			id={fieldId}
+			htmlFor={inputId}
+			className="o-forms-field"
+			data-validate="required,number"
+		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">{labelText}</span>
 				<span className="o-forms-title__prompt">5 to 15 characters (numbers only)</span>

--- a/components/position.jsx
+++ b/components/position.jsx
@@ -21,7 +21,12 @@ export function Position ({
 	]);
 
 	return (
-		<label id={fieldId} className="o-forms-field" data-validate="required">
+		<label
+			id={fieldId}
+			className="o-forms-field"
+			data-validate="required"
+			htmlFor={selectId}
+		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">What’s your job position?</span>
 			</span>

--- a/components/province.jsx
+++ b/components/province.jsx
@@ -27,7 +27,12 @@ export function Province ({
 	]);
 
 	return (
-		<label id={fieldId} className={fieldClassNames} data-validate="required">
+		<label
+			id={fieldId}
+			className={fieldClassNames}
+			data-validate="required"
+			htmlFor={selectId}
+		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">{ isBillingProvince ? 'Billing ' : '' }Province</span>
 			</span>

--- a/components/responsibility.jsx
+++ b/components/responsibility.jsx
@@ -20,7 +20,7 @@ export function Responsibility ({
 	]);
 
 	return (
-		<label id={fieldId} className="o-forms-field" data-validate="required">
+		<label id={fieldId} className="o-forms-field" data-validate="required" htmlFor={selectId}>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">Which best describes your job responsibility?</span>
 			</span>

--- a/components/state.jsx
+++ b/components/state.jsx
@@ -30,6 +30,7 @@ export function State ({
 			id={fieldId}
 			className={fieldClassNames}
 			data-validate="required"
+			htmlFor={selectId}
 		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">{ isBillingState ? 'Billing ' : '' }State</span>

--- a/partials/accept-terms.html
+++ b/partials/accept-terms.html
@@ -1,6 +1,6 @@
 <div id="acceptTermsField" class="o-forms-field" data-validate="required,checked" {{#if isSignup}}data-trackable="sign-up-terms"{{/if}}{{#if isRegister}}data-trackable="register-up-terms"{{/if}}>
 	<span class="o-forms-input o-forms-input--checkbox{{#if hasError}} o-forms-input--invalid{{/if}}">
-		<label>
+		<label for="termsAcceptance">
 			<input type="checkbox" id="termsAcceptance" name="termsAcceptance" value="true" data-trackable="field-terms" aria-required="true" required {{#if isChecked}}checked{{/if}} />
 			{{#if isB2b }}
 			<span id="terms-b2b" class="o-forms-input__label">

--- a/partials/billing-country.html
+++ b/partials/billing-country.html
@@ -1,4 +1,4 @@
-<label id="billingCountryField" class="o-forms-field" data-validate="required">
+<label id="billingCountryField" class="o-forms-field" data-validate="required" for="billingCountry">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">Billing Country</span>
 	</span>

--- a/partials/billing-postcode.html
+++ b/partials/billing-postcode.html
@@ -1,6 +1,7 @@
 <label id="billingPostcodeField"
 	class="o-forms-field{{#if isHidden}} ncf__hidden{{/if}}"
-	data-validate="required">
+	data-validate="required"
+	for="billingPostcode">
 
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">

--- a/partials/company-name.html
+++ b/partials/company-name.html
@@ -1,4 +1,4 @@
-<label id="companyNameField" class="o-forms-field" data-validate="required">
+<label id="companyNameField" class="o-forms-field" data-validate="required" for="companyName">
 
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">Company name</span>

--- a/partials/country.html
+++ b/partials/country.html
@@ -1,4 +1,4 @@
-<label id="countryField" class="o-forms-field js-unknown-user-field" data-validate="required">
+<label id="countryField" class="o-forms-field js-unknown-user-field" data-validate="required" for="country">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">Country{{#if isB2b}}/Region{{/if}}</span>
 	</span>

--- a/partials/decision-maker.html
+++ b/partials/decision-maker.html
@@ -5,11 +5,11 @@
 
 	<span class="o-forms-input o-forms-input--radio-box o-forms-input--inline{{#if hasError}} o-forms-input--invalid{{/if}}">
 		<div class="o-forms-input--radio-box__container">
-			<label>
+			<label for="decisionMakerYes">
 				<input type="radio" id="decisionMakerYes" name="decisionMaker" aria-label="Yes" value="yes"{{#ifEquals value "yes"}} checked{{/ifEquals}} />
 				<span class="o-forms-input__label" aria-hidden="true">Yes</span>
 			</label>
-			<label>
+			<label for="decisionMakerNo">
 				<input type="radio" id="decisionMakerNo" name="decisionMaker" aria-label="No" value="no"{{#ifEquals value "no"}} checked{{/ifEquals}} />
 				<span class="o-forms-input__label o-forms-input__label--negative" aria-hidden="true">No</span>
 			</label>

--- a/partials/delivery-address.html
+++ b/partials/delivery-address.html
@@ -1,5 +1,5 @@
 <div id="deliveryAddressFields" data-validate="required">
-	<label class="o-forms-field">
+	<label class="o-forms-field" for="deliveryAddressLine1">
 		<span class="o-forms-title">
 			<span class="o-forms-title__main">Address line 1</span>
 		</span>
@@ -13,7 +13,7 @@
 				value="{{line1}}" />
 		</span>
 	</label>
-	<label class="o-forms-field o-forms-field--optional">
+	<label class="o-forms-field o-forms-field--optional" for="deliveryAddressLine2">
 		<span class="o-forms-title">
 			<span class="o-forms-title__main">Address line 2</span>
 		</span>
@@ -26,7 +26,7 @@
 				value="{{line2}}" />
 		</span>
 	</label>
-	<label class="o-forms-field o-forms-field--optional">
+	<label class="o-forms-field o-forms-field--optional" for="deliveryAddressLine3">
 		<span class="o-forms-title">
 			<span class="o-forms-title__main">Address line 3</span>
 		</span>

--- a/partials/delivery-city.html
+++ b/partials/delivery-city.html
@@ -1,4 +1,4 @@
-<label id="deliveryCityField" class="o-forms-field" data-validate="required">
+<label id="deliveryCityField" class="o-forms-field" data-validate="required" for="deliveryCity">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">City/town</span>
 	</span>

--- a/partials/delivery-county.html
+++ b/partials/delivery-county.html
@@ -1,4 +1,4 @@
-<label id="deliveryCountyField" class="o-forms-field o-forms-field--optional" data-validate="required">
+<label id="deliveryCountyField" class="o-forms-field o-forms-field--optional" data-validate="required" for="deliveryCounty">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">County</span>
 	</span>

--- a/partials/delivery-instructions.html
+++ b/partials/delivery-instructions.html
@@ -1,4 +1,4 @@
-<label id="deliveryInstructionsField" class="o-forms-field o-forms-field--optional" data-validate="required">
+<label id="deliveryInstructionsField" class="o-forms-field o-forms-field--optional" data-validate="required" for="deliveryInstructions">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">Delivery instructions</span>
 		<span class="o-forms-title__prompt">

--- a/partials/delivery-option.html
+++ b/partials/delivery-option.html
@@ -2,7 +2,7 @@
 	<span class="o-forms-input o-forms-input--radio-round">
 		{{#each options}}
 			{{#ifEqualsSome this.value 'PV' 'HD' 'EV'}}
-			<label class="ncf__delivery-option__item">
+			<label class="ncf__delivery-option__item" for="{{this.value}}">
 				<input type="radio" id="{{this.value}}" name="deliveryOption" value="{{this.value}}" class="ncf__delivery-option__input"{{#if this.isSelected}} checked{{/if}}>
 				<span class="o-forms-input__label ncf__delivery-option__label">
 					{{#ifEquals this.value 'PV'}}

--- a/partials/delivery-postcode.html
+++ b/partials/delivery-postcode.html
@@ -1,6 +1,7 @@
 <label id="deliveryPostcodeField"
 	class="o-forms-field{{#if isHidden}} ncf__hidden{{/if}}"
-	data-validate="required">
+	data-validate="required"
+	for="deliveryPostcode">
 
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">

--- a/partials/delivery-start-date.html
+++ b/partials/delivery-start-date.html
@@ -1,4 +1,4 @@
-<label id="deliveryStartDateField" class="o-forms-field" data-validate="required">
+<label id="deliveryStartDateField" class="o-forms-field" data-validate="required" for="deliveryStartDate">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">Delivery start date</span>
 		<span class="o-forms-title__prompt">Earliest available delivery date: {{date}}</span>

--- a/partials/email.html
+++ b/partials/email.html
@@ -1,4 +1,4 @@
-<label id="emailField" class="o-forms-field" data-validate="required,email">
+<label id="emailField" class="o-forms-field" data-validate="required,email" for="email">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">
 			{{#if isB2b}}

--- a/partials/firstname.html
+++ b/partials/firstname.html
@@ -1,7 +1,8 @@
 <label
 	id="firstNameField"
 	class="o-forms-field"
-	data-validate="required">
+	data-validate="required"
+	for="firstName">
 
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">First name</span>

--- a/partials/industry.html
+++ b/partials/industry.html
@@ -1,4 +1,4 @@
-<label id="industryField" class="o-forms-field" data-validate="required">
+<label id="industryField" class="o-forms-field" data-validate="required" for="industry">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">In which industry do you work?</span>
 	</span>

--- a/partials/job-title.html
+++ b/partials/job-title.html
@@ -1,4 +1,4 @@
-<label id="jobTitleField" class="o-forms-field" data-validate="required">
+<label id="jobTitleField" class="o-forms-field" data-validate="required" for="jobTitle">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">Job title</span>
 	</span>

--- a/partials/lastname.html
+++ b/partials/lastname.html
@@ -1,4 +1,9 @@
-<label id="lastNameField" class="o-forms-field" data-validate="required">
+<label
+	id="lastNameField"
+	class="o-forms-field"
+	data-validate="required"
+	for="lastName"
+>
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">Last name</span>
 	</span>

--- a/partials/payment-type.html
+++ b/partials/payment-type.html
@@ -15,27 +15,27 @@
 <div id="paymentTypeField" class="o-forms-field">
 	<div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
 		<div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard{{#unless enableCreditcard }} ncf__hidden{{/unless}}">
-			<label>
+			<label for="creditcard">
 				<input type="radio" name="paymentType" value="creditcard" id="creditcard" aria-label="Credit / Debit Card"{{#ifEquals value "creditcard"}} checked{{/ifEquals}} />
 				<span class="o-forms-input__label" aria-hidden="true">Credit / Debit Card</span>
 			</label>
 		</div>
 
 		<div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--paypal{{#unless enablePaypal }} ncf__hidden{{/unless}}">
-			<label>
+			<label for="paypal">
 				<input type="radio" name="paymentType" value="paypal" id="paypal" aria-label="PayPal"{{#ifEquals value "paypal"}} checked{{/ifEquals}} />
 				<span class="o-forms-input__label" aria-hidden="true">PayPal</span>
 			</label>
 		</div>
 
 		<div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--directdebit{{#unless enableDirectdebit }} ncf__hidden{{/unless}}">
-			<label>
+			<label for="directdebit">
 				<input type="radio" name="paymentType" value="directdebit" id="directdebit" aria-label="Direct Debit"{{#ifEquals value "directdebit"}} checked{{/ifEquals}} />
 				<span class="o-forms-input__label" aria-hidden="true">Direct Debit</span>
 			</label>
 		</div>
 		<div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--applepay{{#unless enableApplepay }} ncf__hidden{{/unless}}">
-			<label>
+			<label for="applepay">
 				<input type="radio" name="paymentType" value="applepay" id="applepay" aria-label="Apple Pay"{{#ifEquals value "applepay"}} checked{{/ifEquals}} />
 				<span class="o-forms-input__label" aria-hidden="true">Apple Pay</span>
 			</label>

--- a/partials/phone.html
+++ b/partials/phone.html
@@ -1,4 +1,9 @@
-<label id="primaryTelephoneField" class="o-forms-field" data-validate="required,number">
+<label
+	id="primaryTelephoneField"
+	for="primaryTelephone"
+	class="o-forms-field"
+	data-validate="required,number"
+>
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">
 			{{#if isB2b}}

--- a/partials/position.html
+++ b/partials/position.html
@@ -1,4 +1,4 @@
-<label id="positionField" class="o-forms-field" data-validate="required">
+<label id="positionField" class="o-forms-field" data-validate="required" for="position">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">What’s your job position?</span>
 	</span>

--- a/partials/province.html
+++ b/partials/province.html
@@ -1,4 +1,4 @@
-<label id="provinceField" class="o-forms-field{{#if isHidden}} ncf__hidden{{/if}}" data-validate="required">
+<label id="provinceField" class="o-forms-field{{#if isHidden}} ncf__hidden{{/if}}" data-validate="required" for="province">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">{{#if isBillingProvince}}Billing {{/if}}Province</span>
 	</span>

--- a/partials/responsibility.html
+++ b/partials/responsibility.html
@@ -1,4 +1,4 @@
-<label id="responsibilityField" class="o-forms-field" data-validate="required">
+<label id="responsibilityField" class="o-forms-field" data-validate="required" for="responsibility">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">Which best describes your job responsibility?</span>
 	</span>

--- a/partials/state.html
+++ b/partials/state.html
@@ -1,4 +1,4 @@
-<label id="stateField" class="o-forms-field{{#if isHidden}} ncf__hidden{{/if}}" data-validate="required">
+<label id="stateField" class="o-forms-field{{#if isHidden}} ncf__hidden{{/if}}" data-validate="required" for="state">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">{{#if isBillingState}}Billing {{/if}}State</span>
 	</span>


### PR DESCRIPTION
In the origami change some of the labels lost their for attributes as
the label now wraps the input. This ensures that all label tags have a
appropriate `for` attribute which points at the input they are
targeting. Having both a `for` attribute and wrapping the input is
valid.

This was primarily picked up due to the end to end tests trying to find
the input for a radio button to click.