### PR TITLE
CQR-24: Refactor handleDeliveryOptionChange to deal with single nodes 🐿 v2.12.5

### DIFF
--- a/test/utils/delivery-option.spec.js
+++ b/test/utils/delivery-option.spec.js
@@ -1,28 +1,14 @@
 const DeliveryOption = require('../../utils/delivery-option');
 const expect = require('chai').expect;
 const sinon = require('sinon');
+const { JSDOM } = require('jsdom');
 
 describe('DeliveryOption', () => {
 	let sandbox = sinon.createSandbox();
-
 	let document;
-	let formStub;
-	let deliveryOption1Listener;
-	let deliveryOption2Listener;
 
 	beforeEach(() => {
 		document = { querySelector: sandbox.stub().returns(false) };
-		deliveryOption1Listener = sandbox.stub();
-		deliveryOption2Listener = sandbox.stub();
-
-		formStub = {
-			deliveryOption: [
-				{ addEventListener: deliveryOption1Listener },
-				{ addEventListener: deliveryOption2Listener }
-			]
-		};
-
-		document.querySelector.withArgs('form.ncf').returns(formStub);
 	});
 
 	afterEach(() => {
@@ -45,13 +31,74 @@ describe('DeliveryOption', () => {
 	});
 
 	describe('handleDeliveryOptionChange', () => {
-		it('binds the given callback to the change event on the delivery option fields', async () => {
-			let deliveryOptionUtil = new DeliveryOption(document);
-			let callback = sinon.stub();
-			deliveryOptionUtil.handleDeliveryOptionChange(callback);
+		describe('can handle an array', () => {
+			let deliveryOption1Listener;
+			let deliveryOption2Listener;
 
-			expect(deliveryOption1Listener.calledWith('change', callback)).to.be.true;
-			expect(deliveryOption2Listener.calledWith('change', callback)).to.be.true;
+			beforeEach(() => {
+				deliveryOption1Listener = sandbox.stub();
+				deliveryOption2Listener = sandbox.stub();
+
+				const formStub = {
+					deliveryOption: [
+						{ addEventListener: deliveryOption1Listener },
+						{ addEventListener: deliveryOption2Listener }
+					]
+				};
+
+				document.querySelector.withArgs('form.ncf').returns(formStub);
+			});
+
+			afterEach(() => {
+				sandbox.restore();
+			});
+
+			it('binds the given callback to the change event on the delivery option fields', async () => {
+				let deliveryOptionUtil = new DeliveryOption(document);
+				let callback = sinon.stub();
+				deliveryOptionUtil.handleDeliveryOptionChange(callback);
+
+				expect(deliveryOption1Listener.calledWith('change', callback)).to.be.true;
+				expect(deliveryOption2Listener.calledWith('change', callback)).to.be.true;
+			});
+		});
+
+		describe('can handle a single node element', () => {
+			let deliveryOptionUtil;
+			let callback;
+			let deliveryOptionListener;
+
+			beforeEach(() => {
+				const dom = new JSDOM();
+				const formElement = dom.window.document.createElement('HTMLInputElement');
+
+				deliveryOptionListener = sandbox.stub();
+				formElement.addEventListener = deliveryOptionListener;
+
+				const altFormStub = {
+					deliveryOption: formElement
+				};
+
+				document.querySelector.withArgs('form.ncf').returns(altFormStub);
+
+				deliveryOptionUtil = new DeliveryOption(document);
+				callback = sinon.stub();
+			});
+
+			afterEach(() => {
+				sandbox.restore();
+			});
+
+			it('can handle having only one form element', () => {
+				expect(() => {
+					deliveryOptionUtil.handleDeliveryOptionChange(callback);
+				}).to.not.throw();
+			});
+
+			it('adds the event listener', () => {
+				deliveryOptionUtil.handleDeliveryOptionChange(callback);
+				expect(deliveryOptionListener.calledWith('change', callback)).to.be.true;
+			});
 		});
 	});
 

--- a/utils/delivery-option.js
+++ b/utils/delivery-option.js
@@ -26,8 +26,12 @@ class DeliveryOption {
 	 * @param {Function} callback The callback function to call when a change event occurs.
 	 */
 	handleDeliveryOptionChange (callback) {
-		for (let option of [...this.$form.deliveryOption]) {
-			option.addEventListener('change', callback);
+		if (this.$form.deliveryOption.length === undefined) {
+			this.$form.deliveryOption.addEventListener('change', callback);
+		} else {
+			for (let option of [...this.$form.deliveryOption]) {
+				option.addEventListener('change', callback);
+			}
 		}
 	}
 


### PR DESCRIPTION
### Description
Spreading a single node was causing an error in the `handleDeliveryOptionChange` function.

This PR adds tests to exercise the bug and fixes it.

https://financialtimes.atlassian.net/browse/CQR-24

- [x] **Tests** written for new or updated for existing functionality
