### PR TITLE
Fix white space on trial banner 🐿 v2.12.6

### DIFF
--- a/components/trial-banner.jsx
+++ b/components/trial-banner.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 export function TrialBanner ({
 	trialDuration = ''
 }) {
-	const durationMessage = trialDuration === '' ? trialDuration : <span className="ncf__strong">{trialDuration}</span> + ' ';
+	const durationMessage = trialDuration === '' ? trialDuration : <><span className="ncf__strong">{trialDuration}</span>{' '}</>;
 
 	return (
 		<div id="trialBanner" className="ncf__trial-banner">


### PR DESCRIPTION
Related to https://github.com/Financial-Times/n-conversion-forms/pull/419.

Concatenating `' '` to the span causes the same issue. This fixes it.