### PR TITLE
ACQ-87: add billing city fields (for epaper) 🐿 v2.12.6

### DIFF
--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -101,7 +101,7 @@ exports[`AcceptTerms renders appropriately if a signup 1`] = `
            target="_blank"
            rel="noopener noreferrer"
         >
-          customer service through chat, phone or email
+          customer care through chat, phone or email
         </a>
         .
       </span>
@@ -175,7 +175,7 @@ exports[`AcceptTerms renders appropriately if a signup 2`] = `
            target="_blank"
            rel="noopener noreferrer"
         >
-          customer service through chat, phone or email
+          customer care through chat, phone or email
         </a>
         .
       </span>
@@ -249,7 +249,7 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 1`]
            target="_blank"
            rel="noopener noreferrer"
         >
-          customer service through chat, phone or email
+          customer care through chat, phone or email
         </a>
         .
       </span>
@@ -328,7 +328,7 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 2`]
            target="_blank"
            rel="noopener noreferrer"
         >
-          customer service through chat, phone or email
+          customer care through chat, phone or email
         </a>
         .
       </span>
@@ -773,7 +773,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
            target="_blank"
            rel="noopener noreferrer"
         >
-          customer service through chat, phone or email
+          customer care through chat, phone or email
         </a>
         .
       </span>
@@ -847,7 +847,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
            target="_blank"
            rel="noopener noreferrer"
         >
-          customer service through chat, phone or email
+          customer care through chat, phone or email
         </a>
         .
       </span>
@@ -921,7 +921,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
            target="_top"
            rel="noopener noreferrer"
         >
-          customer service through chat, phone or email
+          customer care through chat, phone or email
         </a>
         .
       </span>
@@ -995,7 +995,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
            target="_top"
            rel="noopener noreferrer"
         >
-          customer service through chat, phone or email
+          customer care through chat, phone or email
         </a>
         .
       </span>
@@ -1069,7 +1069,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
            target="_blank"
            rel="noopener noreferrer"
         >
-          customer service through chat, phone or email
+          customer care through chat, phone or email
         </a>
         .
       </span>
@@ -1143,7 +1143,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
            target="_blank"
            rel="noopener noreferrer"
         >
-          customer service through chat, phone or email
+          customer care through chat, phone or email
         </a>
         .
       </span>
@@ -2056,7 +2056,7 @@ exports[`AcceptTerms renders appropriately if is transition 1`] = `
            target="_blank"
            rel="noopener noreferrer"
         >
-          customer service through chat, phone or email
+          customer care through chat, phone or email
         </a>
         .
       </span>
@@ -2129,7 +2129,7 @@ exports[`AcceptTerms renders appropriately if is transition 2`] = `
            target="_blank"
            rel="noopener noreferrer"
         >
-          customer service through chat, phone or email
+          customer care through chat, phone or email
         </a>
         .
       </span>
@@ -2202,7 +2202,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
            target="_blank"
            rel="noopener noreferrer"
         >
-          customer service through chat, phone or email
+          customer care through chat, phone or email
         </a>
         .
       </span>
@@ -2275,7 +2275,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
            target="_blank"
            rel="noopener noreferrer"
         >
-          customer service through chat, phone or email
+          customer care through chat, phone or email
         </a>
         .
       </span>
@@ -2348,7 +2348,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
            target="_blank"
            rel="noopener noreferrer"
         >
-          customer service through chat, phone or email
+          customer care through chat, phone or email
         </a>
         .
       </span>
@@ -2421,7 +2421,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
            target="_blank"
            rel="noopener noreferrer"
         >
-          customer service through chat, phone or email
+          customer care through chat, phone or email
         </a>
         .
       </span>

