### PR TITLE
Amend confirmation message for educational clients

### DIFF
--- a/components/__snapshots__/licence-confirmation.spec.js.snap
+++ b/components/__snapshots__/licence-confirmation.spec.js.snap
@@ -1,5 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`LicenceConfirmation renders if educational licence 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <div class="ncf__paragraph">
+      <h1 class="ncf__header ncf__header--confirmation">
+        Great news, you have joined your school licence
+      </h1>
+    </div>
+  </div>
+  <p class="ncf__paragraph">
+    Go to myFT to personalise your feed &amp; follow topics &amp; articles of interest to you. Set this up now or later.
+  </p>
+  <p class="ncf__paragraph">
+    Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
+  </p>
+  <p class="ncf__paragraph ncf__center">
+    <a href="/myft"
+       class="ncf__button ncf__button--submit"
+    >
+      Go to myFT
+    </a>
+  </p>
+  <p class="ncf__paragraph ncf__center">
+    <a href="/"
+       class="ncf__link"
+    >
+      Go to the homepage
+    </a>
+  </p>
+</div>
+`;
+
+exports[`LicenceConfirmation renders if educational licence 2`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <div class="ncf__paragraph">
+      <h1 class="ncf__header ncf__header--confirmation">
+        Great news, you have joined your school licence
+      </h1>
+    </div>
+  </div>
+  <p class="ncf__paragraph">
+    Go to myFT to personalise your feed &amp; follow topics &amp; articles of interest to you. Set this up now or later.
+  </p>
+  <p class="ncf__paragraph">
+    Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
+  </p>
+  <p class="ncf__paragraph ncf__center">
+    <a href="/myft"
+       class="ncf__button ncf__button--submit"
+    >
+      Go to myFT
+    </a>
+  </p>
+  <p class="ncf__paragraph ncf__center">
+    <a href="/"
+       class="ncf__link"
+    >
+      Go to the homepage
+    </a>
+  </p>
+</div>
+`;
+
 exports[`LicenceConfirmation renders if is embedded 1`] = `
 <div class="ncf ncf__wrapper">
   <div class="ncf__center">

--- a/components/licence-confirmation.jsx
+++ b/components/licence-confirmation.jsx
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types';
 export function LicenceConfirmation ({
 	isTrial = false,
 	isEmbedded = false,
-	duration = null
+	duration = null,
+	isEducationalLicence = false,
 }) {
 	const myFtLinkProps = {
 		href: '/myft',
@@ -26,7 +27,7 @@ export function LicenceConfirmation ({
 					{
 						isTrial
 							? (<h1 className="ncf__header ncf__header--confirmation">Your{ duration ? ` ${duration}` : '' } trial has started</h1>)
-							: (<h1 className="ncf__header ncf__header--confirmation">Great news, you have joined your company licence</h1>)
+							: (<h1 className="ncf__header ncf__header--confirmation">Great news, you have joined your { isEducationalLicence ? 'school' : 'company'} licence</h1>)
 					}
 				</div>
 			</div>
@@ -53,5 +54,6 @@ export function LicenceConfirmation ({
 LicenceConfirmation.propTypes = {
 	isTrial: PropTypes.bool,
 	isEmbedded: PropTypes.bool,
-	duration: PropTypes.string
+	duration: PropTypes.string,
+	isEducationalLicence: PropTypes.bool,
 };

--- a/components/licence-confirmation.spec.js
+++ b/components/licence-confirmation.spec.js
@@ -34,4 +34,9 @@ describe('LicenceConfirmation', () => {
 
 		expect(LicenceConfirmation).toRenderAs(context, props);
 	});
+
+	it('renders if educational licence', () => {
+		const props = { isEducationalLicence: true };
+		expect(LicenceConfirmation).toRenderAs(context, props);
+	});
 });

--- a/partials/licence-confirmation.html
+++ b/partials/licence-confirmation.html
@@ -5,7 +5,7 @@
 			{{#if isTrial}}
 			<h1 class="ncf__header ncf__header--confirmation">Your{{#if duration}} {{duration}}{{/if}} trial has started</h1>
 			{{else}}
-			<h1 class="ncf__header ncf__header--confirmation">Great news, you have joined your company licence</h1>
+			<h1 class="ncf__header ncf__header--confirmation">Great news, you have joined your {{#if isEducationalLicence}}school{{else}}company{{/if}} licence</h1>
 			{{/if}}
 		</div>
 	</div>


### PR DESCRIPTION
### Description
Adds a `isEducationalLicence` prop to the licence-confirmation component and Handlebar template, to customise the confirmation message for people signing up to a B2B licence of an educational client.

[Ticket](https://financialtimes.atlassian.net/jira/software/projects/USG/boards/969?selectedIssue=USG-15)

### Screenshots

| Before | After |
| ------ | ----- |
|![image](https://user-images.githubusercontent.com/1705375/75025921-efe66180-5493-11ea-9fb3-ab9f593619cb.png)|![Screenshot 2020-02-21 at 10 20 19](https://user-images.githubusercontent.com/1705375/75025850-ce857580-5493-11ea-8714-8bffc3b313b4.png)|

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Tests** written for new or updated for existing functionality