### PR TITLE
Revert terms and conditions accessibility changes

### DIFF
--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -2,85 +2,114 @@
 
 exports[`AcceptTerms renders appropriately if a registration 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="register-up-terms"
 >
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label"
-          id="terms-register"
-    >
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener noreferrer"
-         data-trackable="terms-and-conditions"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
     </span>
-    <p class="o-forms-input__error">
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
+        I confirm I am 16 years or older and have read and agree to the
+        <a class="ncf__link--external"
+           href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+           target="_blank"
+           rel="noopener noreferrer"
+           data-trackable="terms-and-conditions"
+        >
+          Terms &amp; Conditions
+        </a>
+        .
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a registration 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="register-up-terms"
 >
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label"
-          id="terms-register"
-    >
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener noreferrer"
-         data-trackable="terms-and-conditions"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
     </span>
-    <p class="o-forms-input__error">
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
+        I confirm I am 16 years or older and have read and agree to the
+        <a class="ncf__link--external"
+           href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+           target="_blank"
+           rel="noopener noreferrer"
+           data-trackable="terms-and-conditions"
+        >
+          Terms &amp; Conditions
+        </a>
+        .
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -91,10 +120,8 @@ exports[`AcceptTerms renders appropriately if a signup 1`] = `
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
         <a class="ncf__link--external"
            href="https://help.ft.com/help/contact-us/"
@@ -104,15 +131,11 @@ exports[`AcceptTerms renders appropriately if a signup 1`] = `
           customer service through chat, phone or email
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -122,37 +145,39 @@ exports[`AcceptTerms renders appropriately if a signup 1`] = `
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -163,10 +188,8 @@ exports[`AcceptTerms renders appropriately if a signup 2`] = `
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
         <a class="ncf__link--external"
            href="https://help.ft.com/help/contact-us/"
@@ -176,15 +199,11 @@ exports[`AcceptTerms renders appropriately if a signup 2`] = `
           customer service through chat, phone or email
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -194,37 +213,39 @@ exports[`AcceptTerms renders appropriately if a signup 2`] = `
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup and has special terms 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -235,10 +256,8 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 1`]
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
         <a class="ncf__link--external"
            href="https://help.ft.com/help/contact-us/"
