### PR TITLE
Make headers optional on customer care partial

### DIFF
--- a/components/customer-care.jsx
+++ b/components/customer-care.jsx
@@ -19,10 +19,10 @@ export function CustomerCare ({
 
 	return (
 		<div className={className}>
-			<div className="ncf__paragraph">
-				<h1 className="ncf__header">{header}</h1>
-				<p id="customer-care-message">{message}</p>
-			</div>
+			{(header || message) && <div className="ncf__paragraph">
+				{header && <h1 className="ncf__header">{header}</h1>}
+				{message && <p id="customer-care-message">{message}</p>}
+			</div>}
 
 			<div className="ncf__paragraph">
 				<div className="ncf__icon ncf__icon--phone ncf__icon--large"></div>


### PR DESCRIPTION
### Description

This partial isn't always used in a full page context so make the headers optional.

[Ticket](https://financialtimes.atlassian.net/browse/AC-246)

For example:

<img width="686" alt="1583493612" src="https://user-images.githubusercontent.com/708296/76079413-8179c700-5f9c-11ea-980e-4f45f7f80443.png">