### PR TITLE
Update delivery options to no longer use ifEqualsSome 🐿 v2.12.5

### DIFF
--- a/components/delivery-option.jsx
+++ b/components/delivery-option.jsx
@@ -36,8 +36,8 @@ export function DeliveryOption ({
 		>
 			<span className="o-forms-input o-forms-input--radio-round">
 				{
-					options.map(({value, isSelected}) => {
-						if (!Object.keys(deliveryOptions).includes(value)) {
+					options.map(({ value, isValidDeliveryOption, isSelected}) => {
+						if (!isValidDeliveryOption) {
 							return null;
 						}
 

--- a/components/delivery-option.spec.js
+++ b/components/delivery-option.spec.js
@@ -16,15 +16,18 @@ describe('DeliveryOption', () => {
 			options: [
 				{
 					value: 'PV',
-					isSelected: true
+					isSelected: true,
+					isValidDeliveryOption: true
 				},
 				{
 					value: 'HD',
-					isSelected: false
+					isSelected: false,
+					isValidDeliveryOption: true
 				},
 				{
 					value: 'EV',
-					isSelected: false
+					isSelected: false,
+					isValidDeliveryOption: true
 				}
 			]
 		};
@@ -37,15 +40,18 @@ describe('DeliveryOption', () => {
 			options: [
 				{
 					value: 'PV',
-					isSelected: true
+					isSelected: true,
+					isValidDeliveryOption: true
 				},
 				{
 					value: 'HD',
-					isSelected: false
+					isSelected: false,
+					isValidDeliveryOption: true
 				},
 				{
 					value: 'EV',
-					isSelected: false
+					isSelected: false,
+					isValidDeliveryOption: true
 				}
 			],
 			isSingle: true
@@ -59,19 +65,23 @@ describe('DeliveryOption', () => {
 			options: [
 				{
 					value: 'PV',
-					isSelected: true
+					isSelected: true,
+					isValidDeliveryOption: true
 				},
 				{
 					value: 'HD',
-					isSelected: false
+					isSelected: false,
+					isValidDeliveryOption: true
 				},
 				{
 					value: 'FOOBAR',
-					isSelected: false
+					isSelected: false,
+					isValidDeliveryOption: false
 				},
 				{
 					value: 'EV',
-					isSelected: false
+					isSelected: false,
+					isValidDeliveryOption: true
 				}
 			]
 		};

--- a/demos/data.json
+++ b/demos/data.json
@@ -107,14 +107,17 @@
       "isSingle": true,
       "options": [
         {
-          "value": "PV"
+          "value": "PV",
+          "isValidDeliveryOption": true
         },
         {
           "value": "HD",
-          "isSelected": true
+          "isSelected": true,
+          "isValidDeliveryOption": true
         },
         {
-          "value": "EV"
+          "value": "EV",
+          "isValidDeliveryOption": true
         }
       ]
     }

--- a/partials/delivery-option.html
+++ b/partials/delivery-option.html
@@ -1,7 +1,7 @@
 <div id="deliveryOptionField" class="o-forms-field ncf__delivery-option{{#if isSingle}} ncf__delivery-option--single{{/if}}" role="group" aria-label="Delivery options">
 	<span class="o-forms-input o-forms-input--radio-round">
 		{{#each options}}
-			{{#ifEqualsSome this.value 'PV' 'HD' 'EV'}}
+			{{#if this.isValidDeliveryOption}}
 			<label class="ncf__delivery-option__item" for="{{this.value}}">
 				<input type="radio" id="{{this.value}}" name="deliveryOption" value="{{this.value}}" class="ncf__delivery-option__input"{{#if this.isSelected}} checked{{/if}}>
 				<span class="o-forms-input__label ncf__delivery-option__label">
@@ -27,7 +27,7 @@
 					{{/ifEquals}}
 				</span>
 			</label>
-			{{/ifEqualsSome}}
+			{{/if}}
 		{{/each}}
 	</span>
 </div>

--- a/test/partials/delivery-option.spec.js
+++ b/test/partials/delivery-option.spec.js
@@ -5,6 +5,7 @@ const {
 
 let context = {};
 const TITLE_SELECTOR = '.ncf__delivery-option__title';
+const isValidDeliveryOption = true;
 
 describe('delivery-option', () => {
 	before(async () => {
@@ -17,15 +18,15 @@ describe('delivery-option', () => {
 	});
 
 	it('should draw a single option', () => {
-		const $ = context.template({ options: [{ value: 'HD' }]});
+		const $ = context.template({ options: [{ value: 'HD', isValidDeliveryOption }]});
 		expect($('input').length).to.equal(1);
 	});
 
 	it('should draw multiple options', () => {
 		const $ = context.template({ options: [
-			{ value: 'HD' },
-			{ value: 'PV' },
-			{ value: 'EV' }
+			{ value: 'HD', isValidDeliveryOption },
+			{ value: 'PV', isValidDeliveryOption },
+			{ value: 'EV', isValidDeliveryOption }
 		]});
 		expect($('input').length).to.equal(3);
 	});
@@ -39,7 +40,8 @@ describe('delivery-option', () => {
 		it('should show the correct title copy', () => {
 			const value = 'PV';
 			const $ = context.template({ options: [{
-				value
+				value,
+				isValidDeliveryOption
 			}]});
 			expect($(TITLE_SELECTOR).text()).to.equal('Paper vouchers');
 		});
@@ -49,7 +51,8 @@ describe('delivery-option', () => {
 		it('should show the correct title copy', () => {
 			const value = 'HD';
 			const $ = context.template({ options: [{
-				value
+				value,
+				isValidDeliveryOption
 			}]});
 			expect($(TITLE_SELECTOR).text()).to.contain('Home delivery');
 		});
@@ -59,7 +62,8 @@ describe('delivery-option', () => {
 		it('should show the correct title copy', () => {
 			const value = 'EV';
 			const $ = context.template({ options: [{
-				value
+				value,
+				isValidDeliveryOption
 			}]});
 			expect($(TITLE_SELECTOR).text()).to.contain('Electronic vouchers');
 		});
@@ -67,14 +71,14 @@ describe('delivery-option', () => {
 
 	it('should populate the value', () => {
 		const value = 'PV';
-		const $ = context.template({ options: [{ value }]});
+		const $ = context.template({ options: [{ value, isValidDeliveryOption }]});
 		expect($('input').attr('id')).to.equal(value);
 		expect($('input').attr('value')).to.equal(value);
 	});
 
 	it('should select the correct radio button', () => {
-		const option1 = { value: 'PV' };
-		const option2 = { value: 'HD', isSelected: true };
+		const option1 = { value: 'PV', isValidDeliveryOption };
+		const option2 = { value: 'HD', isValidDeliveryOption, isSelected: true };
 		const $ = context.template({ options: [option1, option2]});
 		expect($('input[checked]').attr('value')).to.equal(option2.value);
 	});


### PR DESCRIPTION
### Description

As part of the Page Kit migration for `next-subscribe`, I got an error about `ifEqualsSome` not being a registered helper anymore. The only way to get the same functionality (thanks to HBS) was to move that logic to the controller and pass it in.

Ideally, the way it was done in the JSX file was the correct way. Realistically though, the HBS and JSX needs to live in parallel for a little while still so I've had to make them both function the same way to make the tests work.

[Ticket](https://trello.com/c/cMKwZJ0y/1739-next-subscribe-go-live-with-pagekit-migration)

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Tests** written for new or updated for existing functionality
- [x] **Demos** updated to use this change