@@ -248,15 +267,11 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 1`]
           customer service through chat, phone or email
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -266,42 +281,44 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 1`]
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p id="terms-special">
+      </span>
+      <span id="terms-special"
+            class="o-forms-input__label"
+      >
         Special terms text
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup and has special terms 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -312,10 +329,8 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 2`]
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
         <a class="ncf__link--external"
            href="https://help.ft.com/help/contact-us/"
@@ -325,15 +340,11 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 2`]
           customer service through chat, phone or email
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -343,42 +354,44 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 2`]
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p id="terms-special">
+      </span>
+      <span id="terms-special"
+            class="o-forms-input__label"
+      >
         Special terms text
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup for the print product 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -389,15 +402,11 @@ exports[`AcceptTerms renders appropriately if a signup for the print product 1`]
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-print">
+      </span>
+      <span class="terms-print o-forms-input__label">
         Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
-      </p>
-    </li>
-    <li>
-      <p class="terms-print">
+      </span>
+      <span class="terms-print o-forms-input__label">
         Find out more about your delivery start date in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -407,37 +416,39 @@ exports[`AcceptTerms renders appropriately if a signup for the print product 1`]
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup for the print product 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -448,15 +459,11 @@ exports[`AcceptTerms renders appropriately if a signup for the print product 2`]
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-print">
+      </span>
+      <span class="terms-print o-forms-input__label">
         Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
-      </p>
-    </li>
-    <li>
-      <p class="terms-print">
+      </span>
+      <span class="terms-print o-forms-input__label">
         Find out more about your delivery start date in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -466,37 +473,39 @@ exports[`AcceptTerms renders appropriately if a signup for the print product 2`]
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup for the print product and is embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -507,15 +516,11 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-print">
+      </span>
+      <span class="terms-print o-forms-input__label">
         Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
-      </p>
-    </li>
-    <li>
-      <p class="terms-print">
+      </span>
+      <span class="terms-print o-forms-input__label">
         Find out more about your delivery start date in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -525,37 +530,39 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup for the print product and is embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -566,15 +573,11 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-print">
+      </span>
+      <span class="terms-print o-forms-input__label">
         Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
-      </p>
-    </li>
-    <li>
-      <p class="terms-print">
+      </span>
+      <span class="terms-print o-forms-input__label">
         Find out more about your delivery start date in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -584,37 +587,39 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup for the print product and is not embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -625,15 +630,11 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-print">
+      </span>
+      <span class="terms-print o-forms-input__label">
         Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
-      </p>
-    </li>
-    <li>
-      <p class="terms-print">
+      </span>
+      <span class="terms-print o-forms-input__label">
         Find out more about your delivery start date in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -643,37 +644,39 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup for the print product and is not embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -684,15 +687,11 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-print">
+      </span>
+      <span class="terms-print o-forms-input__label">
         Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).
-      </p>
-    </li>
-    <li>
-      <p class="terms-print">
+      </span>
+      <span class="terms-print o-forms-input__label">
         Find out more about your delivery start date in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -702,37 +701,39 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -743,10 +744,8 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
         <a class="ncf__link--external"
            href="https://help.ft.com/help/contact-us/"
@@ -756,15 +755,11 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           customer service through chat, phone or email
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -774,37 +769,39 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -815,10 +812,8 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
         <a class="ncf__link--external"
            href="https://help.ft.com/help/contact-us/"
@@ -828,15 +823,11 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           customer service through chat, phone or email
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -846,37 +837,39 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product and is embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -887,10 +880,8 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
         <a class="ncf__link--external"
            href="https://help.ft.com/help/contact-us/"
@@ -900,15 +891,11 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           customer service through chat, phone or email
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -918,37 +905,39 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product and is embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -959,10 +948,8 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
         <a class="ncf__link--external"
            href="https://help.ft.com/help/contact-us/"
@@ -972,15 +959,11 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           customer service through chat, phone or email
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -990,37 +973,39 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product and is not embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1031,10 +1016,8 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
         <a class="ncf__link--external"
            href="https://help.ft.com/help/contact-us/"
@@ -1044,15 +1027,11 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           customer service through chat, phone or email
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1062,37 +1041,39 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if a signup not for the print product and is not embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
      data-trackable="sign-up-terms"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1103,10 +1084,8 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
         <a class="ncf__link--external"
            href="https://help.ft.com/help/contact-us/"
@@ -1116,15 +1095,11 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           customer service through chat, phone or email
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-      </p>
-    </li>
-    <li>
-      <p class="terms-signup">
+      </span>
+      <span class="terms-signup o-forms-input__label">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1134,36 +1109,39 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if input is checked 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+             checked
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1174,37 +1152,39 @@ exports[`AcceptTerms renders appropriately if input is checked 1`] = `
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-           checked
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if input is checked 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+             checked
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1215,99 +1195,104 @@ exports[`AcceptTerms renders appropriately if input is checked 2`] = `
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-           checked
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is B2B 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-b2b">
-        By submitting this form, you indicate your consent to also being contacted by Financial Times by email, post, or phone about our other products, services or special offers unless you untick this box.
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
     </span>
-    <p class="o-forms-input__error">
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-b2b"
+            class="o-forms-input__label"
+      >
+        By submitting this form, you indicate your consent to also being contacted by Financial Times by email, post, or phone about our other products, services or special offers unless you untick this box.
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is B2B 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-b2b">
-        By submitting this form, you indicate your consent to also being contacted by Financial Times by email, post, or phone about our other products, services or special offers unless you untick this box.
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
     </span>
-    <p class="o-forms-input__error">
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-b2b"
+            class="o-forms-input__label"
+      >
+        By submitting this form, you indicate your consent to also being contacted by Financial Times by email, post, or phone about our other products, services or special offers unless you untick this box.
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is corporate signup 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1318,51 +1303,47 @@ exports[`AcceptTerms renders appropriately if is corporate signup 1`] = `
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is corporate signup 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1373,51 +1354,47 @@ exports[`AcceptTerms renders appropriately if is corporate signup 2`] = `
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is corporate signup and not trial 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1428,51 +1405,47 @@ exports[`AcceptTerms renders appropriately if is corporate signup and not trial 
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is corporate signup and not trial 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1483,51 +1456,47 @@ exports[`AcceptTerms renders appropriately if is corporate signup and not trial 
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is corporate signup and trial 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1538,56 +1507,50 @@ exports[`AcceptTerms renders appropriately if is corporate signup and trial 1`] 
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         This trial is to demonstrate the value of a group subscription and we’ll contact you during your trial.
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is corporate signup and trial 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1598,56 +1561,50 @@ exports[`AcceptTerms renders appropriately if is corporate signup and trial 2`] 
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.
-      </p>
-    </li>
-    <li>
-      <p class="terms-corp-signup">
+      </span>
+      <span class="terms-corp-signup o-forms-input__label">
         This trial is to demonstrate the value of a group subscription and we’ll contact you during your trial.
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1658,36 +1615,38 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1698,36 +1657,38 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and custom age restriction is provided 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 21 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1738,36 +1699,38 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and custom age restriction is provided 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 21 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1778,36 +1741,38 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and is embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1818,36 +1783,38 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and is embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1858,36 +1825,38 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and is not embedded 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1898,36 +1867,38 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms display) and is not embedded 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1938,36 +1909,38 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is transition 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -1978,10 +1951,8 @@ exports[`AcceptTerms renders appropriately if is transition 1`] = `
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition">
+      </span>
+      <span class="terms-transition o-forms-input__label">
         I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
         <a class="ncf__link--external"
            href="https://help.ft.com/help/contact-us/"
@@ -1991,15 +1962,11 @@ exports[`AcceptTerms renders appropriately if is transition 1`] = `
           customer service through chat, phone or email
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition terms-transition--other">
+      </span>
+      <span class="terms-transition terms-transition--other o-forms-input__label">
         By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition">
+      </span>
+      <span class="terms-transition o-forms-input__label">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -2009,36 +1976,38 @@ exports[`AcceptTerms renders appropriately if is transition 1`] = `
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is transition 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -2049,10 +2018,8 @@ exports[`AcceptTerms renders appropriately if is transition 2`] = `
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition">
+      </span>
+      <span class="terms-transition o-forms-input__label">
         I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
         <a class="ncf__link--external"
            href="https://help.ft.com/help/contact-us/"
@@ -2062,15 +2029,11 @@ exports[`AcceptTerms renders appropriately if is transition 2`] = `
           customer service through chat, phone or email
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition terms-transition--other">
+      </span>
+      <span class="terms-transition terms-transition--other o-forms-input__label">
         By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition">
+      </span>
+      <span class="terms-transition o-forms-input__label">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -2080,36 +2043,38 @@ exports[`AcceptTerms renders appropriately if is transition 2`] = `
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is transition with transition type of immediate 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -2120,10 +2085,8 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition">
+      </span>
+      <span class="terms-transition o-forms-input__label">
         I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
         <a class="ncf__link--external"
            href="https://help.ft.com/help/contact-us/"
@@ -2133,15 +2096,11 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
           customer service through chat, phone or email
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition terms-transition--immediate">
+      </span>
+      <span class="terms-transition terms-transition--immediate o-forms-input__label">
         By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition">
+      </span>
+      <span class="terms-transition o-forms-input__label">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -2151,36 +2110,38 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is transition with transition type of immediate 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -2191,10 +2152,8 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition">
+      </span>
+      <span class="terms-transition o-forms-input__label">
         I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
         <a class="ncf__link--external"
            href="https://help.ft.com/help/contact-us/"
@@ -2204,15 +2163,11 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
           customer service through chat, phone or email
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition terms-transition--immediate">
+      </span>
+      <span class="terms-transition terms-transition--immediate o-forms-input__label">
         By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition">
+      </span>
+      <span class="terms-transition o-forms-input__label">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -2222,36 +2177,38 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is transition with transition type other than immediate 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -2262,10 +2219,8 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition">
+      </span>
+      <span class="terms-transition o-forms-input__label">
         I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
         <a class="ncf__link--external"
            href="https://help.ft.com/help/contact-us/"
@@ -2275,15 +2230,11 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
           customer service through chat, phone or email
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition terms-transition--other">
+      </span>
+      <span class="terms-transition terms-transition--other o-forms-input__label">
         By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition">
+      </span>
+      <span class="terms-transition o-forms-input__label">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -2293,36 +2244,38 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders appropriately if is transition with transition type other than immediate 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -2333,10 +2286,8 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition">
+      </span>
+      <span class="terms-transition o-forms-input__label">
         I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
         <a class="ncf__link--external"
            href="https://help.ft.com/help/contact-us/"
@@ -2346,15 +2297,11 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
           customer service through chat, phone or email
         </a>
         .
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition terms-transition--other">
+      </span>
+      <span class="terms-transition terms-transition--other o-forms-input__label">
         By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.
-      </p>
-    </li>
-    <li>
-      <p class="terms-transition">
+      </span>
+      <span class="terms-transition o-forms-input__label">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -2364,36 +2311,38 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders with an error 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox o-forms-input--invalid">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -2404,36 +2353,38 @@ exports[`AcceptTerms renders with an error 1`] = `
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox o-forms-input--invalid">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders with an error 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox o-forms-input--invalid">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -2444,36 +2395,38 @@ exports[`AcceptTerms renders with an error 2`] = `
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox o-forms-input--invalid">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders with default props 1`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -2484,36 +2437,38 @@ exports[`AcceptTerms renders with default props 1`] = `
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;
 
 exports[`AcceptTerms renders with default props 2`] = `
 <div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
+     class="o-forms-field ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list o-typography-list--unordered">
-    <li>
-      <p id="terms-default">
+  <span class="o-forms-title n-ui-hide">
+    <span class="o-forms-title__main">
+      Terms
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--checkbox">
+    <label for="termsAcceptance">
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span id="terms-default"
+            class="o-forms-input__label"
+      >
         I confirm I am 16 years or older and have read and agree to the
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -2524,24 +2479,11 @@ exports[`AcceptTerms renders with default props 2`] = `
           Terms &amp; Conditions
         </a>
         .
-      </p>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox">
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
+      </span>
+    </label>
+    <span class="o-forms-input__error">
       Please accept our terms &amp; conditions
-    </p>
-  </label>
+    </span>
+  </span>
 </div>
 `;

--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -6,9 +6,7 @@ exports[`AcceptTerms renders appropriately if a registration 1`] = `
      data-validate="required,checked"
      data-trackable="register-up-terms"
 >
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -44,9 +42,7 @@ exports[`AcceptTerms renders appropriately if a registration 2`] = `
      data-validate="required,checked"
      data-trackable="register-up-terms"
 >
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -129,9 +125,7 @@ exports[`AcceptTerms renders appropriately if a signup 1`] = `
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -203,9 +197,7 @@ exports[`AcceptTerms renders appropriately if a signup 2`] = `
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -282,9 +274,7 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 1`]
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -361,9 +351,7 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 2`]
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -422,9 +410,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product 1`]
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -483,9 +469,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product 2`]
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -544,9 +528,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -605,9 +587,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -666,9 +646,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -727,9 +705,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -801,9 +777,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -875,9 +849,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -949,9 +921,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1023,9 +993,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1097,9 +1065,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1171,9 +1137,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1213,9 +1177,7 @@ exports[`AcceptTerms renders appropriately if input is checked 1`] = `
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1256,9 +1218,7 @@ exports[`AcceptTerms renders appropriately if input is checked 2`] = `
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1290,9 +1250,7 @@ exports[`AcceptTerms renders appropriately if is B2B 1`] = `
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1323,9 +1281,7 @@ exports[`AcceptTerms renders appropriately if is B2B 2`] = `
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1380,9 +1336,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup 1`] = `
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1437,9 +1391,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup 2`] = `
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1494,9 +1446,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup and not trial 
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1551,9 +1501,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup and not trial 
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1613,9 +1561,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup and trial 1`] 
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1675,9 +1621,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup and trial 2`] 
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1717,9 +1661,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1759,9 +1701,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1801,9 +1741,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1843,9 +1781,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1885,9 +1821,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1927,9 +1861,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -1969,9 +1901,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -2011,9 +1941,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -2084,9 +2012,7 @@ exports[`AcceptTerms renders appropriately if is transition 1`] = `
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -2157,9 +2083,7 @@ exports[`AcceptTerms renders appropriately if is transition 2`] = `
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -2230,9 +2154,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -2303,9 +2225,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -2376,9 +2296,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -2449,9 +2367,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -2491,9 +2407,7 @@ exports[`AcceptTerms renders with an error 1`] = `
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox o-forms-input--invalid"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox o-forms-input--invalid">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -2533,9 +2447,7 @@ exports[`AcceptTerms renders with an error 2`] = `
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox o-forms-input--invalid"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox o-forms-input--invalid">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -2575,9 +2487,7 @@ exports[`AcceptTerms renders with default props 1`] = `
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -2617,9 +2527,7 @@ exports[`AcceptTerms renders with default props 2`] = `
       </p>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