--- a/components/__snapshots__/billing-city.spec.js.snap
+++ b/components/__snapshots__/billing-city.spec.js.snap
@@ -1,0 +1,243 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BillingCity renders with a custom value 1`] = `
+<label id="billingCityField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="billingCity"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing city/town
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="billingCity"
+           name="billingCity"
+           data-trackable="field-billingCity"
+           autocomplete="address-level2"
+           placeholder="e.g. Bath"
+           maxlength="40"
+           aria-required="true"
+           required
+           value="foobar"
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid city or town
+    </span>
+  </span>
+</label>
+`;
+
+exports[`BillingCity renders with a custom value 2`] = `
+<label id="billingCityField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="billingCity"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing city/town
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="billingCity"
+           name="billingCity"
+           data-trackable="field-billingCity"
+           autocomplete="address-level2"
+           placeholder="e.g. Bath"
+           maxlength="40"
+           aria-required="true"
+           required
+           value="foobar"
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid city or town
+    </span>
+  </span>
+</label>
+`;
+
+exports[`BillingCity renders with a disabled input element 1`] = `
+<label id="billingCityField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="billingCity"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing city/town
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="billingCity"
+           name="billingCity"
+           data-trackable="field-billingCity"
+           autocomplete="address-level2"
+           placeholder="e.g. Bath"
+           maxlength="40"
+           aria-required="true"
+           required
+           disabled
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid city or town
+    </span>
+  </span>
+</label>
+`;
+
+exports[`BillingCity renders with a disabled input element 2`] = `
+<label id="billingCityField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="billingCity"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing city/town
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="billingCity"
+           name="billingCity"
+           data-trackable="field-billingCity"
+           autocomplete="address-level2"
+           placeholder="e.g. Bath"
+           maxlength="40"
+           aria-required="true"
+           required
+           disabled
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid city or town
+    </span>
+  </span>
+</label>
+`;
+
+exports[`BillingCity renders with an error 1`] = `
+<label id="billingCityField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="billingCity"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing city/town
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+    <input type="text"
+           id="billingCity"
+           name="billingCity"
+           data-trackable="field-billingCity"
+           autocomplete="address-level2"
+           placeholder="e.g. Bath"
+           maxlength="40"
+           aria-required="true"
+           required
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid city or town
+    </span>
+  </span>
+</label>
+`;
+
+exports[`BillingCity renders with an error 2`] = `
+<label id="billingCityField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="billingCity"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing city/town
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+    <input type="text"
+           id="billingCity"
+           name="billingCity"
+           data-trackable="field-billingCity"
+           autocomplete="address-level2"
+           placeholder="e.g. Bath"
+           maxlength="40"
+           aria-required="true"
+           required
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid city or town
+    </span>
+  </span>
+</label>
+`;
+
+exports[`BillingCity renders with default props 1`] = `
+<label id="billingCityField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="billingCity"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing city/town
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="billingCity"
+           name="billingCity"
+           data-trackable="field-billingCity"
+           autocomplete="address-level2"
+           placeholder="e.g. Bath"
+           maxlength="40"
+           aria-required="true"
+           required
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid city or town
+    </span>
+  </span>
+</label>
+`;
+
+exports[`BillingCity renders with default props 2`] = `
+<label id="billingCityField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="billingCity"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Billing city/town
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="billingCity"
+           name="billingCity"
+           data-trackable="field-billingCity"
+           autocomplete="address-level2"
+           placeholder="e.g. Bath"
+           maxlength="40"
+           aria-required="true"
+           required
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid city or town
+    </span>
+  </span>
+</label>
+`;

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -141,7 +141,7 @@ export function AcceptTerms({
 						target="_blank"
 						rel="noopener noreferrer"
 					>
-						customer service through chat, phone or email
+						customer care through chat, phone or email
 					</a>
 					.
 				</span>
@@ -223,7 +223,7 @@ export function AcceptTerms({
 								target={isEmbedded ? "_top" : "_blank"}
 								rel="noopener noreferrer"
 							>
-								customer service through chat, phone or email
+								customer care through chat, phone or email
 							</a>
 							.
 						</span>

--- a/components/billing-city.jsx
+++ b/components/billing-city.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export function BillingCity ({
+	hasError = false,
+	value = '',
+	isDisabled = false
+}) {
+	const inputWrapperClassName = classNames([
+		'o-forms-input',
+		'o-forms-input--text',
+		{ 'o-forms-input--invalid': hasError }
+	]);
+
+	return (
+		<label
+			id="billingCityField"
+			className="o-forms-field ncf__validation-error"
+			data-validate="required"
+			htmlFor="billingCity"
+		>
+			<span className="o-forms-title">
+				<span className="o-forms-title__main">Billing city/town</span>
+			</span>
+			<span className={inputWrapperClassName}>
+				<input
+					type="text"
+					id="billingCity"
+					name="billingCity"
+					data-trackable="field-billingCity"
+					autoComplete="address-level2"
+					placeholder="e.g. Bath"
+					maxLength={40}
+					aria-required="true"
+					required
+					disabled={isDisabled}
+					defaultValue={value}
+				/>
+			<span className="o-forms-input__error">Please enter a valid city or town</span>
+			</span>
+		</label>
+	);
+}
+
+BillingCity.propTypes = {
+	hasError: PropTypes.bool,
+	value: PropTypes.string,
+	isDisabled: PropTypes.bool,
+	maxlength: PropTypes.number
+};

--- a/components/billing-city.spec.js
+++ b/components/billing-city.spec.js
@@ -1,0 +1,37 @@
+import { BillingCity } from './index';
+import { expectToRenderAs } from '../test-jest/helpers/expect-to-render-as';
+import { fetchPartialAsString } from '../test-jest/helpers/fetch-hbs-as-string';
+
+const context = {};
+
+expect.extend(expectToRenderAs);
+
+describe('BillingCity', () => {
+	beforeAll(async () => {
+		context.template = await fetchPartialAsString('billing-city.html');
+	});
+
+	it('renders with default props', () => {
+		const props = {};
+
+		expect(BillingCity).toRenderAs(context, props);
+	});
+
+	it('renders with an error', () => {
+		const props = { hasError: true };
+
+		expect(BillingCity).toRenderAs(context, props);
+	});
+
+	it('renders with a custom value', () => {
+		const props = { value: 'foobar' };
+
+		expect(BillingCity).toRenderAs(context, props);
+	});
+
+	it('renders with a disabled input element', () => {
+		const props = { isDisabled: true };
+
+		expect(BillingCity).toRenderAs(context, props);
+	});
+});

--- a/components/index.jsx
+++ b/components/index.jsx
@@ -1,5 +1,6 @@
 export { AcceptTerms } from'./accept-terms';
 export { AppBanner } from'./app-banner';
+export { BillingCity } from './billing-city';
 export { BillingCountry } from './billing-country';
 export { BillingPostcode } from'./billing-postcode';
 export { CompanyName } from'./company-name';

--- a/partials/accept-terms.html
+++ b/partials/accept-terms.html
@@ -42,7 +42,7 @@
 
 			{{#if isTransition}}
 				<li>
-					<span class="terms-transition">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="_blank" rel="noopener noreferrer">customer service through chat, phone or email</a>.</span>
+					<span class="terms-transition">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="_blank" rel="noopener noreferrer">customer care through chat, phone or email</a>.</span>
 				</li>
 				{{#ifEquals transitionType 'immediate'}}
 					<li>
@@ -68,7 +68,7 @@
 					</li>
 				{{else}}
 					<li>
-						<span class="terms-signup">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer">customer service through chat, phone or email</a>.</span>
+						<span class="terms-signup">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer">customer care through chat, phone or email</a>.</span>
 					</li>
 					<li>
 						<span class="terms-signup">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</span>

--- a/partials/billing-city.html
+++ b/partials/billing-city.html
@@ -1,0 +1,17 @@
+<label id="billingCityField" class="o-forms-field ncf__validation-error" data-validate="required" for="billingCity">
+	<span class="o-forms-title">
+		<span class="o-forms-title__main">Billing city/town</span>
+	</span>
+	<span class="o-forms-input o-forms-input--text{{#if hasError}} o-forms-input--invalid{{/if}}">
+		<input type="text" id="billingCity" name="billingCity"
+			data-trackable="field-billingCity"
+			autocomplete="address-level2"
+			placeholder="e.g. Bath"
+			maxLength=40
+			aria-required="true" required
+			{{#if isDisabled}}disabled{{/if}}
+			value="{{value}}"
+		/>
+		<span class="o-forms-input__error">Please enter a valid city or town</span>
+	</span>
+</label>

--- a/test/partials/billing-city.spec.js
+++ b/test/partials/billing-city.spec.js
@@ -1,0 +1,23 @@
+const {
+	fetchPartial,
+	shouldBeDisableable,
+	shouldBeRequired,
+	shouldPopulateValue,
+	shouldError
+} = require('../helpers');
+
+let context = {};
+
+describe('billing-city-town template', () => {
+	before(async () => {
+		context.template = await fetchPartial('billing-city.html');
+	});
+
+	shouldPopulateValue(context);
+
+	shouldBeRequired(context, 'input');
+
+	shouldError(context);
+
+	shouldBeDisableable(context, 'input');
+});

--- a/utils/billing-city.js
+++ b/utils/billing-city.js
@@ -1,0 +1,9 @@
+const FormElement = require('./form-element');
+
+class BillingCity extends FormElement {
+	constructor (document) {
+		super(document, '.ncf #billingCityField');
+	}
+}
+
+module.exports = BillingCity;


### PR DESCRIPTION
### Description
ePaper will be sold as a separate and solely product.
The buy flow pages/sign up forms might need few tweaks to cater for some of the ePaper specifics

### Ticket
https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1035&projectKey=ACQ&modal=detail&selectedIssue=ACQ-87

### Screenshots
![image](https://user-images.githubusercontent.com/6513313/77906722-55422500-7280-11ea-8cce-98822f22f7ed.png)

### Note
related to: https://github.com/Financial-Times/next-subscribe/pull/1026