### PR TITLE
Adds isStaticMessge

### DIFF
--- a/components/message.jsx
+++ b/components/message.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export function Message ({ title, message, additional = [], actions = null, name, isNotice, isError, isSuccess, isInform, isHidden }) {
+export function Message ({ title, message, additional = [], actions = null, name, isNotice, isError, isSuccess, isInform, isStaticMessage, isHidden }) {
 
 	const additionalMessages = additional.map((text, index) => {
 		return <p className="o-message__content--additional" key={index}>{text}</p>;
@@ -10,9 +10,9 @@ export function Message ({ title, message, additional = [], actions = null, name
 
 	const oMessageClassNames = classNames({
 		'o-message': true,
-		'o-message--inner': true,
-		'o-message--notice': isNotice,
-		'o-message--alert': !isNotice,
+		'o-message--inner': !isStaticMessage,
+		'o-message--notice': isNotice && !isStaticMessage,
+		'o-message--alert': !isNotice && !isStaticMessage,
 		'o-message--error': isError,
 		'o-message--success': !isError && isSuccess,
 		'o-message--inform': !isError && !isSuccess && isInform,

--- a/partials/message.html
+++ b/partials/message.html
@@ -1,5 +1,5 @@
 <div class="ncf__message{{#if isHidden}} ncf__hidden{{/if}}"{{#if name}} data-message-name="{{name}}"{{/if}}>
-	<div class="o-message o-message--inner {{#if isNotice}}o-message--notice{{else}}o-message--alert{{/if}}{{#if isError}} o-message--error{{else if isSuccess}} o-message--success{{else if isInform}} o-message--inform{{else}} o-message--neutral{{/if}}" data-o-component="o-message">
+	<div class="o-message{{#unless isStaticMessage}} o-message--inner{{/unless}} {{#unless isStaticMessage}}{{#if isNotice}}o-message--notice{{else}}o-message--alert{{/if}}{{/unless}}{{#if isError}} o-message--error{{else if isSuccess}} o-message--success{{else if isInform}} o-message--inform{{else}} o-message--neutral{{/if}}" data-o-component="o-message">
 		<div class="o-message__container">
 			<div class="o-message__content">
 				<p class="o-message__content-main">


### PR DESCRIPTION
 🐿 v2.12.5

### Description
On the account-settings pages, we have a few messages that will be shown to all users i.e `Changing details here changes your login credentials across all FT.com services`. These are `inform` messages but do not require the extra padding that o-message--inner and o-message--notice or o-message--alert supply. I have therefore added an isStaticMessge which prevents these classes from being added to the message component.

[Ticket](https://financialtimes.atlassian.net/browse/AC-77)

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Tests** written for new or updated for existing functionality
