### PR TITLE
Update Fieldset header to be of type node 🐿 v2.13.0

### DIFF
--- a/components/__snapshots__/fieldset.spec.js.snap
+++ b/components/__snapshots__/fieldset.spec.js.snap
@@ -24,6 +24,24 @@ exports[`Fieldset renders a custom descriptor paragraph 2`] = `
 </fieldset>
 `;
 
+exports[`Fieldset renders a custom header containing markup 1`] = `
+<fieldset class="ncf__fieldset">
+  <div class="ncf__fields">
+    <div id="fields_test">
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`Fieldset renders a custom header containing markup 2`] = `
+<fieldset class="ncf__fieldset">
+  <div class="ncf__fields">
+    <div id="fields_test">
+    </div>
+  </div>
+</fieldset>
+`;
+
 exports[`Fieldset renders a custom header in specific heading level tags 1`] = `
 <fieldset class="ncf__fieldset">
   <h2 class="ncf__header">
@@ -133,6 +151,40 @@ exports[`Fieldset renders a fieldset element with default props 1`] = `
 
 exports[`Fieldset renders a fieldset element with default props 2`] = `
 <fieldset class="ncf__fieldset">
+  <div class="ncf__fields">
+    <div id="fields_test">
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`Fieldset renders a custom header containing markup 1`] = `
+<fieldset class="ncf__fieldset">
+  <h2 class="ncf__header">
+    <div>
+      Header text
+      <span class="test">
+        Test
+      </span>
+    </div>
+  </h2>
+  <div class="ncf__fields">
+    <div id="fields_test">
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`Fieldset renders a custom header containing markup 2`] = `
+<fieldset class="ncf__fieldset">
+  <h2 class="ncf__header">
+    <div>
+      Header text
+      <span class="test">
+        Test
+      </span>
+    </div>
+  </h2>
   <div class="ncf__fields">
     <div id="fields_test">
     </div>

--- a/components/fieldset.jsx
+++ b/components/fieldset.jsx
@@ -61,6 +61,6 @@ Fieldset.propTypes = {
 	legend: PropTypes.string,
 	hideLegend: PropTypes.bool,
 	headingLevel: PropTypes.string,
-	header: PropTypes.elementType,
+	header: PropTypes.node,
 	descriptor: PropTypes.string
 };

--- a/components/fieldset.spec.js
+++ b/components/fieldset.spec.js
@@ -80,4 +80,18 @@ describe('Fieldset', () => {
 
 		expect(Fieldset).toRenderAs(context, props);
 	});
+
+	it('renders a custom header containing markup', () => {
+		unregisterPartial('header');
+
+		registerPartial('header', `<div>${HEADER_TEXT}<span class="test">Test</span></div>`);
+
+		const props = {
+			children: (<div id={TEST_FIELDS_ID}></div>),
+			headingLevel: 'h2',
+			header: (<div>{HEADER_TEXT}<span className="test">Test</span></div>)
+		};
+
+		expect(Fieldset).toRenderAs(context, props);
+	});
 });


### PR DESCRIPTION
### Description
Changes Fieldset header to be of proptype node rather than elementType so that markup can be passed to the header (this allows us to include visually hidden text as required in this ticket: https://financialtimes.atlassian.net/browse/ACQ-121)