### PR TITLE
ACQ-170: Fix trial banner trialDuration rendering

### DIFF
--- a/components/trial-banner.jsx
+++ b/components/trial-banner.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export function TrialBanner ({
-	trialDuration = null
+	trialDuration = ''
 }) {
+	const durationMessage = trialDuration === '' ? trialDuration : <span className="ncf__strong">{trialDuration}</span> + ' ';
+
 	return (
 		<div id="trialBanner" className="ncf__trial-banner">
-			<p className="ncf__trial-banner-content">Your free { trialDuration ? (<span className="ncf__strong">{trialDuration}</span> + ' ') : '' }FT.com trial
+			<p className="ncf__trial-banner-content">Your free {durationMessage}FT.com trial
 				<img
 					src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2Fassets%2Fb2b%2Fmacron-desktop-banner.png?source=conversion&height=40"
 					alt="Emmanuel Macron"


### PR DESCRIPTION
It was outputting [object Object] previously

![image](https://user-images.githubusercontent.com/21983479/79218359-316a0c00-7e48-11ea-8f50-06389ec1cbac.png)

<img width="727" alt="image" src="https://user-images.githubusercontent.com/21983479/79218401-4050be80-7e48-11ea-8753-0c36e65c48c5.png">

