### PR TITLE
Unpin bower dependencies 🐿 v2.12.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,21 +33,21 @@
     "main.scss"
   ],
   "devDependencies": {
-    "o-layout": "4.0.1",
-    "o-header-services": "4.0.0"
+    "o-layout": "^4.0.1",
+    "o-header-services": "^4.0.0"
   },
   "dependencies": {
-    "o-forms": "8.1.9",
-    "o-buttons": "6.0.2",
-    "o-message": "4.0.1",
-    "o-colors": "5.0.2",
-    "o-icons": "6.0.0",
-    "o-stepped-progress": "2.0.0",
-    "o-expander": "5.0.1",
-    "o-loading": "4.0.0",
-    "o-grid": "5.0.0",
-    "o-typography": "6.1.0",
-    "o-normalise": "2.0.1"
+    "o-forms": "^8.1.9",
+    "o-buttons": "^6.0.2",
+    "o-message": "^4.0.1",
+    "o-colors": "^5.0.2",
+    "o-icons": "^6.0.0",
+    "o-stepped-progress": "^2.0.0",
+    "o-expander": "^5.0.1",
+    "o-loading": "^4.0.0",
+    "o-grid": "^5.0.0",
+    "o-typography": "^6.1.0",
+    "o-normalise": "^2.0.1"
   },
   "resolutions": {
     "ftdomdelegate": "3.0.0"

--- a/bower.json
+++ b/bower.json
@@ -50,6 +50,6 @@
     "o-normalise": "^2.0.1"
   },
   "resolutions": {
-    "ftdomdelegate": "3.0.0"
+    "ftdomdelegate": "^3.0.0"
   }
 }


### PR DESCRIPTION
 - Fix for issue in `next-retention` were build was failing due to conflicting dependencies.