### PR TITLE
Merge pull request #378 from Financial-Times/rb-loader-title

### DIFF
--- a/test/utils/loader.spec.js
+++ b/test/utils/loader.spec.js
@@ -17,6 +17,7 @@ describe('Loader', () => {
 				remove: sandbox.stub()
 			},
 			focus: sandbox.stub(),
+			insertBefore: sandbox.stub(),
 			removeAttribute: sandbox.stub()
 		};
 		documentStub = {
@@ -24,6 +25,7 @@ describe('Loader', () => {
 			querySelector: sandbox.stub(),
 			removeEventListener: sandbox.stub()
 		};
+		global.document.createElement = sandbox.stub().returns(elementStub);
 	});
 
 	afterEach(() => {
@@ -60,6 +62,11 @@ describe('Loader', () => {
 		});
 
 		describe('setContent', () => {
+			it('should create the title element if it doesn\'t exist yet', () => {
+				loader.$loaderContentTitle = null;
+				loader.setContent({ title: 'Hooray!'});
+				expect(elementStub.insertBefore.calledWith(elementStub)).to.be.true;
+			});
 			it('should set the title of the partial', () => {
 				loader.setContent({ title: 'Hooray!'});
 				expect(elementStub.innerHTML).to.equal('Hooray!');

--- a/utils/loader.js
+++ b/utils/loader.js
@@ -46,6 +46,11 @@ class Loader {
 	 */
 	setContent ({ title, content}) {
 		if (title) {
+			if (!this.$loaderContentTitle) {
+				this.$loaderContentTitle = document.createElement('div');
+				this.$loaderContentTitle.classList.add('ncf__loader__content__title');
+				this.$loaderContent.insertBefore(this.$loaderContentTitle, this.$loaderContentMain);
+			}
 			this.$loaderContentTitle.innerHTML = title;
 		}
 		if (content) {


### PR DESCRIPTION
### Description

Found this as part of the Page Kit work on `next-subscribe`. The code previously assumed that the title element would be there and then blow up when it wasn't.

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Tests** written for new or updated for existing functionality