### PR TITLE
Ensure origami form inputs have titles

### DIFF
--- a/components/__snapshots__/delivery-option.spec.js.snap
+++ b/components/__snapshots__/delivery-option.spec.js.snap
@@ -18,7 +18,7 @@ exports[`DeliveryOption renders with a context of being single 1`] = `
              checked
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Paper vouchers
         </span>
         <div class="ncf__delivery-option__description">
@@ -36,7 +36,7 @@ exports[`DeliveryOption renders with a context of being single 1`] = `
              class="ncf__delivery-option__input"
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Home delivery
         </span>
         <div class="ncf__delivery-option__description">
@@ -54,7 +54,7 @@ exports[`DeliveryOption renders with a context of being single 1`] = `
              class="ncf__delivery-option__input"
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Electronic vouchers
         </span>
         <div class="ncf__delivery-option__description">
@@ -84,7 +84,7 @@ exports[`DeliveryOption renders with a context of being single 2`] = `
              checked
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Paper vouchers
         </span>
         <div class="ncf__delivery-option__description">
@@ -102,7 +102,7 @@ exports[`DeliveryOption renders with a context of being single 2`] = `
              class="ncf__delivery-option__input"
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Home delivery
         </span>
         <div class="ncf__delivery-option__description">
@@ -120,7 +120,7 @@ exports[`DeliveryOption renders with a context of being single 2`] = `
              class="ncf__delivery-option__input"
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Electronic vouchers
         </span>
         <div class="ncf__delivery-option__description">
@@ -150,7 +150,7 @@ exports[`DeliveryOption renders with minimum mandatory props 1`] = `
              checked
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Paper vouchers
         </span>
         <div class="ncf__delivery-option__description">
@@ -168,7 +168,7 @@ exports[`DeliveryOption renders with minimum mandatory props 1`] = `
              class="ncf__delivery-option__input"
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Home delivery
         </span>
         <div class="ncf__delivery-option__description">
@@ -186,7 +186,7 @@ exports[`DeliveryOption renders with minimum mandatory props 1`] = `
              class="ncf__delivery-option__input"
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Electronic vouchers
         </span>
         <div class="ncf__delivery-option__description">
@@ -216,7 +216,7 @@ exports[`DeliveryOption renders with minimum mandatory props 2`] = `
              checked
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Paper vouchers
         </span>
         <div class="ncf__delivery-option__description">
@@ -234,7 +234,7 @@ exports[`DeliveryOption renders with minimum mandatory props 2`] = `
              class="ncf__delivery-option__input"
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Home delivery
         </span>
         <div class="ncf__delivery-option__description">
@@ -252,7 +252,7 @@ exports[`DeliveryOption renders with minimum mandatory props 2`] = `
              class="ncf__delivery-option__input"
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Electronic vouchers
         </span>
         <div class="ncf__delivery-option__description">
@@ -282,7 +282,7 @@ exports[`DeliveryOption renders without unrecognised delivery options 1`] = `
              checked
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Paper vouchers
         </span>
         <div class="ncf__delivery-option__description">
@@ -300,7 +300,7 @@ exports[`DeliveryOption renders without unrecognised delivery options 1`] = `
              class="ncf__delivery-option__input"
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Home delivery
         </span>
         <div class="ncf__delivery-option__description">
@@ -318,7 +318,7 @@ exports[`DeliveryOption renders without unrecognised delivery options 1`] = `
              class="ncf__delivery-option__input"
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Electronic vouchers
         </span>
         <div class="ncf__delivery-option__description">
@@ -348,7 +348,7 @@ exports[`DeliveryOption renders without unrecognised delivery options 2`] = `
              checked
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Paper vouchers
         </span>
         <div class="ncf__delivery-option__description">
@@ -366,7 +366,7 @@ exports[`DeliveryOption renders without unrecognised delivery options 2`] = `
              class="ncf__delivery-option__input"
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Home delivery
         </span>
         <div class="ncf__delivery-option__description">
@@ -384,7 +384,7 @@ exports[`DeliveryOption renders without unrecognised delivery options 2`] = `
              class="ncf__delivery-option__input"
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
-        <span class="ncf__delivery-option__title">
+        <span class="ncf__delivery-option__title o-forms-title__main">
           Electronic vouchers
         </span>
         <div class="ncf__delivery-option__description">

--- a/components/delivery-option.jsx
+++ b/components/delivery-option.jsx
@@ -56,7 +56,7 @@ export function DeliveryOption ({
 							<label key={value} className="ncf__delivery-option__item" htmlFor={value}>
 								<input {...inputProps} />
 								<span className="o-forms-input__label ncf__delivery-option__label">
-									<span className="ncf__delivery-option__title">{deliveryOptionValue.title}</span>
+									<span className="ncf__delivery-option__title o-forms-title__main">{deliveryOptionValue.title}</span>
 									<div className="ncf__delivery-option__description">{deliveryOptionValue.description}</div>
 								</span>
 							</label>

--- a/partials/delivery-option.html
+++ b/partials/delivery-option.html
@@ -6,21 +6,21 @@
 				<input type="radio" id="{{this.value}}" name="deliveryOption" value="{{this.value}}" class="ncf__delivery-option__input"{{#if this.isSelected}} checked{{/if}}>
 				<span class="o-forms-input__label ncf__delivery-option__label">
 					{{#ifEquals this.value 'PV'}}
-					<span class="ncf__delivery-option__title">Paper vouchers</span>
+					<span class="ncf__delivery-option__title o-forms-title__main">Paper vouchers</span>
 					<div class="ncf__delivery-option__description">
 						13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
 					</div>
 					{{/ifEquals}}
 
 					{{#ifEquals this.value 'HD'}}
-					<span class="ncf__delivery-option__title">Home delivery</span>
+					<span class="ncf__delivery-option__title o-forms-title__main">Home delivery</span>
 					<div class="ncf__delivery-option__description">
 						Free delivery to your home or office before 7am.
 					</div>
 					{{/ifEquals}}
 
 					{{#ifEquals this.value 'EV'}}
-					<span class="ncf__delivery-option__title">Electronic vouchers</span>
+					<span class="ncf__delivery-option__title o-forms-title__main">Electronic vouchers</span>
 					<div class="ncf__delivery-option__description">
 						Delivered via email and card, redeemable at retailers nationwide.
 					</div>


### PR DESCRIPTION
This is needed for the validation code to work. Without it the form
can't be submitted if there is a validation error. 🐿 v2.12.5
