### PR TITLE
ACQ-180 Add article linking to licence-confirmation component

### DIFF
--- a/components/__snapshots__/licence-confirmation.spec.js.snap
+++ b/components/__snapshots__/licence-confirmation.spec.js.snap
@@ -1,5 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`LicenceConfirmation renders if content id 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <div class="ncf__paragraph">
+      <h1 class="ncf__header ncf__header--confirmation">
+        Great news, you have joined your company licence
+      </h1>
+    </div>
+  </div>
+  <p class="ncf__paragraph">
+    Go to myFT to personalise your feed &amp; follow topics &amp; articles of interest to you. Set this up now or later.
+  </p>
+  <p class="ncf__paragraph">
+    Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
+  </p>
+  <p class="ncf__paragraph ncf__center">
+    <a href="/myft"
+       class="ncf__button ncf__button--submit"
+    >
+      Go to myFT
+    </a>
+  </p>
+  <p class="ncf__paragraph ncf__center">
+    <a href="/content/d19dc7a6-c33b-4931-9a7e-4a74674da29a"
+       class="ncf__link"
+    >
+      Start reading
+    </a>
+  </p>
+</div>
+`;
+
+exports[`LicenceConfirmation renders if content id 2`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <div class="ncf__paragraph">
+      <h1 class="ncf__header ncf__header--confirmation">
+        Great news, you have joined your company licence
+      </h1>
+    </div>
+  </div>
+  <p class="ncf__paragraph">
+    Go to myFT to personalise your feed &amp; follow topics &amp; articles of interest to you. Set this up now or later.
+  </p>
+  <p class="ncf__paragraph">
+    Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
+  </p>
+  <p class="ncf__paragraph ncf__center">
+    <a href="/myft"
+       class="ncf__button ncf__button--submit"
+    >
+      Go to myFT
+    </a>
+  </p>
+  <p class="ncf__paragraph ncf__center">
+    <a href="/content/d19dc7a6-c33b-4931-9a7e-4a74674da29a"
+       class="ncf__link"
+    >
+      Start reading
+    </a>
+  </p>
+</div>
+`;
+
 exports[`LicenceConfirmation renders if educational licence 1`] = `
 <div class="ncf ncf__wrapper">
   <div class="ncf__center">
@@ -28,7 +96,7 @@ exports[`LicenceConfirmation renders if educational licence 1`] = `
     <a href="/"
        class="ncf__link"
     >
-      Go to the homepage
+      Start reading
     </a>
   </p>
 </div>
@@ -62,7 +130,7 @@ exports[`LicenceConfirmation renders if educational licence 2`] = `
     <a href="/"
        class="ncf__link"
     >
-      Go to the homepage
+      Start reading
     </a>
   </p>
 </div>
@@ -98,7 +166,7 @@ exports[`LicenceConfirmation renders if is embedded 1`] = `
        class="ncf__link"
        target="_top"
     >
-      Go to the homepage
+      Start reading
     </a>
   </p>
 </div>
@@ -134,7 +202,7 @@ exports[`LicenceConfirmation renders if is embedded 2`] = `
        class="ncf__link"
        target="_top"
     >
-      Go to the homepage
+      Start reading
     </a>
   </p>
 </div>
@@ -168,7 +236,7 @@ exports[`LicenceConfirmation renders if is trial 1`] = `
     <a href="/"
        class="ncf__link"
     >
-      Go to the homepage
+      Start reading
     </a>
   </p>
 </div>
@@ -202,7 +270,7 @@ exports[`LicenceConfirmation renders if is trial 2`] = `
     <a href="/"
        class="ncf__link"
     >
-      Go to the homepage
+      Start reading
     </a>
   </p>
 </div>
@@ -236,7 +304,7 @@ exports[`LicenceConfirmation renders with custom duration value 1`] = `
     <a href="/"
        class="ncf__link"
     >
-      Go to the homepage
+      Start reading
     </a>
   </p>
 </div>
@@ -270,7 +338,7 @@ exports[`LicenceConfirmation renders with custom duration value 2`] = `
     <a href="/"
        class="ncf__link"
     >
-      Go to the homepage
+      Start reading
     </a>
   </p>
 </div>
@@ -304,7 +372,7 @@ exports[`LicenceConfirmation renders with default props 1`] = `
     <a href="/"
        class="ncf__link"
     >
-      Go to the homepage
+      Start reading
     </a>
   </p>
 </div>
@@ -338,7 +406,7 @@ exports[`LicenceConfirmation renders with default props 2`] = `
     <a href="/"
        class="ncf__link"
     >
-      Go to the homepage
+      Start reading
     </a>
   </p>
 </div>

--- a/components/licence-confirmation.jsx
+++ b/components/licence-confirmation.jsx
@@ -11,13 +11,13 @@ export function LicenceConfirmation ({
 		href: '/myft',
 		className: 'ncf__button ncf__button--submit',
 		...(isEmbedded && { target: '_top' })
-	}
+	};
 
 	const homepageLinkProps = {
 		href: '/',
 		className: 'ncf__link',
 		...(isEmbedded && { target: '_top' })
-	}
+	};
 
 	return (
 		<div className="ncf ncf__wrapper">

--- a/components/licence-confirmation.jsx
+++ b/components/licence-confirmation.jsx
@@ -46,7 +46,7 @@ export function LicenceConfirmation ({
 			</p>
 
 			<p className="ncf__paragraph ncf__center">
-				<a {...readingLinkProps}>Go to the homepage</a>
+				<a {...readingLinkProps}>Start reading</a>
 			</p>
 		</div>
 	);

--- a/components/licence-confirmation.jsx
+++ b/components/licence-confirmation.jsx
@@ -57,4 +57,5 @@ LicenceConfirmation.propTypes = {
 	isEmbedded: PropTypes.bool,
 	duration: PropTypes.string,
 	isEducationalLicence: PropTypes.bool,
+	contentId: PropTypes.string,
 };

--- a/components/licence-confirmation.jsx
+++ b/components/licence-confirmation.jsx
@@ -6,6 +6,7 @@ export function LicenceConfirmation ({
 	isEmbedded = false,
 	duration = null,
 	isEducationalLicence = false,
+	contentId = '',
 }) {
 	const myFtLinkProps = {
 		href: '/myft',
@@ -13,8 +14,8 @@ export function LicenceConfirmation ({
 		...(isEmbedded && { target: '_top' })
 	};
 
-	const homepageLinkProps = {
-		href: '/',
+	const readingLinkProps = {
+		href: contentId === '' ? '/' : `/content/${contentId}`,
 		className: 'ncf__link',
 		...(isEmbedded && { target: '_top' })
 	};
@@ -45,7 +46,7 @@ export function LicenceConfirmation ({
 			</p>
 
 			<p className="ncf__paragraph ncf__center">
-				<a {...homepageLinkProps}>Go to the homepage</a>
+				<a {...readingLinkProps}>Go to the homepage</a>
 			</p>
 		</div>
 	);

--- a/components/licence-confirmation.spec.js
+++ b/components/licence-confirmation.spec.js
@@ -39,4 +39,9 @@ describe('LicenceConfirmation', () => {
 		const props = { isEducationalLicence: true };
 		expect(LicenceConfirmation).toRenderAs(context, props);
 	});
+
+	it('renders if content id', () => {
+		const props = { contentId: 'd19dc7a6-c33b-4931-9a7e-4a74674da29a' };
+		expect(LicenceConfirmation).toRenderAs(context, props);
+	});
 });

--- a/partials/licence-confirmation.html
+++ b/partials/licence-confirmation.html
@@ -23,6 +23,6 @@
 	</p>
 
 	<p class="ncf__paragraph ncf__center">
-		<a href="/" class="ncf__link"{{#if isEmbedded}} target="_top"{{/if}}>Go to the homepage</a>
+		<a href="/" class="ncf__link"{{#if isEmbedded}} target="_top"{{/if}}>Start reading</a>
 	</p>
 </div>

--- a/partials/licence-confirmation.html
+++ b/partials/licence-confirmation.html
@@ -23,6 +23,6 @@
 	</p>
 
 	<p class="ncf__paragraph ncf__center">
-		<a href="/" class="ncf__link"{{#if isEmbedded}} target="_top"{{/if}}>Start reading</a>
+		<a href={{#if contentId}}"/content/{{contentId}}"{{else}}"/"{{/if}} class="ncf__link"{{#if isEmbedded}} target="_top"{{/if}}>Start reading</a>
 	</p>
 </div>

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -6,7 +6,8 @@ module.exports = {
 	strings: {
 		deny: [],
 		denyOverrides: [
-			'test@example\\.com' // demos/data.json:90, tests/partials/confirmation.spec.js:12
+			'test@example\\.com', // demos/data.json:90, tests/partials/confirmation.spec.js:12
+			'd19dc7a6-c33b-4931-9a7e-4a74674da29a' // components/licence-confirmation.spec.js:44
 		]
 	}
 };


### PR DESCRIPTION
- copy for the bottom link on `licence-confirmation` has been changed to "Start reading"
- add `contentId` prop to `licence-confirmation` allowing the start reading link to point at articles

<img width="559" alt="image" src="https://user-images.githubusercontent.com/21983479/79549913-88aded80-808f-11ea-92ab-db412c4b6241.png">

- [x] **Tests** written for new or updated for existing functionality
