### PR TITLE
ACQ-115: Set message text html with dangerouslySetInnerHTML 🐿 v2.12.6

### DIFF
--- a/components/message.jsx
+++ b/components/message.jsx
@@ -39,7 +39,7 @@ export function Message ({ title, message, additional = [], actions = null, name
 					<div className="o-message__content">
 						<p className="o-message__content-main">
 							{title ? <span className="o-message__content-highlight">{title}</span> : null}
-							<span className="o-message__content-detail">{message}</span>
+							<span className="o-message__content-detail" dangerouslySetInnerHTML={{__html: message }}></span>
 						</p>
 						{additionalMessages}
 						{callToActionsList}


### PR DESCRIPTION
Very similar to https://github.com/Financial-Times/n-conversion-forms/pull/415.

`next-subscribe` passes links in the text for `message`. This needs to be set dangerously for it to be rendered properly.

[Ticket](https://financialtimes.atlassian.net/browse/ACQ-115)