### PR TITLE
Bug fix shows validation message

### DIFF
--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`AcceptTerms renders appropriately if a registration 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="register-up-terms"
 >
@@ -45,7 +45,7 @@ exports[`AcceptTerms renders appropriately if a registration 1`] = `
 
 exports[`AcceptTerms renders appropriately if a registration 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="register-up-terms"
 >
@@ -88,7 +88,7 @@ exports[`AcceptTerms renders appropriately if a registration 2`] = `
 
 exports[`AcceptTerms renders appropriately if a signup 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
@@ -156,7 +156,7 @@ exports[`AcceptTerms renders appropriately if a signup 1`] = `
 
 exports[`AcceptTerms renders appropriately if a signup 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
@@ -224,7 +224,7 @@ exports[`AcceptTerms renders appropriately if a signup 2`] = `
 
 exports[`AcceptTerms renders appropriately if a signup and has special terms 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
@@ -297,7 +297,7 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 1`]
 
 exports[`AcceptTerms renders appropriately if a signup and has special terms 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
@@ -370,7 +370,7 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 2`]
 
 exports[`AcceptTerms renders appropriately if a signup for the print product 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
@@ -427,7 +427,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product 1`]
 
 exports[`AcceptTerms renders appropriately if a signup for the print product 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
@@ -484,7 +484,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product 2`]
 
 exports[`AcceptTerms renders appropriately if a signup for the print product and is embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
@@ -541,7 +541,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
 
 exports[`AcceptTerms renders appropriately if a signup for the print product and is embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
@@ -598,7 +598,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
 
 exports[`AcceptTerms renders appropriately if a signup for the print product and is not embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
@@ -655,7 +655,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
 
 exports[`AcceptTerms renders appropriately if a signup for the print product and is not embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
@@ -712,7 +712,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
@@ -780,7 +780,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
@@ -848,7 +848,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product and is embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
@@ -916,7 +916,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product and is embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
@@ -984,7 +984,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product and is not embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
@@ -1052,7 +1052,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product and is not embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
@@ -1120,7 +1120,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
 
 exports[`AcceptTerms renders appropriately if input is checked 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1163,7 +1163,7 @@ exports[`AcceptTerms renders appropriately if input is checked 1`] = `
 
 exports[`AcceptTerms renders appropriately if input is checked 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1206,7 +1206,7 @@ exports[`AcceptTerms renders appropriately if input is checked 2`] = `
 
 exports[`AcceptTerms renders appropriately if is B2B 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1239,7 +1239,7 @@ exports[`AcceptTerms renders appropriately if is B2B 1`] = `
 
 exports[`AcceptTerms renders appropriately if is B2B 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1272,7 +1272,7 @@ exports[`AcceptTerms renders appropriately if is B2B 2`] = `
 
 exports[`AcceptTerms renders appropriately if is corporate signup 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1323,7 +1323,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup 1`] = `
 
 exports[`AcceptTerms renders appropriately if is corporate signup 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1374,7 +1374,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup 2`] = `
 
 exports[`AcceptTerms renders appropriately if is corporate signup and not trial 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1425,7 +1425,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup and not trial 
 
 exports[`AcceptTerms renders appropriately if is corporate signup and not trial 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1476,7 +1476,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup and not trial 
 
 exports[`AcceptTerms renders appropriately if is corporate signup and trial 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1530,7 +1530,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup and trial 1`] 
 
 exports[`AcceptTerms renders appropriately if is corporate signup and trial 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1584,7 +1584,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup and trial 2`] 
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1626,7 +1626,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1668,7 +1668,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and custom age restriction is provided 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1710,7 +1710,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and custom age restriction is provided 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1752,7 +1752,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and is embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1794,7 +1794,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and is embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1836,7 +1836,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and is not embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1878,7 +1878,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and is not embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1920,7 +1920,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
 
 exports[`AcceptTerms renders appropriately if is transition 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -1987,7 +1987,7 @@ exports[`AcceptTerms renders appropriately if is transition 1`] = `
 
 exports[`AcceptTerms renders appropriately if is transition 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -2054,7 +2054,7 @@ exports[`AcceptTerms renders appropriately if is transition 2`] = `
 
 exports[`AcceptTerms renders appropriately if is transition with transition type of immediate 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -2121,7 +2121,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
 
 exports[`AcceptTerms renders appropriately if is transition with transition type of immediate 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -2188,7 +2188,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
 
 exports[`AcceptTerms renders appropriately if is transition with transition type other than immediate 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -2255,7 +2255,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
 
 exports[`AcceptTerms renders appropriately if is transition with transition type other than immediate 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -2322,7 +2322,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
 
 exports[`AcceptTerms renders with an error 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -2364,7 +2364,7 @@ exports[`AcceptTerms renders with an error 1`] = `
 
 exports[`AcceptTerms renders with an error 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -2406,7 +2406,7 @@ exports[`AcceptTerms renders with an error 2`] = `
 
 exports[`AcceptTerms renders with default props 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">
@@ -2448,7 +2448,7 @@ exports[`AcceptTerms renders with default props 1`] = `
 
 exports[`AcceptTerms renders with default props 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
   <span class="o-forms-title n-ui-hide">

--- a/components/__snapshots__/country.spec.js.snap
+++ b/components/__snapshots__/country.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Country renders with default props 1`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field"
+       class="o-forms-field js-unknown-user-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -797,7 +797,7 @@ exports[`Country renders with default props 1`] = `
 
 exports[`Country renders with default props 2`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field"
+       class="o-forms-field js-unknown-user-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -1592,7 +1592,7 @@ exports[`Country renders with default props 2`] = `
 
 exports[`Country renders with hasError 1`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field"
+       class="o-forms-field js-unknown-user-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -2387,7 +2387,7 @@ exports[`Country renders with hasError 1`] = `
 
 exports[`Country renders with hasError 2`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field"
+       class="o-forms-field js-unknown-user-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -3182,7 +3182,7 @@ exports[`Country renders with hasError 2`] = `
 
 exports[`Country renders with isB2b 1`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field"
+       class="o-forms-field js-unknown-user-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -3977,7 +3977,7 @@ exports[`Country renders with isB2b 1`] = `
 
 exports[`Country renders with isB2b 2`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field"
+       class="o-forms-field js-unknown-user-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -4772,7 +4772,7 @@ exports[`Country renders with isB2b 2`] = `
 
 exports[`Country renders with isDisabled 1`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field"
+       class="o-forms-field js-unknown-user-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -5568,7 +5568,7 @@ exports[`Country renders with isDisabled 1`] = `
 
 exports[`Country renders with isDisabled 2`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field"
+       class="o-forms-field js-unknown-user-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -6364,7 +6364,7 @@ exports[`Country renders with isDisabled 2`] = `
 
 exports[`Country renders with large filterList 1`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field"
+       class="o-forms-field js-unknown-user-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -6453,7 +6453,7 @@ exports[`Country renders with large filterList 1`] = `
 
 exports[`Country renders with large filterList 2`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field"
+       class="o-forms-field js-unknown-user-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -6542,7 +6542,7 @@ exports[`Country renders with large filterList 2`] = `
 
 exports[`Country renders with small filterList 1`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field"
+       class="o-forms-field js-unknown-user-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -6574,7 +6574,7 @@ exports[`Country renders with small filterList 1`] = `
 
 exports[`Country renders with small filterList 2`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field"
+       class="o-forms-field js-unknown-user-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -6606,7 +6606,7 @@ exports[`Country renders with small filterList 2`] = `
 
 exports[`Country renders with value 1`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field"
+       class="o-forms-field js-unknown-user-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -7403,7 +7403,7 @@ exports[`Country renders with value 1`] = `
 
 exports[`Country renders with value 2`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field"
+       class="o-forms-field js-unknown-user-field ncf__validation-error"
        data-validate="required"
        for="country"
 >

--- a/components/__snapshots__/delivery-address.spec.js.snap
+++ b/components/__snapshots__/delivery-address.spec.js.snap
@@ -23,6 +23,9 @@ exports[`DeliveryAddress renders default props 1`] = `
              required
              value
       >
+      <span class="o-forms-input__error">
+        Please enter a valid address
+      </span>
     </span>
   </label>
   <label class="o-forms-field o-forms-field--optional"
@@ -89,6 +92,9 @@ exports[`DeliveryAddress renders default props 2`] = `
              required
              value
       >
+      <span class="o-forms-input__error">
+        Please enter a valid address
+      </span>
     </span>
   </label>
   <label class="o-forms-field o-forms-field--optional"
@@ -155,6 +161,9 @@ exports[`DeliveryAddress renders with an error 1`] = `
              required
              value
       >
+      <span class="o-forms-input__error">
+        Please enter a valid address
+      </span>
     </span>
   </label>
   <label class="o-forms-field o-forms-field--optional"
@@ -221,6 +230,9 @@ exports[`DeliveryAddress renders with an error 2`] = `
              required
              value
       >
+      <span class="o-forms-input__error">
+        Please enter a valid address
+      </span>
     </span>
   </label>
   <label class="o-forms-field o-forms-field--optional"
@@ -287,6 +299,9 @@ exports[`DeliveryAddress renders with custom line 1 value 1`] = `
              required
              value="Line 1 text"
       >
+      <span class="o-forms-input__error">
+        Please enter a valid address
+      </span>
     </span>
   </label>
   <label class="o-forms-field o-forms-field--optional"
@@ -353,6 +368,9 @@ exports[`DeliveryAddress renders with custom line 1 value 2`] = `
              required
              value="Line 1 text"
       >
+      <span class="o-forms-input__error">
+        Please enter a valid address
+      </span>
     </span>
   </label>
   <label class="o-forms-field o-forms-field--optional"
@@ -419,6 +437,9 @@ exports[`DeliveryAddress renders with custom line 2 value 1`] = `
              required
              value
       >
+      <span class="o-forms-input__error">
+        Please enter a valid address
+      </span>
     </span>
   </label>
   <label class="o-forms-field o-forms-field--optional"
@@ -485,6 +506,9 @@ exports[`DeliveryAddress renders with custom line 2 value 2`] = `
              required
              value
       >
+      <span class="o-forms-input__error">
+        Please enter a valid address
+      </span>
     </span>
   </label>
   <label class="o-forms-field o-forms-field--optional"
@@ -551,6 +575,9 @@ exports[`DeliveryAddress renders with custom line 3 value 1`] = `
              required
              value
       >
+      <span class="o-forms-input__error">
+        Please enter a valid address
+      </span>
     </span>
   </label>
   <label class="o-forms-field o-forms-field--optional"
@@ -617,6 +644,9 @@ exports[`DeliveryAddress renders with custom line 3 value 2`] = `
              required
              value
       >
+      <span class="o-forms-input__error">
+        Please enter a valid address
+      </span>
     </span>
   </label>
   <label class="o-forms-field o-forms-field--optional"
@@ -684,6 +714,9 @@ exports[`DeliveryAddress renders with disabled input elements 1`] = `
              disabled
              value
       >
+      <span class="o-forms-input__error">
+        Please enter a valid address
+      </span>
     </span>
   </label>
   <label class="o-forms-field o-forms-field--optional"
@@ -753,6 +786,9 @@ exports[`DeliveryAddress renders with disabled input elements 2`] = `
              disabled
              value
       >
+      <span class="o-forms-input__error">
+        Please enter a valid address
+      </span>
     </span>
   </label>
   <label class="o-forms-field o-forms-field--optional"

--- a/components/__snapshots__/delivery-address.spec.js.snap
+++ b/components/__snapshots__/delivery-address.spec.js.snap
@@ -4,7 +4,7 @@ exports[`DeliveryAddress renders default props 1`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field"
+  <label class="o-forms-field ncf__validation-error"
          for="deliveryAddressLine1"
   >
     <span class="o-forms-title">
@@ -73,7 +73,7 @@ exports[`DeliveryAddress renders default props 2`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field"
+  <label class="o-forms-field ncf__validation-error"
          for="deliveryAddressLine1"
   >
     <span class="o-forms-title">
@@ -142,7 +142,7 @@ exports[`DeliveryAddress renders with an error 1`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field"
+  <label class="o-forms-field ncf__validation-error"
          for="deliveryAddressLine1"
   >
     <span class="o-forms-title">
@@ -211,7 +211,7 @@ exports[`DeliveryAddress renders with an error 2`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field"
+  <label class="o-forms-field ncf__validation-error"
          for="deliveryAddressLine1"
   >
     <span class="o-forms-title">
@@ -280,7 +280,7 @@ exports[`DeliveryAddress renders with custom line 1 value 1`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field"
+  <label class="o-forms-field ncf__validation-error"
          for="deliveryAddressLine1"
   >
     <span class="o-forms-title">
@@ -349,7 +349,7 @@ exports[`DeliveryAddress renders with custom line 1 value 2`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field"
+  <label class="o-forms-field ncf__validation-error"
          for="deliveryAddressLine1"
   >
     <span class="o-forms-title">
@@ -418,7 +418,7 @@ exports[`DeliveryAddress renders with custom line 2 value 1`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field"
+  <label class="o-forms-field ncf__validation-error"
          for="deliveryAddressLine1"
   >
     <span class="o-forms-title">
@@ -487,7 +487,7 @@ exports[`DeliveryAddress renders with custom line 2 value 2`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field"
+  <label class="o-forms-field ncf__validation-error"
          for="deliveryAddressLine1"
   >
     <span class="o-forms-title">
@@ -556,7 +556,7 @@ exports[`DeliveryAddress renders with custom line 3 value 1`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field"
+  <label class="o-forms-field ncf__validation-error"
          for="deliveryAddressLine1"
   >
     <span class="o-forms-title">
@@ -625,7 +625,7 @@ exports[`DeliveryAddress renders with custom line 3 value 2`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field"
+  <label class="o-forms-field ncf__validation-error"
          for="deliveryAddressLine1"
   >
     <span class="o-forms-title">
@@ -694,7 +694,7 @@ exports[`DeliveryAddress renders with disabled input elements 1`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field"
+  <label class="o-forms-field ncf__validation-error"
          for="deliveryAddressLine1"
   >
     <span class="o-forms-title">
@@ -766,7 +766,7 @@ exports[`DeliveryAddress renders with disabled input elements 2`] = `
 <div id="deliveryAddressFields"
      data-validate="required"
 >
-  <label class="o-forms-field"
+  <label class="o-forms-field ncf__validation-error"
          for="deliveryAddressLine1"
   >
     <span class="o-forms-title">

--- a/components/__snapshots__/delivery-city.spec.js.snap
+++ b/components/__snapshots__/delivery-city.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DeliveryCity renders with a custom value 1`] = `
 <label id="deliveryCityField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryCity"
 >
@@ -31,7 +31,7 @@ exports[`DeliveryCity renders with a custom value 1`] = `
 
 exports[`DeliveryCity renders with a custom value 2`] = `
 <label id="deliveryCityField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryCity"
 >
@@ -60,7 +60,7 @@ exports[`DeliveryCity renders with a custom value 2`] = `
 
 exports[`DeliveryCity renders with a disabled input element 1`] = `
 <label id="deliveryCityField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryCity"
 >
@@ -90,7 +90,7 @@ exports[`DeliveryCity renders with a disabled input element 1`] = `
 
 exports[`DeliveryCity renders with a disabled input element 2`] = `
 <label id="deliveryCityField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryCity"
 >
@@ -120,7 +120,7 @@ exports[`DeliveryCity renders with a disabled input element 2`] = `
 
 exports[`DeliveryCity renders with an error 1`] = `
 <label id="deliveryCityField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryCity"
 >
@@ -149,7 +149,7 @@ exports[`DeliveryCity renders with an error 1`] = `
 
 exports[`DeliveryCity renders with an error 2`] = `
 <label id="deliveryCityField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryCity"
 >
@@ -178,7 +178,7 @@ exports[`DeliveryCity renders with an error 2`] = `
 
 exports[`DeliveryCity renders with default props 1`] = `
 <label id="deliveryCityField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryCity"
 >
@@ -207,7 +207,7 @@ exports[`DeliveryCity renders with default props 1`] = `
 
 exports[`DeliveryCity renders with default props 2`] = `
 <label id="deliveryCityField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryCity"
 >

--- a/components/__snapshots__/delivery-city.spec.js.snap
+++ b/components/__snapshots__/delivery-city.spec.js.snap
@@ -22,6 +22,9 @@ exports[`DeliveryCity renders with a custom value 1`] = `
            required
            value="foobar"
     >
+    <span class="o-forms-input__error">
+      Please enter a valid city or town
+    </span>
   </span>
 </label>
 `;
@@ -48,6 +51,9 @@ exports[`DeliveryCity renders with a custom value 2`] = `
            required
            value="foobar"
     >
+    <span class="o-forms-input__error">
+      Please enter a valid city or town
+    </span>
   </span>
 </label>
 `;
@@ -75,6 +81,9 @@ exports[`DeliveryCity renders with a disabled input element 1`] = `
            disabled
            value
     >
+    <span class="o-forms-input__error">
+      Please enter a valid city or town
+    </span>
   </span>
 </label>
 `;
@@ -102,6 +111,9 @@ exports[`DeliveryCity renders with a disabled input element 2`] = `
            disabled
            value
     >
+    <span class="o-forms-input__error">
+      Please enter a valid city or town
+    </span>
   </span>
 </label>
 `;
@@ -128,6 +140,9 @@ exports[`DeliveryCity renders with an error 1`] = `
            required
            value
     >
+    <span class="o-forms-input__error">
+      Please enter a valid city or town
+    </span>
   </span>
 </label>
 `;
@@ -154,6 +169,9 @@ exports[`DeliveryCity renders with an error 2`] = `
            required
            value
     >
+    <span class="o-forms-input__error">
+      Please enter a valid city or town
+    </span>
   </span>
 </label>
 `;
@@ -180,6 +198,9 @@ exports[`DeliveryCity renders with default props 1`] = `
            required
            value
     >
+    <span class="o-forms-input__error">
+      Please enter a valid city or town
+    </span>
   </span>
 </label>
 `;
@@ -206,6 +227,9 @@ exports[`DeliveryCity renders with default props 2`] = `
            required
            value
     >
+    <span class="o-forms-input__error">
+      Please enter a valid city or town
+    </span>
   </span>
 </label>
 `;

--- a/components/__snapshots__/delivery-start-date.spec.js.snap
+++ b/components/__snapshots__/delivery-start-date.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DeliveryStartDate renders with a custom date 1`] = `
 <label id="deliveryStartDateField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryStartDate"
 >
@@ -41,7 +41,7 @@ exports[`DeliveryStartDate renders with a custom date 1`] = `
 
 exports[`DeliveryStartDate renders with a custom date 2`] = `
 <label id="deliveryStartDateField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryStartDate"
 >
@@ -80,7 +80,7 @@ exports[`DeliveryStartDate renders with a custom date 2`] = `
 
 exports[`DeliveryStartDate renders with a custom input max value 1`] = `
 <label id="deliveryStartDateField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryStartDate"
 >
@@ -119,7 +119,7 @@ exports[`DeliveryStartDate renders with a custom input max value 1`] = `
 
 exports[`DeliveryStartDate renders with a custom input max value 2`] = `
 <label id="deliveryStartDateField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryStartDate"
 >
@@ -158,7 +158,7 @@ exports[`DeliveryStartDate renders with a custom input max value 2`] = `
 
 exports[`DeliveryStartDate renders with a custom input min value 1`] = `
 <label id="deliveryStartDateField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryStartDate"
 >
@@ -197,7 +197,7 @@ exports[`DeliveryStartDate renders with a custom input min value 1`] = `
 
 exports[`DeliveryStartDate renders with a custom input min value 2`] = `
 <label id="deliveryStartDateField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryStartDate"
 >
@@ -236,7 +236,7 @@ exports[`DeliveryStartDate renders with a custom input min value 2`] = `
 
 exports[`DeliveryStartDate renders with a custom input value 1`] = `
 <label id="deliveryStartDateField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryStartDate"
 >
@@ -274,7 +274,7 @@ exports[`DeliveryStartDate renders with a custom input value 1`] = `
 
 exports[`DeliveryStartDate renders with a custom input value 2`] = `
 <label id="deliveryStartDateField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryStartDate"
 >
@@ -312,7 +312,7 @@ exports[`DeliveryStartDate renders with a custom input value 2`] = `
 
 exports[`DeliveryStartDate renders with a disabled input 1`] = `
 <label id="deliveryStartDateField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryStartDate"
 >
@@ -351,7 +351,7 @@ exports[`DeliveryStartDate renders with a disabled input 1`] = `
 
 exports[`DeliveryStartDate renders with a disabled input 2`] = `
 <label id="deliveryStartDateField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryStartDate"
 >
@@ -390,7 +390,7 @@ exports[`DeliveryStartDate renders with a disabled input 2`] = `
 
 exports[`DeliveryStartDate renders with an error 1`] = `
 <label id="deliveryStartDateField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryStartDate"
 >
@@ -428,7 +428,7 @@ exports[`DeliveryStartDate renders with an error 1`] = `
 
 exports[`DeliveryStartDate renders with an error 2`] = `
 <label id="deliveryStartDateField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryStartDate"
 >
@@ -466,7 +466,7 @@ exports[`DeliveryStartDate renders with an error 2`] = `
 
 exports[`DeliveryStartDate renders with default props 1`] = `
 <label id="deliveryStartDateField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryStartDate"
 >
@@ -504,7 +504,7 @@ exports[`DeliveryStartDate renders with default props 1`] = `
 
 exports[`DeliveryStartDate renders with default props 2`] = `
 <label id="deliveryStartDateField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="deliveryStartDate"
 >

--- a/components/__snapshots__/email.spec.js.snap
+++ b/components/__snapshots__/email.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Email with confirmation render a email input for B2B 1`] = `
 <label id="emailField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,email"
        for="email"
 >
@@ -34,7 +34,7 @@ exports[`Email with confirmation render a email input for B2B 1`] = `
 
 exports[`Email with confirmation render a email input for B2B 2`] = `
 <label id="emailField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,email"
        for="email"
 >
@@ -66,7 +66,7 @@ exports[`Email with confirmation render a email input for B2B 2`] = `
 
 exports[`Email with confirmation render a email input with default params 1`] = `
 <label id="emailField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,email"
        for="email"
 >
@@ -98,7 +98,7 @@ exports[`Email with confirmation render a email input with default params 1`] = 
 
 exports[`Email with confirmation render a email input with default params 2`] = `
 <label id="emailField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,email"
        for="email"
 >
@@ -130,7 +130,7 @@ exports[`Email with confirmation render a email input with default params 2`] = 
 
 exports[`Email with confirmation render a email input with default value 1`] = `
 <label id="emailField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,email"
        for="email"
 >
@@ -162,7 +162,7 @@ exports[`Email with confirmation render a email input with default value 1`] = `
 
 exports[`Email with confirmation render a email input with default value 2`] = `
 <label id="emailField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,email"
        for="email"
 >
@@ -194,7 +194,7 @@ exports[`Email with confirmation render a email input with default value 2`] = `
 
 exports[`Email with confirmation render a email input with disabled fields 1`] = `
 <label id="emailField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,email"
        for="email"
 >
@@ -227,7 +227,7 @@ exports[`Email with confirmation render a email input with disabled fields 1`] =
 
 exports[`Email with confirmation render a email input with disabled fields 2`] = `
 <label id="emailField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,email"
        for="email"
 >
@@ -260,7 +260,7 @@ exports[`Email with confirmation render a email input with disabled fields 2`] =
 
 exports[`Email with confirmation render a email input with email error 1`] = `
 <label id="emailField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,email"
        for="email"
 >
@@ -292,7 +292,7 @@ exports[`Email with confirmation render a email input with email error 1`] = `
 
 exports[`Email with confirmation render a email input with email error 2`] = `
 <label id="emailField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,email"
        for="email"
 >
@@ -324,7 +324,7 @@ exports[`Email with confirmation render a email input with email error 2`] = `
 
 exports[`Email with confirmation render a email input with given description 1`] = `
 <label id="emailField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,email"
        for="email"
 >
@@ -356,7 +356,7 @@ exports[`Email with confirmation render a email input with given description 1`]
 
 exports[`Email with confirmation render a email input with given description 2`] = `
 <label id="emailField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,email"
        for="email"
 >
@@ -388,7 +388,7 @@ exports[`Email with confirmation render a email input with given description 2`]
 
 exports[`Email with confirmation render a email input with read only fields 1`] = `
 <label id="emailField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,email"
        for="email"
 >
@@ -420,7 +420,7 @@ exports[`Email with confirmation render a email input with read only fields 1`] 
 
 exports[`Email with confirmation render a email input with read only fields 2`] = `
 <label id="emailField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,email"
        for="email"
 >
@@ -452,7 +452,7 @@ exports[`Email with confirmation render a email input with read only fields 2`] 
 
 exports[`Email with confirmation render default label if B2B and educational licence 1`] = `
 <label id="emailField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,email"
        for="email"
 >
@@ -484,7 +484,7 @@ exports[`Email with confirmation render default label if B2B and educational lic
 
 exports[`Email with confirmation render default label if B2B and educational licence 2`] = `
 <label id="emailField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,email"
        for="email"
 >

--- a/components/__snapshots__/first-name.spec.js.snap
+++ b/components/__snapshots__/first-name.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`First name render a disabled field 1`] = `
 <label id="firstNameField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="firstName"
 >
@@ -32,7 +32,7 @@ exports[`First name render a disabled field 1`] = `
 
 exports[`First name render a disabled field 2`] = `
 <label id="firstNameField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="firstName"
 >
@@ -62,7 +62,7 @@ exports[`First name render a disabled field 2`] = `
 
 exports[`First name render a field with default settings 1`] = `
 <label id="firstNameField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="firstName"
 >
@@ -91,7 +91,7 @@ exports[`First name render a field with default settings 1`] = `
 
 exports[`First name render a field with default settings 2`] = `
 <label id="firstNameField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="firstName"
 >
@@ -120,7 +120,7 @@ exports[`First name render a field with default settings 2`] = `
 
 exports[`First name render a field with error 1`] = `
 <label id="firstNameField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="firstName"
 >
@@ -149,7 +149,7 @@ exports[`First name render a field with error 1`] = `
 
 exports[`First name render a field with error 2`] = `
 <label id="firstNameField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="firstName"
 >
@@ -178,7 +178,7 @@ exports[`First name render a field with error 2`] = `
 
 exports[`First name render a field with value 1`] = `
 <label id="firstNameField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="firstName"
 >
@@ -207,7 +207,7 @@ exports[`First name render a field with value 1`] = `
 
 exports[`First name render a field with value 2`] = `
 <label id="firstNameField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="firstName"
 >

--- a/components/__snapshots__/industry.spec.js.snap
+++ b/components/__snapshots__/industry.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Industry can render a disable select 1`] = `
 <label id="industryField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="industry"
 >
@@ -122,7 +122,7 @@ exports[`Industry can render a disable select 1`] = `
 
 exports[`Industry can render a disable select 2`] = `
 <label id="industryField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="industry"
 >
@@ -242,7 +242,7 @@ exports[`Industry can render a disable select 2`] = `
 
 exports[`Industry can render an error message 1`] = `
 <label id="industryField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="industry"
 >
@@ -361,7 +361,7 @@ exports[`Industry can render an error message 1`] = `
 
 exports[`Industry can render an error message 2`] = `
 <label id="industryField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="industry"
 >
@@ -480,7 +480,7 @@ exports[`Industry can render an error message 2`] = `
 
 exports[`Industry can render an initial selected value 1`] = `
 <label id="industryField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="industry"
 >
@@ -601,7 +601,7 @@ exports[`Industry can render an initial selected value 1`] = `
 
 exports[`Industry can render an initial selected value 2`] = `
 <label id="industryField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="industry"
 >
@@ -722,7 +722,7 @@ exports[`Industry can render an initial selected value 2`] = `
 
 exports[`Industry render a select with a label 1`] = `
 <label id="industryField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="industry"
 >
@@ -841,7 +841,7 @@ exports[`Industry render a select with a label 1`] = `
 
 exports[`Industry render a select with a label 2`] = `
 <label id="industryField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="industry"
 >

--- a/components/__snapshots__/job-title.spec.js.snap
+++ b/components/__snapshots__/job-title.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`JobTitle can render a disable input 1`] = `
 <label id="jobTitleField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="jobTitle"
 >
@@ -31,7 +31,7 @@ exports[`JobTitle can render a disable input 1`] = `
 
 exports[`JobTitle can render a disable input 2`] = `
 <label id="jobTitleField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="jobTitle"
 >
@@ -60,7 +60,7 @@ exports[`JobTitle can render a disable input 2`] = `
 
 exports[`JobTitle can render an error message 1`] = `
 <label id="jobTitleField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="jobTitle"
 >
@@ -88,7 +88,7 @@ exports[`JobTitle can render an error message 1`] = `
 
 exports[`JobTitle can render an error message 2`] = `
 <label id="jobTitleField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="jobTitle"
 >
@@ -116,7 +116,7 @@ exports[`JobTitle can render an error message 2`] = `
 
 exports[`JobTitle can render an initial selected value 1`] = `
 <label id="jobTitleField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="jobTitle"
 >
@@ -144,7 +144,7 @@ exports[`JobTitle can render an initial selected value 1`] = `
 
 exports[`JobTitle can render an initial selected value 2`] = `
 <label id="jobTitleField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="jobTitle"
 >
@@ -172,7 +172,7 @@ exports[`JobTitle can render an initial selected value 2`] = `
 
 exports[`JobTitle render a select with a label 1`] = `
 <label id="jobTitleField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="jobTitle"
 >
@@ -200,7 +200,7 @@ exports[`JobTitle render a select with a label 1`] = `
 
 exports[`JobTitle render a select with a label 2`] = `
 <label id="jobTitleField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="jobTitle"
 >

--- a/components/__snapshots__/last-name.spec.js.snap
+++ b/components/__snapshots__/last-name.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Last name render a disabled field 1`] = `
 <label id="lastNameField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="lastName"
 >
@@ -32,7 +32,7 @@ exports[`Last name render a disabled field 1`] = `
 
 exports[`Last name render a disabled field 2`] = `
 <label id="lastNameField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="lastName"
 >
@@ -62,7 +62,7 @@ exports[`Last name render a disabled field 2`] = `
 
 exports[`Last name render a field with default error 1`] = `
 <label id="lastNameField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="lastName"
 >
@@ -91,7 +91,7 @@ exports[`Last name render a field with default error 1`] = `
 
 exports[`Last name render a field with default error 2`] = `
 <label id="lastNameField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="lastName"
 >
@@ -120,7 +120,7 @@ exports[`Last name render a field with default error 2`] = `
 
 exports[`Last name render a field with default settings 1`] = `
 <label id="lastNameField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="lastName"
 >
@@ -149,7 +149,7 @@ exports[`Last name render a field with default settings 1`] = `
 
 exports[`Last name render a field with default settings 2`] = `
 <label id="lastNameField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="lastName"
 >
@@ -178,7 +178,7 @@ exports[`Last name render a field with default settings 2`] = `
 
 exports[`Last name render a field with value 1`] = `
 <label id="lastNameField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="lastName"
 >
@@ -207,7 +207,7 @@ exports[`Last name render a field with value 1`] = `
 
 exports[`Last name render a field with value 2`] = `
 <label id="lastNameField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="lastName"
 >

--- a/components/__snapshots__/password.spec.js.snap
+++ b/components/__snapshots__/password.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Password can render a disable input 1`] = `
 <div id="passwordField"
-     class="o-forms-field ncf__password-field"
+     class="o-forms-field ncf__password-field ncf__validation-error"
      data-validate="required,password"
 >
   <label for="password"
@@ -48,7 +48,7 @@ exports[`Password can render a disable input 1`] = `
 
 exports[`Password can render a disable input 2`] = `
 <div id="passwordField"
-     class="o-forms-field ncf__password-field"
+     class="o-forms-field ncf__password-field ncf__validation-error"
      data-validate="required,password"
 >
   <label for="password"
@@ -94,7 +94,7 @@ exports[`Password can render a disable input 2`] = `
 
 exports[`Password can render a pattern attribute 1`] = `
 <div id="passwordField"
-     class="o-forms-field ncf__password-field"
+     class="o-forms-field ncf__password-field ncf__validation-error"
      data-validate="required,password"
 >
   <label for="password"
@@ -140,7 +140,7 @@ exports[`Password can render a pattern attribute 1`] = `
 
 exports[`Password can render a pattern attribute 2`] = `
 <div id="passwordField"
-     class="o-forms-field ncf__password-field"
+     class="o-forms-field ncf__password-field ncf__validation-error"
      data-validate="required,password"
 >
   <label for="password"
@@ -186,7 +186,7 @@ exports[`Password can render a pattern attribute 2`] = `
 
 exports[`Password can render as an Error 1`] = `
 <div id="passwordField"
-     class="o-forms-field ncf__password-field"
+     class="o-forms-field ncf__password-field ncf__validation-error"
      data-validate="required,password"
 >
   <label for="password"
@@ -231,7 +231,7 @@ exports[`Password can render as an Error 1`] = `
 
 exports[`Password can render as an Error 2`] = `
 <div id="passwordField"
-     class="o-forms-field ncf__password-field"
+     class="o-forms-field ncf__password-field ncf__validation-error"
      data-validate="required,password"
 >
   <label for="password"
@@ -276,7 +276,7 @@ exports[`Password can render as an Error 2`] = `
 
 exports[`Password can render as an Unknown user 1`] = `
 <div id="passwordField"
-     class="o-forms-field ncf__password-field js-unknown-user-field"
+     class="o-forms-field ncf__password-field ncf__validation-error js-unknown-user-field"
      data-validate="required,password"
 >
   <label for="password"
@@ -321,7 +321,7 @@ exports[`Password can render as an Unknown user 1`] = `
 
 exports[`Password can render as an Unknown user 2`] = `
 <div id="passwordField"
-     class="o-forms-field ncf__password-field js-unknown-user-field"
+     class="o-forms-field ncf__password-field ncf__validation-error js-unknown-user-field"
      data-validate="required,password"
 >
   <label for="password"
@@ -366,7 +366,7 @@ exports[`Password can render as an Unknown user 2`] = `
 
 exports[`Password render a password input with a label where input ID and Name are the same 1`] = `
 <div id="passwordField"
-     class="o-forms-field ncf__password-field"
+     class="o-forms-field ncf__password-field ncf__validation-error"
      data-validate="required,password"
 >
   <label for="password"
@@ -411,7 +411,7 @@ exports[`Password render a password input with a label where input ID and Name a
 
 exports[`Password render a password input with a label where input ID and Name are the same 2`] = `
 <div id="passwordField"
-     class="o-forms-field ncf__password-field"
+     class="o-forms-field ncf__password-field ncf__validation-error"
      data-validate="required,password"
 >
   <label for="password"

--- a/components/__snapshots__/phone.spec.js.snap
+++ b/components/__snapshots__/phone.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`Phone render a disabled phone input 1`] = `
 <label id="primaryTelephoneField"
        for="primaryTelephone"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,number"
 >
   <span class="o-forms-title">
@@ -40,7 +40,7 @@ exports[`Phone render a disabled phone input 1`] = `
 exports[`Phone render a disabled phone input 2`] = `
 <label id="primaryTelephoneField"
        for="primaryTelephone"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,number"
 >
   <span class="o-forms-title">
@@ -77,7 +77,7 @@ exports[`Phone render a disabled phone input 2`] = `
 exports[`Phone render a phone input with a label 1`] = `
 <label id="primaryTelephoneField"
        for="primaryTelephone"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,number"
 >
   <span class="o-forms-title">
@@ -113,7 +113,7 @@ exports[`Phone render a phone input with a label 1`] = `
 exports[`Phone render a phone input with a label 2`] = `
 <label id="primaryTelephoneField"
        for="primaryTelephone"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,number"
 >
   <span class="o-forms-title">
@@ -149,7 +149,7 @@ exports[`Phone render a phone input with a label 2`] = `
 exports[`Phone render a phone input with a label for B2B 1`] = `
 <label id="primaryTelephoneField"
        for="primaryTelephone"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,number"
 >
   <span class="o-forms-title">
@@ -185,7 +185,7 @@ exports[`Phone render a phone input with a label for B2B 1`] = `
 exports[`Phone render a phone input with a label for B2B 2`] = `
 <label id="primaryTelephoneField"
        for="primaryTelephone"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,number"
 >
   <span class="o-forms-title">
@@ -221,7 +221,7 @@ exports[`Phone render a phone input with a label for B2B 2`] = `
 exports[`Phone render a phone input with error styling 1`] = `
 <label id="primaryTelephoneField"
        for="primaryTelephone"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,number"
 >
   <span class="o-forms-title">
@@ -257,7 +257,7 @@ exports[`Phone render a phone input with error styling 1`] = `
 exports[`Phone render a phone input with error styling 2`] = `
 <label id="primaryTelephoneField"
        for="primaryTelephone"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,number"
 >
   <span class="o-forms-title">
@@ -293,7 +293,7 @@ exports[`Phone render a phone input with error styling 2`] = `
 exports[`Phone render default label if B2B and educational licence 1`] = `
 <label id="primaryTelephoneField"
        for="primaryTelephone"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,number"
 >
   <span class="o-forms-title">
@@ -329,7 +329,7 @@ exports[`Phone render default label if B2B and educational licence 1`] = `
 exports[`Phone render default label if B2B and educational licence 2`] = `
 <label id="primaryTelephoneField"
        for="primaryTelephone"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required,number"
 >
   <span class="o-forms-title">

--- a/components/__snapshots__/position.spec.js.snap
+++ b/components/__snapshots__/position.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Position can render a disable select 1`] = `
 <label id="positionField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="position"
 >
@@ -95,7 +95,7 @@ exports[`Position can render a disable select 1`] = `
 
 exports[`Position can render a disable select 2`] = `
 <label id="positionField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="position"
 >
@@ -188,7 +188,7 @@ exports[`Position can render a disable select 2`] = `
 
 exports[`Position can render an error message 1`] = `
 <label id="positionField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="position"
 >
@@ -280,7 +280,7 @@ exports[`Position can render an error message 1`] = `
 
 exports[`Position can render an error message 2`] = `
 <label id="positionField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="position"
 >
@@ -372,7 +372,7 @@ exports[`Position can render an error message 2`] = `
 
 exports[`Position can render an initial selected value 1`] = `
 <label id="positionField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="position"
 >
@@ -466,7 +466,7 @@ exports[`Position can render an initial selected value 1`] = `
 
 exports[`Position can render an initial selected value 2`] = `
 <label id="positionField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="position"
 >
@@ -560,7 +560,7 @@ exports[`Position can render an initial selected value 2`] = `
 
 exports[`Position render a select with a label 1`] = `
 <label id="positionField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="position"
 >
@@ -652,7 +652,7 @@ exports[`Position render a select with a label 1`] = `
 
 exports[`Position render a select with a label 2`] = `
 <label id="positionField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="position"
 >

--- a/components/__snapshots__/responsibility.spec.js.snap
+++ b/components/__snapshots__/responsibility.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Responsibility can render a disable select 1`] = `
 <label id="responsibilityField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="responsibility"
 >
@@ -113,7 +113,7 @@ exports[`Responsibility can render a disable select 1`] = `
 
 exports[`Responsibility can render a disable select 2`] = `
 <label id="responsibilityField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="responsibility"
 >
@@ -224,7 +224,7 @@ exports[`Responsibility can render a disable select 2`] = `
 
 exports[`Responsibility can render an error message 1`] = `
 <label id="responsibilityField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="responsibility"
 >
@@ -334,7 +334,7 @@ exports[`Responsibility can render an error message 1`] = `
 
 exports[`Responsibility can render an error message 2`] = `
 <label id="responsibilityField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="responsibility"
 >
@@ -444,7 +444,7 @@ exports[`Responsibility can render an error message 2`] = `
 
 exports[`Responsibility can render an initial selected value 1`] = `
 <label id="responsibilityField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="responsibility"
 >
@@ -556,7 +556,7 @@ exports[`Responsibility can render an initial selected value 1`] = `
 
 exports[`Responsibility can render an initial selected value 2`] = `
 <label id="responsibilityField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="responsibility"
 >
@@ -668,7 +668,7 @@ exports[`Responsibility can render an initial selected value 2`] = `
 
 exports[`Responsibility render a select with a label 1`] = `
 <label id="responsibilityField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="responsibility"
 >
@@ -778,7 +778,7 @@ exports[`Responsibility render a select with a label 1`] = `
 
 exports[`Responsibility render a select with a label 2`] = `
 <label id="responsibilityField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="responsibility"
 >

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -27,7 +27,7 @@ export function AcceptTerms ({
 
 	const divProps = {
 		id: 'acceptTermsField',
-		className: 'o-forms-field',
+		className: 'o-forms-field ncf__validation-error',
 		'data-validate': 'required,checked',
 		...(isSignup && { 'data-trackable': 'sign-up-terms' }),
 		...(isRegister && { 'data-trackable': 'register-up-terms' })

--- a/components/country.jsx
+++ b/components/country.jsx
@@ -53,7 +53,7 @@ export function Country ({
 	return (
 		<label
 			id={fieldId}
-			className="o-forms-field js-unknown-user-field"
+			className="o-forms-field js-unknown-user-field ncf__validation-error"
 			data-validate="required"
 			htmlFor={selectProps.id}
 		>

--- a/components/delivery-address.jsx
+++ b/components/delivery-address.jsx
@@ -18,7 +18,7 @@ export function DeliveryAddress ({
 
 	return (
 		<div id="deliveryAddressFields" data-validate="required">
-			<label className="o-forms-field" htmlFor="deliveryAddressLine1">
+			<label className="o-forms-field ncf__validation-error" htmlFor="deliveryAddressLine1">
 				<span className="o-forms-title">
 					<span className="o-forms-title__main">Address line 1</span>
 				</span>

--- a/components/delivery-address.jsx
+++ b/components/delivery-address.jsx
@@ -36,6 +36,7 @@ export function DeliveryAddress ({
 						disabled={isDisabled}
 						defaultValue={line1}
 					/>
+				<span className="o-forms-input__error">Please enter a valid address</span>
 				</span>
 			</label>
 			<label className="o-forms-field o-forms-field--optional" htmlFor="deliveryAddressLine2">

--- a/components/delivery-city.jsx
+++ b/components/delivery-city.jsx
@@ -17,7 +17,7 @@ export function DeliveryCity ({
 	return (
 		<label
 			id="deliveryCityField"
-			className="o-forms-field"
+			className="o-forms-field ncf__validation-error"
 			data-validate="required"
 			htmlFor="deliveryCity"
 		>

--- a/components/delivery-city.jsx
+++ b/components/delivery-city.jsx
@@ -38,6 +38,7 @@ export function DeliveryCity ({
 					disabled={isDisabled}
 					defaultValue={value}
 				/>
+			<span className="o-forms-input__error">Please enter a valid city or town</span>
 			</span>
 		</label>
 	);

--- a/components/delivery-start-date.jsx
+++ b/components/delivery-start-date.jsx
@@ -32,7 +32,7 @@ export function DeliveryStartDate ({
 	return (
 		<label
 			id="deliveryStartDateField"
-			className="o-forms-field"
+			className="o-forms-field ncf__validation-error"
 			data-validate="required"
 			htmlFor={inputProps.id}
 		>

--- a/components/email.jsx
+++ b/components/email.jsx
@@ -26,7 +26,7 @@ export function Email ({
 	return (
 		<label
 			id={fieldId}
-			className="o-forms-field"
+			className="o-forms-field ncf__validation-error"
 			data-validate="required,email"
 			htmlFor={inputId}
 		>

--- a/components/first-name.jsx
+++ b/components/first-name.jsx
@@ -26,7 +26,7 @@ export function FirstName ({
 	return (
 		<label
 			id={fieldId}
-			className="o-forms-field"
+			className="o-forms-field ncf__validation-error"
 			data-validate="required"
 			htmlFor={inputId}
 		>

--- a/components/industry.jsx
+++ b/components/industry.jsx
@@ -23,7 +23,7 @@ export function Industry ({
 	return (
 		<label
 			id={fieldId}
-			className="o-forms-field"
+			className="o-forms-field ncf__validation-error"
 			data-validate="required"
 			htmlFor={selectId}
 		>

--- a/components/job-title.jsx
+++ b/components/job-title.jsx
@@ -20,7 +20,7 @@ export function JobTitle ({
 	return (
 		<label
 			id={fieldId}
-			className="o-forms-field"
+			className="o-forms-field ncf__validation-error"
 			data-validate="required"
 			htmlFor={inputId}
 		>

--- a/components/last-name.jsx
+++ b/components/last-name.jsx
@@ -26,7 +26,7 @@ export function LastName ({
 	return (
 		<label
 			id={fieldId}
-			className="o-forms-field"
+			className="o-forms-field ncf__validation-error"
 			data-validate="required"
 			htmlFor={inputId}
 		>

--- a/components/password.jsx
+++ b/components/password.jsx
@@ -25,6 +25,7 @@ export function Password ({
 	const fieldClassNames = classNames([
 		'o-forms-field',
 		'ncf__password-field',
+		'ncf__validation-error',
 		{
 			'js-unknown-user-field': unknownUser
 		}

--- a/components/phone.jsx
+++ b/components/phone.jsx
@@ -26,7 +26,7 @@ export function Phone ({
 		<label
 			id={fieldId}
 			htmlFor={inputId}
-			className="o-forms-field"
+			className="o-forms-field ncf__validation-error"
 			data-validate="required,number"
 		>
 			<span className="o-forms-title">

--- a/components/position.jsx
+++ b/components/position.jsx
@@ -23,7 +23,7 @@ export function Position ({
 	return (
 		<label
 			id={fieldId}
-			className="o-forms-field"
+			className="o-forms-field ncf__validation-error"
 			data-validate="required"
 			htmlFor={selectId}
 		>

--- a/components/responsibility.jsx
+++ b/components/responsibility.jsx
@@ -20,7 +20,7 @@ export function Responsibility ({
 	]);
 
 	return (
-		<label id={fieldId} className="o-forms-field" data-validate="required" htmlFor={selectId}>
+		<label id={fieldId} className="o-forms-field ncf__validation-error" data-validate="required" htmlFor={selectId}>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">Which best describes your job responsibility?</span>
 			</span>

--- a/main.scss
+++ b/main.scss
@@ -17,6 +17,7 @@
 @import './styles/banner';
 @import './styles/customer-care';
 @import './styles/forms-additional-field-information';
+@import './styles/error';
 
 @include oFonts();
 @include oForms($opts: (

--- a/partials/accept-terms.html
+++ b/partials/accept-terms.html
@@ -1,4 +1,4 @@
-<div id="acceptTermsField" class="o-forms-field" data-validate="required,checked" {{#if isSignup}}data-trackable="sign-up-terms"{{/if}}{{#if isRegister}}data-trackable="register-up-terms"{{/if}}>
+<div id="acceptTermsField" class="o-forms-field ncf__validation-error" data-validate="required,checked" {{#if isSignup}}data-trackable="sign-up-terms"{{/if}}{{#if isRegister}}data-trackable="register-up-terms"{{/if}}>
 	<span class="o-forms-title n-ui-hide">
 		<span class="o-forms-title__main">Terms</span>
 	</span>

--- a/partials/country.html
+++ b/partials/country.html
@@ -1,4 +1,4 @@
-<label id="countryField" class="o-forms-field js-unknown-user-field" data-validate="required" for="country">
+<label id="countryField" class="o-forms-field js-unknown-user-field ncf__validation-error" data-validate="required" for="country">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">Country{{#if isB2b}}/Region{{/if}}</span>
 	</span>

--- a/partials/delivery-address.html
+++ b/partials/delivery-address.html
@@ -10,7 +10,9 @@
 				placeholder="e.g. 10 Elm Street"
 				aria-required="true" required
 				{{#if isDisabled}}disabled{{/if}}
-				value="{{line1}}" />
+				value="{{line1}}"
+			/>
+			<span class="o-forms-input__error">Please enter a valid address</span>
 		</span>
 	</label>
 	<label class="o-forms-field o-forms-field--optional" for="deliveryAddressLine2">

--- a/partials/delivery-address.html
+++ b/partials/delivery-address.html
@@ -1,5 +1,5 @@
 <div id="deliveryAddressFields" data-validate="required">
-	<label class="o-forms-field" for="deliveryAddressLine1">
+	<label class="o-forms-field ncf__validation-error" for="deliveryAddressLine1">
 		<span class="o-forms-title">
 			<span class="o-forms-title__main">Address line 1</span>
 		</span>

--- a/partials/delivery-city.html
+++ b/partials/delivery-city.html
@@ -9,6 +9,8 @@
 			placeholder="e.g. Bath"
 			aria-required="true" required
 			{{#if isDisabled}}disabled{{/if}}
-			value="{{value}}">
+			value="{{value}}"
+		/>
+		<span class="o-forms-input__error">Please enter a valid city or town</span>
 	</span>
 </label>

--- a/partials/delivery-city.html
+++ b/partials/delivery-city.html
@@ -1,4 +1,4 @@
-<label id="deliveryCityField" class="o-forms-field" data-validate="required" for="deliveryCity">
+<label id="deliveryCityField" class="o-forms-field ncf__validation-error" data-validate="required" for="deliveryCity">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">City/town</span>
 	</span>

--- a/partials/delivery-start-date.html
+++ b/partials/delivery-start-date.html
@@ -1,4 +1,4 @@
-<label id="deliveryStartDateField" class="o-forms-field" data-validate="required" for="deliveryStartDate">
+<label id="deliveryStartDateField" class="o-forms-field ncf__validation-error" data-validate="required" for="deliveryStartDate">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">Delivery start date</span>
 		<span class="o-forms-title__prompt">Earliest available delivery date: {{date}}</span>

--- a/partials/email.html
+++ b/partials/email.html
@@ -1,4 +1,4 @@
-<label id="emailField" class="o-forms-field" data-validate="required,email" for="email">
+<label id="emailField" class="o-forms-field ncf__validation-error" data-validate="required,email" for="email">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">
 			{{#if isB2b}}

--- a/partials/firstname.html
+++ b/partials/firstname.html
@@ -1,6 +1,6 @@
 <label
 	id="firstNameField"
-	class="o-forms-field"
+	class="o-forms-field ncf__validation-error"
 	data-validate="required"
 	for="firstName">
 

--- a/partials/industry.html
+++ b/partials/industry.html
@@ -1,4 +1,4 @@
-<label id="industryField" class="o-forms-field" data-validate="required" for="industry">
+<label id="industryField" class="o-forms-field ncf__validation-error" data-validate="required" for="industry">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">In which industry do you work?</span>
 	</span>

--- a/partials/job-title.html
+++ b/partials/job-title.html
@@ -1,4 +1,4 @@
-<label id="jobTitleField" class="o-forms-field" data-validate="required" for="jobTitle">
+<label id="jobTitleField" class="o-forms-field ncf__validation-error" data-validate="required" for="jobTitle">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">Job title</span>
 	</span>

--- a/partials/lastname.html
+++ b/partials/lastname.html
@@ -1,6 +1,6 @@
 <label
 	id="lastNameField"
-	class="o-forms-field"
+	class="o-forms-field ncf__validation-error"
 	data-validate="required"
 	for="lastName"
 >

--- a/partials/password.html
+++ b/partials/password.html
@@ -1,4 +1,4 @@
-<div id="passwordField" class="o-forms-field ncf__password-field{{#if unknownUser}} js-unknown-user-field{{/if}}" data-validate="required,password">
+<div id="passwordField" class="o-forms-field ncf__password-field ncf__validation-error{{#if unknownUser}} js-unknown-user-field{{/if}}" data-validate="required,password">
 	<label for="password" class="o-forms-title">
 		<span class="o-forms-title__main">Password</span>
 		<span class="o-forms-title__prompt">Use 8 or more characters with a mix of letters, numbers &amp; symbols</span>

--- a/partials/phone.html
+++ b/partials/phone.html
@@ -1,7 +1,7 @@
 <label
 	id="primaryTelephoneField"
 	for="primaryTelephone"
-	class="o-forms-field"
+	class="o-forms-field ncf__validation-error"
 	data-validate="required,number"
 >
 	<span class="o-forms-title">

--- a/partials/position.html
+++ b/partials/position.html
@@ -1,4 +1,4 @@
-<label id="positionField" class="o-forms-field" data-validate="required" for="position">
+<label id="positionField" class="o-forms-field ncf__validation-error" data-validate="required" for="position">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">What’s your job position?</span>
 	</span>

--- a/partials/responsibility.html
+++ b/partials/responsibility.html
@@ -1,4 +1,4 @@
-<label id="responsibilityField" class="o-forms-field" data-validate="required" for="responsibility">
+<label id="responsibilityField" class="o-forms-field ncf__validation-error" data-validate="required" for="responsibility">
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">Which best describes your job responsibility?</span>
 	</span>

--- a/styles/error.scss
+++ b/styles/error.scss
@@ -1,0 +1,3 @@
+.ncf__validation-error .o-forms-input--invalid {
+	margin-bottom: oSpacingByName('s3');
+}


### PR DESCRIPTION
 🐿 v2.12.5

### Description
We currently are not showing any validation messages on the delivery address form section in next-subscribe. This fixes that.

I have also added a margin-bottom of 12px when the validation error is shown.

I have checked next-subscribe B2C (print and single pages), B2B signup forms, personal-details and profile. 

### Screenshots

| Before | After |
| ------ | ----- |
|  ![no-error-messages-shown](https://user-images.githubusercontent.com/19288962/73524117-5a136580-4404-11ea-9143-6081af0a9c6f.png) |  ![image](https://user-images.githubusercontent.com/19288962/73524161-77483400-4404-11ea-9dfb-0d92448e5902.png)|


