### PR TITLE
fix: allow optional usage of browser validation 🐿 v2.12.5

### DIFF
--- a/utils/validation.js
+++ b/utils/validation.js
@@ -7,9 +7,9 @@ class Validation {
 	 * Set up the Validation utility
 	 * @param {Boolean} mutePromptBeforeLeaving (default: false) Whether to prompt the user before leaving if there have been changes in any of the fields.
 	 */
-	constructor ({ mutePromptBeforeLeaving } = {}) {
+	constructor ({ mutePromptBeforeLeaving, useBrowserValidation } = {}) {
 		this.$form = document.querySelector('form.ncf');
-		this.oForms = OForms.init(this.$form);
+		this.oForms = OForms.init(this.$form, { useBrowserValidation });
 		this.$requiredEls = this.oForms.formInputs
 			.filter(({input}) => input.type !== 'hidden' && input.required);
 		this.formValid = false;


### PR DESCRIPTION
### Description

When using the Validation util, it initialises OForms for our form and that attaches an event listener to the submit handler which runs the custom validation and then submits the form programmatically upon success.

This breaks our journey on next-subscribe as we don't want to submit the form immediately - we need to wait for the iframe completion.
