### PR TITLE
fix!: correct DeliveryPostCode misspelled property

### DIFF
--- a/components/country.jsx
+++ b/components/country.jsx
@@ -11,7 +11,7 @@ export function Country ({
 	isB2b = false,
 	isDisabled = false,
 	value,
-	additonalFieldInformation
+	additionalFieldInformation
 }) {
 	const selectWrapperClassName = classNames([
 		'o-forms-input',
@@ -47,7 +47,7 @@ export function Country ({
 
 	const fieldErrorClassNames = classNames([
 		'o-forms-input__error',
-		{ 'additional-field-information__with-field-error': additonalFieldInformation }
+		{ 'additional-field-information__with-field-error': additionalFieldInformation }
 	]);
 
 	return (
@@ -63,8 +63,8 @@ export function Country ({
 			<span className={selectWrapperClassName}>
 				{createSelect(countries)}
 				<span className={fieldErrorClassNames}>{error}</span>
-					{additonalFieldInformation ? (
-						<p className="additional-field-information">{additonalFieldInformation}</p>
+					{additionalFieldInformation ? (
+						<p className="additional-field-information">{additionalFieldInformation}</p>
 					) : null}
 			</span>
 		</label>
@@ -79,5 +79,5 @@ Country.propTypes = {
 	isB2b: PropTypes.bool,
 	isDisabled: PropTypes.bool,
 	value: PropTypes.string,
-	additonalFieldInformation: PropTypes.node
+	additionalFieldInformation: PropTypes.node
 };

--- a/components/delivery-postcode.jsx
+++ b/components/delivery-postcode.jsx
@@ -14,7 +14,7 @@ export function DeliveryPostcode ({
 	hasError = false,
 	isHidden = false,
 	pattern,
-	additonalFieldInformation,
+	additionalFieldInformation,
 }) {
 
 	const postcodeReference = postcodeLabel[country.toUpperCase()] || 'postcode';
@@ -32,7 +32,7 @@ export function DeliveryPostcode ({
 
 	const fieldErrorClassNames = classNames([
 		'o-forms-input__error',
-		{ 'additional-field-information__with-field-error': additonalFieldInformation }
+		{ 'additional-field-information__with-field-error': additionalFieldInformation }
 	]);
 
 	return (
@@ -65,8 +65,8 @@ export function DeliveryPostcode ({
 				<span className={fieldErrorClassNames}>
 					Please enter a valid <span data-reference="postcode">{postcodeReference}</span>.
 				</span>
-				{additonalFieldInformation ? (
-					<p className="additional-field-information">{additonalFieldInformation}</p>
+				{additionalFieldInformation ? (
+					<p className="additional-field-information">{additionalFieldInformation}</p>
 				) : null}
 			</span>
 		</label>
@@ -80,5 +80,5 @@ DeliveryPostcode.propTypes = {
 	isDisabled: PropTypes.bool,
 	hasError: PropTypes.bool,
 	isHidden: PropTypes.bool,
-	additonalFieldInformation: PropTypes.node
+	additionalFieldInformation: PropTypes.node
 };


### PR DESCRIPTION
### Description

fixes a spelling mistake on DeliveryPostCode component. 

Changes property spelling from `additonalFieldInformation` to `additionalFieldInformation`


**THIS IS A BREAKING CHANGE** ❗
