### PR TITLE
Add way of showing loader on inital render of payment types

### DIFF
--- a/components/__snapshots__/payment-type.spec.js.snap
+++ b/components/__snapshots__/payment-type.spec.js.snap
@@ -1,5 +1,191 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PaymentType can initialise with the loader visible 1`] = `
+<div class="ncf__security-seal">
+</div>
+<div id="paymentTypeField"
+     class="o-forms-field"
+>
+  <div class="ncf__loader is-visible ncf__loader--element"
+       role="dialog"
+       aria-labelledby="loader-aria-label"
+       aria-describedby="loader-aria-description"
+       aria-modal="true"
+       tabindex="1"
+  >
+    <div class="ncf__loader__content">
+      <div class="ncf__loader__content__title"
+           id="loader-aria-label"
+      >
+        Loading payment form...
+      </div>
+      <div class="ncf__loader__content__main"
+           id="loader-aria-description"
+      >
+      </div>
+    </div>
+  </div>
+  <div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard ncf__hidden">
+      <label for="creditcard">
+        <input type="radio"
+               name="paymentType"
+               value="creditcard"
+               id="creditcard"
+               aria-label="Credit / Debit Card"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Credit / Debit Card
+        </span>
+      </label>
+    </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--paypal ncf__hidden">
+      <label for="paypal">
+        <input type="radio"
+               name="paymentType"
+               value="paypal"
+               id="paypal"
+               aria-label="PayPal"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          PayPal
+        </span>
+      </label>
+    </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--directdebit ncf__hidden">
+      <label for="directdebit">
+        <input type="radio"
+               name="paymentType"
+               value="directdebit"
+               id="directdebit"
+               aria-label="Direct Debit"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Direct Debit
+        </span>
+      </label>
+    </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--applepay ncf__hidden">
+      <label for="applepay">
+        <input type="radio"
+               name="paymentType"
+               value="applepay"
+               id="applepay"
+               aria-label="Apple Pay"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Apple Pay
+        </span>
+      </label>
+    </div>
+  </div>
+  <div class="o-forms-input__error">
+    Please enter a valid payment type
+  </div>
+</div>
+`;
+
+exports[`PaymentType can initialise with the loader visible 2`] = `
+<div class="ncf__security-seal">
+</div>
+<div id="paymentTypeField"
+     class="o-forms-field"
+>
+  <div class="ncf__loader is-visible ncf__loader--element"
+       role="dialog"
+       aria-labelledby="loader-aria-label"
+       aria-describedby="loader-aria-description"
+       aria-modal="true"
+       tabindex="1"
+  >
+    <div class="ncf__loader__content">
+      <div class="ncf__loader__content__title"
+           id="loader-aria-label"
+      >
+        Loading payment form...
+      </div>
+      <div class="ncf__loader__content__main"
+           id="loader-aria-description"
+      >
+      </div>
+    </div>
+  </div>
+  <div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard ncf__hidden">
+      <label for="creditcard">
+        <input type="radio"
+               name="paymentType"
+               value="creditcard"
+               id="creditcard"
+               aria-label="Credit / Debit Card"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Credit / Debit Card
+        </span>
+      </label>
+    </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--paypal ncf__hidden">
+      <label for="paypal">
+        <input type="radio"
+               name="paymentType"
+               value="paypal"
+               id="paypal"
+               aria-label="PayPal"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          PayPal
+        </span>
+      </label>
+    </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--directdebit ncf__hidden">
+      <label for="directdebit">
+        <input type="radio"
+               name="paymentType"
+               value="directdebit"
+               id="directdebit"
+               aria-label="Direct Debit"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Direct Debit
+        </span>
+      </label>
+    </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--applepay ncf__hidden">
+      <label for="applepay">
+        <input type="radio"
+               name="paymentType"
+               value="applepay"
+               id="applepay"
+               aria-label="Apple Pay"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Apple Pay
+        </span>
+      </label>
+    </div>
+  </div>
+  <div class="o-forms-input__error">
+    Please enter a valid payment type
+  </div>
+</div>
+`;
+
 exports[`PaymentType render with default props 1`] = `
 <div class="ncf__security-seal">
 </div>

