### PR TITLE
Remove unnecessary 'make build' from .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,9 +80,6 @@ jobs:
           name: shared-helper / generate-build-state-artifacts
           command: .circleci/shared-helpers/helper-generate-build-state-artifacts
           when: always
-      - run:
-          name: Build dist files
-          command: make build
       - *cache_npm_cache
       - store_artifacts:
           path: build-state


### PR DESCRIPTION
### Description
Preceding `run` command will call `make install`, which ends with a build step that creates the `dist` and so need not be repeated.

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Demos** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer 
- [ ] **Product Review** ran past the product owner