+  <label class="o-forms-input o-forms-input--checkbox">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 const DEFAULT_AGE_RESTRICTION = '16';
 
-export function AcceptTerms({
+export function AcceptTerms ({
 	hasError = false,
 	isSignup = false,
 	isRegister = false,
@@ -19,19 +19,19 @@ export function AcceptTerms({
 	isPrintProduct = false,
 	specialTerms = null
 }) {
-	const divProps = {
-		id: 'acceptTermsField',
-		className: 'o-forms-field o-layout-typography ncf__validation-error',
-		'data-validate': 'required,checked',
-		...(isSignup && { 'data-trackable': 'sign-up-terms' }),
-		...(isRegister && { 'data-trackable': 'register-up-terms' })
-	};
-
-	const labelClassName = classNames([
+	const inputWrapperClassName = classNames([
 		'o-forms-input',
 		'o-forms-input--checkbox',
 		{ 'o-forms-input--invalid': hasError }
 	]);
+
+	const divProps = {
+		id: 'acceptTermsField',
+		className: 'o-forms-field ncf__validation-error',
+		'data-validate': 'required,checked',
+		...(isSignup && { 'data-trackable': 'sign-up-terms' }),
+		...(isRegister && { 'data-trackable': 'register-up-terms' })
+	};
 
 	const inputProps = {
 		id: 'termsAcceptance',
@@ -44,245 +44,89 @@ export function AcceptTerms({
 		...(isChecked && { defaultChecked: true })
 	};
 
-	const registerTerms = (
-		<label className={labelClassName}>
-			<input {...inputProps} />
-			<span className="o-forms-input__label" id="terms-register">
-				I confirm I am {ageRestriction} years or older and have read and
-				agree to the{" "}
-				<a
-					className="ncf__link--external"
-					href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-					target={isEmbedded ? "_top" : "_blank"}
-					rel="noopener noreferrer"
-					data-trackable="terms-and-conditions"
-				>
-					Terms &amp; Conditions
-				</a>
-				.
-			</span>
-			<p className="o-forms-input__error">Please accept our terms &amp; conditions</p>
-		</label>
-	)
+	const b2bTerms = isB2b && (
+		<span id="terms-b2b" className="o-forms-input__label">
+			By submitting this form, you indicate your consent to also being contacted by Financial Times by email, post, or phone about our other products, services or special offers unless you untick this box.
+		</span>
+	);
 
-	const b2bTerms = isB2b ? (
-		<li>
-			<p id="terms-b2b">
-				By submitting this form, you indicate your consent to also being
-				contacted by Financial Times by email, post, or phone about our
-				other products, services or special offers unless you untick this
-				box.
-			</p>
-		</li>
-	) : (
-		<li>
-			<p id="terms-default">
-				I confirm I am {ageRestriction} years or older and have read and
-				agree to the{" "}
-				<a
-					className="ncf__link--external"
-					href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-					target={isEmbedded ? "_top" : "_blank"}
-					rel="noopener noreferrer"
-					data-trackable="terms-and-conditions"
-				>
-					Terms &amp; Conditions
-				</a>
-				.
-			</p>
-		</li>
+	const defaultTerms = !isB2b && (
+		<span id="terms-default" className="o-forms-input__label">
+			I confirm I am {ageRestriction} years or older and have read and agree to the{' '}
+			<a
+				className="ncf__link--external"
+				href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+				target={ isEmbedded ? '_top' : '_blank' }
+				rel="noopener noreferrer"
+				data-trackable="terms-and-conditions"
+			>Terms &amp; Conditions</a>.
+		</span>
 	);
 
 	const corpSignupTerms = isCorpSignup && (
-		<>
-			<li>
-				<p className="terms-corp-signup">
-					Your organisation’s administrator(s) may view basic usage
-					and profile data about your account and have the ability to
-					set up myFT topic follows on your behalf.
-				</p>
-			</li>
-			<li>
-				<p className="terms-corp-signup">
-					Basic usage and profile data about your account can include;
-					for example, your job title and profile information, the
-					date you last visited, volume of content consumed, etc.
-				</p>
-			</li>
-			<li>
-				<p className="terms-corp-signup">
-					myFT topics may be selected on your behalf by your company
-					administrator or FT representative for you to follow. You
-					can unfollow these topics or unsubscribe from the myFT
-					digest through the Contact preferences section on myFT.
-				</p>
-			</li>
-			{isTrial && (
-				<li>
-					<p className="terms-corp-signup">
-						This trial is to demonstrate the value of a group
-						subscription and we’ll contact you during your trial.
-					</p>
-				</li>
-			)}
-		</>
+		<React.Fragment>
+			<span className="terms-corp-signup o-forms-input__label">Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.</span>
+			<span className="terms-corp-signup o-forms-input__label">Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.</span>
+			<span className="terms-corp-signup o-forms-input__label">myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.</span>
+			{ isTrial && (<span className="terms-corp-signup o-forms-input__label">This trial is to demonstrate the value of a group subscription and we’ll contact you during your trial.</span>) }
+		</React.Fragment>
 	);
 
 	const transitionTerms = isTransition && (
-		<>
-			<li>
-				<p className="terms-transition">
-					I give consent for my chosen payment method to be charged
-					automatically at the end of each subscription term until I
-					cancel it by contacting{" "}
-					<a
-						className="ncf__link--external"
-						href="https://help.ft.com/help/contact-us/"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						customer service through chat, phone or email
-					</a>
-					.
-				</p>
-			</li>
-			{transitionType === "immediate" ? (
-				<li>
-					<p className="terms-transition terms-transition--immediate">
-						By placing my order, my subscription will start
-						immediately. Cancellation notice would take effect at
-						the end of the subscription period and previously paid
-						amounts are non-refundable.
-					</p>
-				</li>
-			) : (
-				<li>
-					<p className="terms-transition terms-transition--other">
-						By placing my order, I acknowledge that my subscription
-						will start on the date given above. Any cancellation
-						notice received after that date will take effect at the
-						end of my subscription term and previously paid amounts
-						are non-refundable.
-					</p>
-				</li>
-			)}
-			<li>
-				<p className="terms-transition">
-					Find out more about our cancellation policy in our{" "}
-					<a
-						className="ncf__link--external"
-						href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						Terms &amp; Conditions
-					</a>
-					.
-				</p>
-			</li>
-		</>
+		<React.Fragment>
+			<span className="terms-transition o-forms-input__label">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a className="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="_blank" rel="noopener noreferrer">customer service through chat, phone or email</a>.</span>
+			{
+				transitionType === 'immediate'
+					? (<span className="terms-transition terms-transition--immediate o-forms-input__label">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</span>)
+					: (<span className="terms-transition terms-transition--other o-forms-input__label">By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.</span>)
+			}
+			<span className="terms-transition o-forms-input__label">Find out more about our cancellation policy in our <a className="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="_blank" rel="noopener noreferrer">Terms &amp; Conditions</a>.</span>
+		</React.Fragment>
 	);
 
 	const signupTerms = isSignup && (
-		<>
-			{isPrintProduct ? (
-				<>
-					<li>
-						<p className="terms-print">
-							Credit for delivery suspensions is only available
-							for hand-delivered subscriptions and is limited to a
-							maximum of 24 issues per yearly subscription terms
-							(4 issues per yearly FT Weekend subscription term).
-						</p>
-					</li>
-					<li>
-						<p className="terms-print">
-							Find out more about your delivery start date in our{" "}
-							<a
-								className="ncf__link--external"
-								href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-								target={isEmbedded ? "_top" : "_blank"}
-								rel="noopener noreferrer"
-							>
-								Terms &amp; Conditions
-							</a>
-							.
-						</p>
-					</li>
-				</>
-			) : (
-				<>
-					<li>
-						<p className="terms-signup">
-							I give consent for my chosen payment method to be
-							charged automatically at the end of each
-							subscription term until I cancel it by contacting{" "}
-							<a
-								className="ncf__link--external"
-								href="https://help.ft.com/help/contact-us/"
-								target={isEmbedded ? "_top" : "_blank"}
-								rel="noopener noreferrer"
-							>
-								customer service through chat, phone or email
-							</a>
-							.
-						</p>
-					</li>
-					<li>
-						<p className="terms-signup">
-							By placing my order, my subscription will start
-							immediately. Cancellation notice would take effect
-							at the end of the subscription period and previously
-							paid amounts are non-refundable.
-						</p>
-					</li>
-					<li>
-						<p className="terms-signup">
-							Find out more about our cancellation policy in our{" "}
-							<a
-								className="ncf__link--external"
-								href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-								target={isEmbedded ? "_top" : "_blank"}
-								rel="noopener noreferrer"
-							>
-								Terms &amp; Conditions
-							</a>
-							.
-						</p>
-					</li>
-				</>
-			)}
+		<React.Fragment>
+			{
+				isPrintProduct
+					? (
+						<React.Fragment>
+							<span className="terms-print o-forms-input__label">Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).</span>
+							<span className="terms-print o-forms-input__label">Find out more about your delivery start date in our <a className="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target={ isEmbedded ? '_top' : '_blank' } rel="noopener noreferrer">Terms &amp; Conditions</a>.</span>
+						</React.Fragment>
+					)
+					: (
+						<React.Fragment>
+							<span className="terms-signup o-forms-input__label">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a className="ncf__link--external" href="https://help.ft.com/help/contact-us/" target={ isEmbedded ? '_top' : '_blank' } rel="noopener noreferrer">customer service through chat, phone or email</a>.</span>
+							<span className="terms-signup o-forms-input__label">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</span>
+							<span className="terms-signup o-forms-input__label">Find out more about our cancellation policy in our <a className="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target={ isEmbedded ? '_top' : '_blank' } rel="noopener noreferrer">Terms &amp; Conditions</a>.</span>
+						</React.Fragment>
+					)
+			}
 
-			{specialTerms && (
-				<li>
-					<p id="terms-special">{specialTerms}</p>
-				</li>
-			)}
-		</>
+			{ specialTerms && (<span id="terms-special" className="o-forms-input__label">{specialTerms}</span>) }
+		</React.Fragment>
 	);
 
 	return (
 		<div {...divProps}>
-			{isRegister ? 
-				registerTerms 
-				: (
-					<>
-						<ul className="o-typography-list o-typography-list--unordered">	
-							{b2bTerms}
-							{corpSignupTerms}
-							{transitionTerms}
-							{signupTerms}
-						</ul>
-						<label className={labelClassName}>
-							<input {...inputProps} />
-							<span className="o-forms-input__label">
-								I agree to the terms &amp; conditions.
-							</span>
-							<p className="o-forms-input__error">Please accept our terms &amp; conditions</p>
-						</label>
-					</>
-				)
-			}
+			<span className="o-forms-title n-ui-hide">
+				<span className="o-forms-title__main">Terms</span>
+			</span>
+			<span className={inputWrapperClassName}>
+				<label htmlFor={inputProps.id}>
+					<input {...inputProps} />
+					{ b2bTerms }
+
+					{ defaultTerms }
+
+					{ corpSignupTerms }
+
+					{ transitionTerms }
+
+					{ signupTerms }
+				</label>
+				<span className="o-forms-input__error">Please accept our terms &amp; conditions</span>
+			</span>
 		</div>
 	);
 }

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -45,7 +45,7 @@ export function AcceptTerms({
 	};
 
 	const registerTerms = (
-		<label className={labelClassName} htmlFor="termsAcceptance">
+		<label className={labelClassName}>
 			<input {...inputProps} />
 			<span className="o-forms-input__label" id="terms-register">
 				I confirm I am {ageRestriction} years or older and have read and
@@ -273,7 +273,7 @@ export function AcceptTerms({
 							{transitionTerms}
 							{signupTerms}
 						</ul>
-						<label className={labelClassName} htmlFor="termsAcceptance">
+						<label className={labelClassName}>
 							<input {...inputProps} />
 							<span className="o-forms-input__label">
 								I agree to the terms &amp; conditions.

--- a/main.scss
+++ b/main.scss
@@ -19,7 +19,6 @@
 @import './styles/forms-additional-field-information';
 @import './styles/error';
 
-@include oTypography();
 @include oFonts();
 @include oForms($opts: (
 	'elements': (

--- a/partials/accept-terms.html
+++ b/partials/accept-terms.html
@@ -1,6 +1,6 @@
 <div id="acceptTermsField" class="o-forms-field o-layout-typography ncf__validation-error" data-validate="required,checked" {{#if isSignup}}data-trackable="sign-up-terms"{{/if}}{{#if isRegister}}data-trackable="register-up-terms"{{/if}}>
 	{{#if isRegister}}
-		<label class="o-forms-input o-forms-input--checkbox{{#if hasError}} o-forms-input--invalid{{/if}}" for="termsAcceptance">
+		<label class="o-forms-input o-forms-input--checkbox{{#if hasError}} o-forms-input--invalid{{/if}}">
 			<input type="checkbox" id="termsAcceptance" name="termsAcceptance" value="true" data-trackable="field-terms" aria-required="true" required {{#if isChecked}}checked{{/if}} />
 			<span class="o-forms-input__label" id="terms-register">
 				I confirm I am {{#if ageRestriction}}{{ageRestriction}}{{else}}16{{/if}} years or older and have read and agree to the
@@ -85,7 +85,7 @@
 			{{/if}}
 
 		</ul>
-		<label class="o-forms-input o-forms-input--checkbox{{#if hasError}} o-forms-input--invalid{{/if}}" for="termsAcceptance">
+		<label class="o-forms-input o-forms-input--checkbox{{#if hasError}} o-forms-input--invalid{{/if}}">
 			<input type="checkbox" id="termsAcceptance" name="termsAcceptance" value="true" data-trackable="field-terms" aria-required="true" required {{#if isChecked}}checked{{/if}} />
 			<span class="o-forms-input__label">
 				I agree to the terms &amp; conditions.

--- a/partials/accept-terms.html
+++ b/partials/accept-terms.html
@@ -1,96 +1,55 @@
-<div id="acceptTermsField" class="o-forms-field o-layout-typography ncf__validation-error" data-validate="required,checked" {{#if isSignup}}data-trackable="sign-up-terms"{{/if}}{{#if isRegister}}data-trackable="register-up-terms"{{/if}}>
-	{{#if isRegister}}
-		<label class="o-forms-input o-forms-input--checkbox{{#if hasError}} o-forms-input--invalid{{/if}}">
+<div id="acceptTermsField" class="o-forms-field ncf__validation-error" data-validate="required,checked" {{#if isSignup}}data-trackable="sign-up-terms"{{/if}}{{#if isRegister}}data-trackable="register-up-terms"{{/if}}>
+	<span class="o-forms-title n-ui-hide">
+		<span class="o-forms-title__main">Terms</span>
+	</span>
+	<span class="o-forms-input o-forms-input--checkbox{{#if hasError}} o-forms-input--invalid{{/if}}">
+		<label for="termsAcceptance">
 			<input type="checkbox" id="termsAcceptance" name="termsAcceptance" value="true" data-trackable="field-terms" aria-required="true" required {{#if isChecked}}checked{{/if}} />
-			<span class="o-forms-input__label" id="terms-register">
-				I confirm I am {{#if ageRestriction}}{{ageRestriction}}{{else}}16{{/if}} years or older and have read and agree to the
-					<a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer" data-trackable="terms-and-conditions">Terms &amp; Conditions</a>.
+			{{#if isB2b }}
+			<span id="terms-b2b" class="o-forms-input__label">
+				By submitting this form, you indicate your consent to also being contacted by Financial Times by email, post, or phone about our other products, services or special offers unless you untick this box.
 			</span>
-			<p class="o-forms-input__error">Please accept our terms &amp; conditions</p>
-		</label>
-	{{else}}
-		<ul class="o-typography-list o-typography-list--unordered">
-			<li>
-				{{#if isB2b }}
-					<p id="terms-b2b">
-						By submitting this form, you indicate your consent to also being contacted by Financial Times by email, post, or phone about our other products, services or special offers unless you untick this box.
-					</p>
-				{{else}}
-					<p id="terms-default">
-						I confirm I am {{#if ageRestriction}}{{ageRestriction}}{{else}}16{{/if}} years or older and have read and agree to the
-						<a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded }}_top{{else}}_blank{{/if}}" rel="noopener noreferrer" data-trackable="terms-and-conditions">Terms &amp; Conditions</a>.
-					</p>
-				{{/if}}
-			</li>
+			{{else}}
+			<span id="terms-default" class="o-forms-input__label">
+				I confirm I am {{#if ageRestriction}}{{ageRestriction}}{{else}}16{{/if}} years or older and have read and agree to the
+				<a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer" data-trackable="terms-and-conditions">Terms &amp; Conditions</a>.
+			</span>
+			{{/if}}
 
 			{{#if isCorpSignup}}
-				<li>
-					<p class="terms-corp-signup">Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.</p>
-				</li>
-				<li>
-					<p class="terms-corp-signup">Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.</p>
-				</li>
-				<li>
-					<p class="terms-corp-signup">myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.</p>
-				</li>
+			<span class="terms-corp-signup o-forms-input__label">Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.</span>
+			<span class="terms-corp-signup o-forms-input__label">Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.</span>
+			<span class="terms-corp-signup o-forms-input__label">myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.</span>
+
 				{{#if isTrial}}
-					<li>
-						<p class="terms-corp-signup">This trial is to demonstrate the value of a group subscription and we’ll contact you during your trial.</p>
-					</li>
+				<span class="terms-corp-signup o-forms-input__label">This trial is to demonstrate the value of a group subscription and we’ll contact you during your trial.</span>
 				{{/if}}
 			{{/if}}
 
 			{{#if isTransition}}
-				<li>
-					<p class="terms-transition">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="_blank" rel="noopener noreferrer">customer service through chat, phone or email</a>.</p>
-				</li>
-				{{#ifEquals transitionType 'immediate'}}
-					<li>
-						<p class="terms-transition terms-transition--immediate">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</p>
-					</li>
-				{{else}}
-					<li>
-						<p class="terms-transition terms-transition--other">By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.</p>
-					</li>
-				{{/ifEquals}}
-				<li>
-					<p class="terms-transition">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="_blank" rel="noopener noreferrer">Terms &amp; Conditions</a>.</p>
-				</li>
+			<span class="terms-transition o-forms-input__label">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="_blank" rel="noopener noreferrer">customer service through chat, phone or email</a>.</span>
+			{{#ifEquals transitionType 'immediate'}}
+			<span class="terms-transition terms-transition--immediate o-forms-input__label">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</span>
+			{{else}}
+			<span class="terms-transition terms-transition--other o-forms-input__label">By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.</span>
+			{{/ifEquals}}
+			<span class="terms-transition o-forms-input__label">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="_blank" rel="noopener noreferrer">Terms &amp; Conditions</a>.</span>
 			{{/if}}
 
 			{{#if isSignup}}
 				{{#if isPrintProduct}}
-					<li>
-						<p class="terms-print">Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).</p>
-					</li>
-					<li>
-						<p class="terms-print">Find out more about your delivery start date in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer">Terms &amp; Conditions</a>.</p>
-					</li>
+			<span class="terms-print o-forms-input__label">Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).</span>
+			<span class="terms-print o-forms-input__label">Find out more about your delivery start date in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer">Terms &amp; Conditions</a>.</span>
 				{{else}}
-					<li>
-						<p class="terms-signup">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer">customer service through chat, phone or email</a>.</p>
-					</li>
-					<li>
-						<p class="terms-signup">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</p>
-					</li>
-					<li>
-						<p class="terms-signup">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer">Terms &amp; Conditions</a>.</p>
-					</li>
+			<span class="terms-signup o-forms-input__label">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer">customer service through chat, phone or email</a>.</span>
+			<span class="terms-signup o-forms-input__label">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</span>
+			<span class="terms-signup o-forms-input__label">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer">Terms &amp; Conditions</a>.</span>
 				{{/if}}
 				{{#if specialTerms}}
-					<li>
-						<p id="terms-special">{{specialTerms}}</p>
-					</li>
+			<span id="terms-special" class="o-forms-input__label">{{specialTerms}}</span>
 				{{/if}}
 			{{/if}}
-
-		</ul>
-		<label class="o-forms-input o-forms-input--checkbox{{#if hasError}} o-forms-input--invalid{{/if}}">
-			<input type="checkbox" id="termsAcceptance" name="termsAcceptance" value="true" data-trackable="field-terms" aria-required="true" required {{#if isChecked}}checked{{/if}} />
-			<span class="o-forms-input__label">
-				I agree to the terms &amp; conditions.
-			</span>
-			<p class="o-forms-input__error">Please accept our terms &amp; conditions</p>
 		</label>
-	{{/if}}
+		<span class="o-forms-input__error">Please accept our terms &amp; conditions</span>
+	</span>
 </div>

--- a/test/partials/accept-terms.spec.js
+++ b/test/partials/accept-terms.spec.js
@@ -5,13 +5,12 @@ const {
 } = require('../helpers');
 
 const SELECTOR_STANDARD_TERMS = '#terms-default';
-const SELECTOR_PRINT_TERMS = '.terms-print';
-const SELECTOR_SIGNUP_TERMS = '.terms-signup';
+const SELECTOR_PRINT_TERMS = 'label .terms-print';
+const SELECTOR_SIGNUP_TERMS = 'label .terms-signup';
 const SELECTOR_SPECIAL_TERMS = '#terms-special';
 const SELECTOR_B2B_TERMS = '#terms-b2b';
-const SELECTOR_CORP_TERMS = '.terms-corp-signup';
-const SELECTOR_TRANSITION_TERMS = '.terms-transition';
-const SELECTOR_REGISTER_TERMS = '#terms-register';
+const SELECTOR_CORP_TERMS = 'label .terms-corp-signup';
+const SELECTOR_TRANSITION_TERMS = 'label .terms-transition';
 const SELECTOR_ACCEPT_TERMS_FIELD = '#acceptTermsField';
 const SELECTOR_CHECKBOX = 'input';
 const SELECTOR_ANCHOR = 'a';
@@ -71,7 +70,7 @@ describe('accept-terms template', () => {
 		it('should have default terms', () => {
 			const $ = context.template(params);
 
-			expectTerms($, {register: 1});
+			expectTerms($, {standard: 1});
 		});
 	});
 
@@ -212,7 +211,7 @@ describe('accept-terms template', () => {
 	shouldError(context);
 });
 
-function expectTerms ($, { standard=0, print=0, signup=0, special=0, b2b=0, corp=0, transition=0, register=0 }) {
+function expectTerms ($, { standard=0, print=0, signup=0, special=0, b2b=0, corp=0, transition=0 }) {
 	expect($(SELECTOR_STANDARD_TERMS).length).to.equal(standard);
 	expect($(SELECTOR_PRINT_TERMS).length).to.equal(print);
 	expect($(SELECTOR_SIGNUP_TERMS).length).to.equal(signup);
@@ -220,5 +219,4 @@ function expectTerms ($, { standard=0, print=0, signup=0, special=0, b2b=0, corp
 	expect($(SELECTOR_B2B_TERMS).length).to.equal(b2b);
 	expect($(SELECTOR_CORP_TERMS).length).to.equal(corp);
 	expect($(SELECTOR_TRANSITION_TERMS).length).to.equal(transition);
-	expect($(SELECTOR_REGISTER_TERMS).length).to.equal(register);
 }


### PR DESCRIPTION
### Description
 - Revert accessibiliy changes to terms and conditions whilst we await Product to check with legal regarding copy approval.

[Ticket](https://financialtimes.atlassian.net/browse/AC-112?atlOrigin=eyJpIjoiY2VjZTQ1MzYyMDQ0NDY2MmEwZDYwZjM1ZDFkMjZhM2UiLCJwIjoiaiJ9)

### Screenshots

| Before | After |
| ------ | ----- |
| <img width="710" alt="image" src="https://user-images.githubusercontent.com/7748470/74549372-6e4c7c00-4f47-11ea-8844-9255f2ce18c4.png"> | <img width="710" alt="image" src="https://user-images.githubusercontent.com/7748470/74549042-d6e72900-4f46-11ea-901a-388508cf43ee.png"> |
