### PR TITLE
Amend package.json 'main' property value

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@financial-times/n-conversion-forms",
   "version": "0.0.0",
   "description": "Containing partials and styles for forms included on Conversion apps (next-signup, next-corp-signup, next-b2b-prospect etc).",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "precommit": "node_modules/.bin/secret-squirrel",


### PR DESCRIPTION
### Description
For any apps consuming `n-conversion-forms`, the `main` value that currently points to `index.js` will produce this error:

> "Cannot find module '/Users/andy.gout/Documents/next-subscribe/node_modules/@financial-times/n-conversion-forms/index.js'. Please verify that the package.json has a valid \"main\" entry"

No `index.js` file exists at root level at suggested; it exists in the `dist` directory, which this PR fixes.

#### Contents of `next-subscribe/node_modules/@financial-times`

![Screenshot 2020-02-06 at 13 20 45](https://user-images.githubusercontent.com/10484515/73940721-e087e580-48e3-11ea-9415-38122d6eeb63.png)

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Demos** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer 
- [ ] **Product Review** ran past the product owner
