### PR TITLE
ACQ-177: Print trial t and c

### DIFF
--- a/components/__snapshots__/debug.spec.js.snap
+++ b/components/__snapshots__/debug.spec.js.snap
@@ -28,6 +28,7 @@ exports[`Debug renders with isTest 1`] = `
 	var SYSTEM_CODE = document.documentElement.getAttribute('data-next-app') || 'n-conversion-forms';
 
 	var debugData = {
+		billingCity: 'London',
 		billingCountry: 'GBR',
 		billingPostcode: 'EC4M9BT',
 		country: 'GBR',
@@ -150,6 +151,7 @@ exports[`Debug renders with isTest 2`] = `
 	var SYSTEM_CODE = document.documentElement.getAttribute('data-next-app') || 'n-conversion-forms';
 
 	var debugData = {
+		billingCity: 'London',
 		billingCountry: 'GBR',
 		billingPostcode: 'EC4M9BT',
 		country: 'GBR',
@@ -296,6 +298,7 @@ exports[`Debug renders with showHelpers 1`] = `
 	var SYSTEM_CODE = document.documentElement.getAttribute('data-next-app') || 'n-conversion-forms';
 
 	var debugData = {
+		billingCity: 'London',
 		billingCountry: 'GBR',
 		billingPostcode: 'EC4M9BT',
 		country: 'GBR',
@@ -438,6 +441,7 @@ exports[`Debug renders with showHelpers 2`] = `
 	var SYSTEM_CODE = document.documentElement.getAttribute('data-next-app') || 'n-conversion-forms';
 
 	var debugData = {
+		billingCity: 'London',
 		billingCountry: 'GBR',
 		billingPostcode: 'EC4M9BT',
 		country: 'GBR',

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -63,7 +63,7 @@ export function AcceptTerms({
 			</span>
 			<p className="o-forms-input__error">Please accept our terms &amp; conditions</p>
 		</label>
-	)
+	);
 
 	const b2bTerms = isB2b ? (
 		<li>
@@ -183,16 +183,19 @@ export function AcceptTerms({
 		</>
 	);
 
+	const printSignupTermText = isTrial ?
+		'Credits for delivery suspension or delivery failure are not available during introductory offer periods.'
+	:
+		'Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).'
+	;
+
 	const signupTerms = isSignup && (
 		<>
 			{isPrintProduct ? (
 				<>
 					<li>
 						<span className="terms-print">
-							Credit for delivery suspensions is only available
-							for hand-delivered subscriptions and is limited to a
-							maximum of 24 issues per yearly subscription terms
-							(4 issues per yearly FT Weekend subscription term).
+							{printSignupTermText}
 						</span>
 					</li>
 					<li>
@@ -263,11 +266,11 @@ export function AcceptTerms({
 
 	return (
 		<div {...divProps}>
-			{isRegister ? 
-				registerTerms 
+			{isRegister ?
+				registerTerms
 				: (
 					<>
-						<ul className="o-typography-list ncf__accept-terms-list">	
+						<ul className="o-typography-list ncf__accept-terms-list">
 							{b2bTerms}
 							{corpSignupTerms}
 							{transitionTerms}

--- a/components/debug.jsx
+++ b/components/debug.jsx
@@ -48,6 +48,7 @@ export function Debug ({
 	var SYSTEM_CODE = document.documentElement.getAttribute('data-next-app') || 'n-conversion-forms';
 
 	var debugData = {
+		billingCity: 'London',
 		billingCountry: 'GBR',
 		billingPostcode: 'EC4M9BT',
 		country: 'GBR',

--- a/demos/init-jsx.js
+++ b/demos/init-jsx.js
@@ -8,7 +8,7 @@ function initDemo () {
 
 	const element =
 		<React.Fragment>
-			<ncf.AcceptTerms />
+			<ncf.AcceptTerms isSignup={true} isPrintProduct={true} isTrial={true}/>
 			<ncf.AppBanner />
 			<ncf.BillingCountry></ncf.BillingCountry>
 			<ncf.BillingPostcode postcodeReference={'billing postcode'}/>

--- a/partials/accept-terms.html
+++ b/partials/accept-terms.html
@@ -60,9 +60,15 @@
 
 			{{#if isSignup}}
 				{{#if isPrintProduct}}
-					<li>
-						<span class="terms-print">Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).</span>
-					</li>
+					{{#if isTrial}}
+						<li>
+							<span class="terms-print">Credits for delivery suspension or delivery failure are not available during introductory offer periods.</span>
+						</li>
+					{{else}}
+						<li>
+							<span class="terms-print">Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).</span>
+						</li>
+					{{/if}}
 					<li>
 						<span class="terms-print">Find out more about your delivery start date in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer">Terms &amp; Conditions</a>.</span>
 					</li>

--- a/partials/debug.html
+++ b/partials/debug.html
@@ -39,6 +39,7 @@
 	var SYSTEM_CODE = document.documentElement.getAttribute('data-next-app') || 'n-conversion-forms';
 
 	var debugData = {
+		billingCity: 'London',
 		billingCountry: 'GBR',
 		billingPostcode: 'EC4M9BT',
 		country: 'GBR',


### PR DESCRIPTION
### Description
During Print trials, subscribers are not eligible to receive credits for non-received newspaper copies (in case of delivery complaints or suspended subscriptions).
This fact shall be clearly stated to user before completing the SignUp journey

###Ticket
https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1035&projectKey=ACQ&modal=detail&selectedIssue=ACQ-177

### Screenshots

| Before | After |
| ------ | ----- |
|        |       |

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Demos** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer 
- [ ] **Product Review** ran past the product owner
