### PR TITLE
Rename npm transpile script to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ node_modules/@financial-times/n-gage/index.mk:
 -include node_modules/@financial-times/n-gage/index.mk
 
 build:
-	npm run transpile
+	npm run build
 
 build-demo:
 	make build

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "precommit": "node_modules/.bin/secret-squirrel",
     "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
     "prepush": "make verify -j3",
-    "prepare": "npx snyk protect || npx snyk protect -d || true",
-    "transpile": "babel components/*.jsx -d dist --copy-files"
+    "prepare": "(npx snyk protect || npx snyk protect -d || true) && npm run build",
+    "build": "babel components/*.jsx -d dist --copy-files"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description
Rename npm script `transpile` to `build` for semantic clarity and parity with corresponding `make` command (i.e. `make build`).

Also have it run at end of npm `prepare` script.

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Demos** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer 
- [ ] **Product Review** ran past the product owner
