### PR TITLE
Fix iframe overflow issue 🐿 v2.12.5

### DIFF
--- a/components/__snapshots__/payment-type.spec.js.snap
+++ b/components/__snapshots__/payment-type.spec.js.snap
@@ -380,7 +380,7 @@ exports[`PaymentType render with enableCreditcard 1`] = `
               frameborder="0"
               allowtransparency="true"
               class="z_hppm_iframe"
-              style="display:block"
+              style="display:block;width:100%"
       >
       </iframe>
     </div>
@@ -474,7 +474,7 @@ exports[`PaymentType render with enableCreditcard 2`] = `
               frameborder="0"
               allowtransparency="true"
               class="z_hppm_iframe"
-              style="display:block"
+              style="display:block;width:100%"
       >
       </iframe>
     </div>
@@ -607,7 +607,7 @@ exports[`PaymentType render with enableDirectdebit 1`] = `
               frameborder="0"
               allowtransparency="true"
               class="z_hppm_iframe"
-              style="display:block"
+              style="display:block;width:100%"
       >
       </iframe>
     </div>
@@ -740,7 +740,7 @@ exports[`PaymentType render with enableDirectdebit 2`] = `
               frameborder="0"
               allowtransparency="true"
               class="z_hppm_iframe"
-              style="display:block"
+              style="display:block;width:100%"
       >
       </iframe>
     </div>

--- a/components/payment-type.jsx
+++ b/components/payment-type.jsx
@@ -86,7 +86,7 @@ export function PaymentType ({
 				<div className="ncf__zuora-payment-overlay ncf__hidden"></div>
 				<div id="zuora_payment" className="ncf__zuora-payment">
 					<iframe id="z_hppm_iframe" title="Zuora Payment" overflow="visible" scrolling="no" frameBorder="0" allowtransparency="true"
-						className="z_hppm_iframe" style={{display: 'block'}}>
+						className="z_hppm_iframe" style={{display: 'block', width: "100%"}}>
 					</iframe>
 				</div>
 				<script src="https://static.zuora.com/Resources/libs/hosted/1.3.1/zuora-min.js"></script>

--- a/partials/payment-type.html
+++ b/partials/payment-type.html
@@ -66,7 +66,7 @@
 		<!-- ID "zuora_payment" is used by Zuora to target the iframe -->
 		<div id="zuora_payment" class="ncf__zuora-payment">
 			<iframe id="z_hppm_iframe" title="Zuora Payment" overflow="visible" scrolling="no" frameborder="0" allowtransparency="true"
-				class="z_hppm_iframe" style="display:block">
+				class="z_hppm_iframe" style="display:block;width:100%">
 			</iframe>
 		</div>
 		<script src="https://static.zuora.com/Resources/libs/hosted/1.3.1/zuora-min.js"></script>


### PR DESCRIPTION
Prevent the iframe in `next-subscribe` from overflowing.

<img width="589" alt="image" src="https://user-images.githubusercontent.com/7748470/72913446-0d10fe80-3d35-11ea-9c12-2503918b5a5a.png">
