### PR TITLE
Add options for US-based contracts

### DIFF
--- a/components/education-job-title.jsx
+++ b/components/education-job-title.jsx
@@ -9,12 +9,17 @@ export function EducationJobTitle ({
 	fieldId = 'jobTitleField',
 	inputId = 'jobTitle',
 	inputName = 'jobTitle',
+	isUSContract = false,
 }) {
 	const inputWrapperClassName = classNames([
 		'o-forms-input',
 		'o-forms-input--select',
 		{ 'o-forms-input--invalid': hasError }
 	]);
+
+	const availableJobTitles = ['Faculty/Other'].concat(
+		isUSContract ? ['Graduate Student', 'Undergraduate Student'] : ['Student']
+	);
 
 	return (
 		<label
@@ -38,8 +43,9 @@ export function EducationJobTitle ({
 					defaultValue={value}
 				>
 					<option value="">Select your occupation</option>
-					<option>Faculty/Other</option>
-					<option>Student</option>
+					{availableJobTitles.map((jobTitle, idx) => {
+						return <option key={idx}>{jobTitle}</option>;
+					})}
 				</select>
 				<span className="o-forms-input__error">Please enter your occupation.</span>
 			</span>

--- a/components/education-job-title.jsx
+++ b/components/education-job-title.jsx
@@ -43,8 +43,8 @@ export function EducationJobTitle ({
 					defaultValue={value}
 				>
 					<option value="">Select your occupation</option>
-					{availableJobTitles.map((jobTitle, idx) => {
-						return <option key={idx}>{jobTitle}</option>;
+					{availableJobTitles.map((jobTitle, index) => {
+						return <option key={index}>{jobTitle}</option>;
 					})}
 				</select>
 				<span className="o-forms-input__error">Please enter your occupation.</span>

--- a/partials/education-job-title.html
+++ b/partials/education-job-title.html
@@ -14,7 +14,12 @@
 		>
 			<option {{#unless value}}selected{{/unless}} value="">Select your occupation</option>
 			<option {{#if value}}{{#ifEquals  value 'Faculty/Other' }} selected{{/ifEquals}}{{/if}}>Faculty/Other</option>
+			{{#if isUSContract}}
+			<option {{#if value}}{{#ifEquals value 'Graduate Student'}}selected{{/ifEquals}}{{/if}}>Graduate Student</option>
+			<option {{#if value}}{{#ifEquals value 'Undergraduate Student'}}selected{{/ifEquals}}{{/if}}>Undergraduate Student</option>
+			{{else}}
 			<option {{#if value}}{{#ifEquals  value 'Student' }} selected{{/ifEquals}}{{/if}}>Student</option>
+			{{/if}}
 		</select>
 		<span class="o-forms-input__error">Please enter your occupation.</span>
 	</span>


### PR DESCRIPTION
### Description
As part of the US growth work, we want to capture whether anyone joining the licence of an educational client is a student or faculty member. The US B2B team wants to further distinguish students between post- and under- graduates. This PR changes the "Student" option for "Graduate Student" and "Undergraduate Student" if the prop `isUSContract` is set to true.

[Ticket](https://financialtimes.atlassian.net/jira/software/projects/USG/boards/969?selectedIssue=USG-15)

### Reminder

- [x] **Tests** written for new or updated for existing functionality