### PR TITLE
Remove teal colouring for customer care message on mobile 🐿 v2.12.5

### DIFF
--- a/styles/customer-care.scss
+++ b/styles/customer-care.scss
@@ -2,32 +2,6 @@
 
 @mixin ncfCustomerCarePanel() {
 
-	@include oGridRespondTo($until: M) {
-
-		&__customer-care {
-			background: oColorsByName('teal');
-			color: oColorsByName('white');
-		}
-
-		&__customer-care &__icon {
-			background: oColorsByName('white');
-			border-color: oColorsByName('white');
-			&::before {
-				@include oIconsContent(
-					$icon-name: 'phone',
-					$color: oColorsByName('teal'),
-					$size: 40
-				);
-				color: oColorsByName('teal');
-			}
-		}
-
-		&__customer-care &__link {
-			color: oColorsByName('white');
-		}
-
-	}
-
 	&__customer-care {
 		&__phone {
 			margin-bottom: 0;


### PR DESCRIPTION
### Description

Doing a search turned up instances of this only being used in `next-retention` which is where this bug was reported so it may as well be ripped out.

[Ticket](https://financialtimes.atlassian.net/browse/AC-241)

### Screenshots

| Before | After |
| ------ | ----- |
| <img width="281" alt="1583254889" src="https://user-images.githubusercontent.com/708296/75800004-d507cd00-5d70-11ea-9ecf-3bad1d8cc406.png"> | <img width="280" alt="1583254960" src="https://user-images.githubusercontent.com/708296/75800029-ddf89e80-5d70-11ea-80ac-00e7c1e3b496.png"> |