--- a/components/error-page.spec.js
+++ b/components/error-page.spec.js
@@ -3,7 +3,6 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { ErrorPage } from './index';
 import { expectToRenderAs } from '../test-jest/helpers/expect-to-render-as';
 import { fetchPartialAsString } from '../test-jest/helpers/fetch-hbs-as-string';
-import { registerPartial, unregisterPartial } from '../test/helpers';
 
 const CHILDREN = <div id="children">Children</div>;
 const CHILDREN_STRING = renderToStaticMarkup(CHILDREN);
@@ -14,12 +13,7 @@ expect.extend(expectToRenderAs);
 
 describe('ErrorPage', () => {
 	beforeAll(async () => {
-		registerPartial('@partial-block', CHILDREN_STRING);
-		context.template = await fetchPartialAsString('error-page.html');
-	});
-
-	afterAll(() => {
-		unregisterPartial('@partial-block');
+		context.template = await fetchPartialAsString('error-page.html', CHILDREN_STRING);
 	});
 
 	it('renders with default props', () => {

--- a/components/loader.jsx
+++ b/components/loader.jsx
@@ -6,6 +6,7 @@ export function Loader ({
 	children,
 	showLoader,
 	title,
+	inElement,
 }) {
 	const label = title ? (
 		<div className="ncf__loader__content__title" id="loader-aria-label">{title}</div>
@@ -15,7 +16,8 @@ export function Loader ({
 	const className = classNames([
 		'ncf__loader',
 		{ 'is-visible': showLoader },
-		{ 'ncf__hidden': !showLoader }
+		{ 'ncf__hidden': !showLoader },
+		{ 'ncf__loader--element': inElement }
 	]);
 	const props = {
 		className,
@@ -44,5 +46,6 @@ Loader.propTypes = {
 		PropTypes.node
 	]),
 	showLoader: PropTypes.bool,
-	title: PropTypes.string
+	title: PropTypes.string,
+	inElement: PropTypes.bool
 };

--- a/components/loader.spec.js
+++ b/components/loader.spec.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Loader } from './index';
-import { registerPartial, unregisterPartial } from '../test/helpers.js';
 import { expectToRenderAs } from '../test-jest/helpers/expect-to-render-as';
 import { fetchPartialAsString } from '../test-jest/helpers/fetch-hbs-as-string';
 
@@ -12,12 +11,7 @@ expect.extend(expectToRenderAs);
 
 describe('Loader', () => {
 	beforeAll(async () => {
-		registerPartial('@partial-block', CHILDREN_STRING);
-		context.template = await fetchPartialAsString('loader.html');
-	});
-
-	afterAll(() => {
-		unregisterPartial('@partial-block');
+		context.template = await fetchPartialAsString('loader.html', CHILDREN_STRING);
 	});
 
 	it('renders with default props', () => {

--- a/components/payment-type.jsx
+++ b/components/payment-type.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { Loader } from './loader';
 
 export function PaymentType ({
 	enableApplepay = false,
 	enableCreditcard = false,
 	enableDirectdebit = false,
 	enablePaypal = false,
+	showLoaderOnInit = false,
 	fieldId = 'paymentTypeField',
 	inputId = 'paymentType',
 	value
@@ -94,10 +96,17 @@ export function PaymentType ({
 		);
 	};
 
+	const createLoaderOnInit = () => {
+		return showLoaderOnInit && (
+			<Loader inElement={true} showLoader={true} title="Loading payment form..." />
+		);
+	}
+
 	return (
 		<React.Fragment>
 			{createSecuritySeal()}
 			<div id={fieldId} className="o-forms-field">
+				{createLoaderOnInit()}
 				<div className="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
 					{createPaymentTypes()}
 				</div>
@@ -117,6 +126,7 @@ PaymentType.propTypes = {
 	enableCreditcard: PropTypes.bool,
 	enableDirectdebit: PropTypes.bool,
 	enablePaypal: PropTypes.bool,
+	showLoaderOnInit: PropTypes.bool,
 	fieldId: PropTypes.string,
 	inputId: PropTypes.string,
 	value: PropTypes.string

--- a/components/payment-type.spec.js
+++ b/components/payment-type.spec.js
@@ -57,4 +57,12 @@ describe('PaymentType', () => {
 
 		expect(PaymentType).toRenderAs(context, props);
 	});
+
+	it('can initialise with the loader visible', () => {
+		const props = {
+			showLoaderOnInit: true
+		};
+
+		expect(PaymentType).toRenderAs(context, props);
+	});
 });

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -381,6 +381,7 @@ A full screen loading overlay.
 
 + `showLoader`: boolean - Whether to show the loader by default/on page load.
 + `title`: string - The title of the message shown underneath the loading spinner.
++ `inElement`: boolean - Whether to style this to be contained within an element.
 
 ### Inline Partials
 

--- a/partials/loader.html
+++ b/partials/loader.html
@@ -1,4 +1,4 @@
-<div class="ncf__loader {{#if showLoader}}is-visible{{else}}ncf__hidden{{/if}}"
+<div class="ncf__loader {{#if showLoader}}is-visible{{else}}ncf__hidden{{/if}}{{#if inElement}} ncf__loader--element{{/if}}"
 	role="dialog" aria-labelledby="loader-aria-label" aria-describedby="loader-aria-description"
 	aria-modal="true" {{#if showLoader}}tabindex="1"{{/if}}>
 	<div class="ncf__loader__content">

--- a/partials/payment-type.html
+++ b/partials/payment-type.html
@@ -13,6 +13,9 @@
 </div>
 
 <div id="paymentTypeField" class="o-forms-field">
+	{{#if showLoaderOnInit}}
+		{{> n-conversion-forms/partials/loader inElement=true showLoader=true title="Loading payment form..." }}
+	{{/if}}
 	<div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
 		<div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard{{#unless enableCreditcard }} ncf__hidden{{/unless}}">
 			<label for="creditcard">

--- a/test-jest/helpers/fetch-hbs-as-string.js
+++ b/test-jest/helpers/fetch-hbs-as-string.js
@@ -1,15 +1,21 @@
 const fs = require('fs');
 const cheerio = require('cheerio');
 const promisify = require('util').promisify;
-const Handlebars = require('@financial-times/n-handlebars').handlebars;
+const Handlebars = require('@financial-times/n-handlebars').standalone;
 
 const readFile = promisify(fs.readFile);
 const PARTIAL_DIR = __dirname + '/../../partials/';
 
-const handlebars = Handlebars();
-
 const fetchPartial = async (name, returnString = false) => {
+	const hbsStandalone = await Handlebars({
+		directory: '../../',
+		partialsDir: './partials'
+	});
+	const handlebars = hbsStandalone.handlebars;
+
 	let file = await readFile(PARTIAL_DIR + name, 'utf8');
+	// We need to replace any internal references to ncf partials.
+	file = file.replace(/\{\{> n-conversion-forms\/partials\//gm, '{{> ');
 	// HACK ALERT: this is necessary to make testing @partial-block work. It does mean that any test where
 	//  a @partial-block helper isn't registered will blow up, but that will just have to be worked around
 	//  by always registering it - even with an empty value if necessary.

--- a/test-jest/helpers/fetch-hbs-as-string.js
+++ b/test-jest/helpers/fetch-hbs-as-string.js
@@ -6,7 +6,7 @@ const Handlebars = require('@financial-times/n-handlebars').standalone;
 const readFile = promisify(fs.readFile);
 const PARTIAL_DIR = __dirname + '/../../partials/';
 
-const fetchPartial = async (name, returnString = false) => {
+const fetchPartial = async (name, returnString = false, partialBlockString = '') => {
 	const hbsStandalone = await Handlebars({
 		directory: '../../',
 		partialsDir: './partials'
@@ -21,6 +21,7 @@ const fetchPartial = async (name, returnString = false) => {
 	//  by always registering it - even with an empty value if necessary.
 	//  We need to use the `#if` around the partial block to make using that in a template optional.
 	file = file.replace(/{{#if @partial-block}}([\s\S]*){{\/if}}/gm, '$1');
+	file = file.replace(/{{> @partial-block\s?}}/gm, partialBlockString);
 	const template = handlebars.compile(file);
 	if (returnString) {
 		return (context) => template(context);
@@ -28,7 +29,7 @@ const fetchPartial = async (name, returnString = false) => {
 	return (context) => cheerio.load(template(context));
 };
 
-const fetchPartialAsString = async (name) => fetchPartial(name, true);
+const fetchPartialAsString = async (name, partialBlockString) => fetchPartial(name, true, partialBlockString);
 
 module.exports = {
 	fetchPartialAsString

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -32,13 +32,14 @@ const unregisterHelper = name => {
 	return handlebars.unregisterHelper(name);
 };
 
-const fetchPartial = async (name, returnString = false) => {
+const fetchPartial = async (name, returnString = false, partialBlockString = '') => {
 	let file = await readFile(PARTIAL_DIR + name, 'utf8');
 	// HACK ALERT: this is necessary to make testing @partial-block work. It does mean that any test where
 	//  a @partial-block helper isn't registered will blow up, but that will just have to be worked around
 	//  by always registering it - even with an empty value if necessary.
 	//  We need to use the `#if` around the partial block to make using that in a template optional.
 	file = file.replace(/{{#if @partial-block}}([\s\S]*){{\/if}}/gm, '$1');
+	file = file.replace(/{{> @partial-block\s?}}/gm, partialBlockString);
 	const template = handlebars.compile(file);
 	if (returnString) {
 		return (context) => template(context);

--- a/test/partials/error-page.spec.js
+++ b/test/partials/error-page.spec.js
@@ -1,21 +1,12 @@
 const { expect } = require('chai');
-const {
-	registerPartial,
-	unregisterPartial,
-	fetchPartial,
-} = require('../helpers');
+const { fetchPartial } = require('../helpers');
 
 let context = {};
 
 describe('error page template', () => {
 
 	before(async () => {
-		registerPartial('@partial-block', '<div>Foo Bar</div>');
-		context.template = await fetchPartial('error-page.html');
-	});
-
-	after(() => {
-		unregisterPartial('@partial-block');
+		context.template = await fetchPartial('error-page.html', false, '<div>Foo Bar</div>');
 	});
 
 	it('should display an error icon', () => {
@@ -60,7 +51,7 @@ describe('error page template', () => {
 	});
 
 	it('should allow content in the partial', () => {
-		const $ = context.template();
+		const $ = context.template({});
 		expect($('.ncf__error-page__content').html().trim()).to.equal('<div>Foo Bar</div>');
 	});
 

--- a/test/partials/loader.spec.js
+++ b/test/partials/loader.spec.js
@@ -1,21 +1,12 @@
 const { expect } = require('chai');
-const {
-	registerPartial,
-	unregisterPartial,
-	fetchPartial,
-} = require('../helpers');
+const { fetchPartial } = require('../helpers');
 
 let context = {};
 
 describe('loader template', () => {
 
 	before(async () => {
-		registerPartial('@partial-block', '<div>Foo Bar</div>');
-		context.template = await fetchPartial('loader.html');
-	});
-
-	after(() => {
-		unregisterPartial('@partial-block');
+		context.template = await fetchPartial('loader.html', false, '<div>Foo Bar</div>');
 	});
 
 	it('should have the loader element', () => {

--- a/utils/loader.js
+++ b/utils/loader.js
@@ -119,8 +119,14 @@ class Loader {
 	 * @param {Object} content Content for the loader in standard format
 	 */
 	showOnElement (element, content) {
-		const loader = new DOMParser().parseFromString(this.template(content), 'text/html');
-		element.appendChild(loader.querySelector('.ncf__loader'));
+		const existingLoader = element.querySelector('.ncf__loader');
+		const loader = new DOMParser().parseFromString(this.template(content), 'text/html').querySelector('.ncf__loader');
+
+		if (!existingLoader) {
+			element.appendChild(loader);
+		} else {
+			existingLoader.innerHTML = loader;
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Description

We need to have a way of rendering a loading overlay on top of the payment types while the Zuora iframe config is fetched so as to avoid users on slow connections to submit forms without the payment information being entered.

[Ticket](https://financialtimes.atlassian.net/jira/software/projects/AC/boards/971?selectedIssue=AC-66)

### Screenshots

<img width="552" alt="1580299922" src="https://user-images.githubusercontent.com/708296/73364029-b742d600-42a1-11ea-82c8-8244a2670008.png">

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality