### PR TITLE
Fix filterList proptype to be array of strings (country codes) 🐿 v2.13.0

### DIFF
--- a/components/country.jsx
+++ b/components/country.jsx
@@ -73,11 +73,7 @@ export function Country ({
 
 Country.propTypes = {
 	fieldId: PropTypes.string,
-	filterList: PropTypes.arrayOf(PropTypes.shape({
-		code: PropTypes.string,
-		label: PropTypes.string,
-		name: PropTypes.string
-	})),
+	filterList: PropTypes.arrayOf(PropTypes.string),
 	hasError: PropTypes.bool,
 	inputId: PropTypes.string,
 	isB2b: PropTypes.bool,


### PR DESCRIPTION
filterList should be an array of strings (country codes) not an array of objects. You can see it is used in `utils/countries.js` (as `filter`) as follows:

`data = data.filter(item => filter.includes(item.code));`

This was spotted as part of https://financialtimes.atlassian.net/browse/ACQ-122 when migrating the offer / details page which uses this component.