### PR TITLE
ACQ-115: Set additonalMessages html with dangerouslySetInnerHTML 🐿 v2.12.6

### DIFF
--- a/components/message.jsx
+++ b/components/message.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 export function Message ({ title, message, additional = [], actions = null, name, isNotice, isError, isSuccess, isInform, isStaticMessage, isHidden }) {
 
 	const additionalMessages = additional.map((text, index) => {
-		return <p className="o-message__content--additional" key={index}>{text}</p>;
+		return <p className="o-message__content--additional" key={index} dangerouslySetInnerHTML={{__html: text }}></p>;
 	});
 
 	const oMessageClassNames = classNames({


### PR DESCRIPTION
`next-subscribe` passes links in the text for `additionalMessages`. This needs to be set dangerously for it to be rendered properly.

[Ticket](https://financialtimes.atlassian.net/browse/ACQ-115)