### PR TITLE
ACC-401 Improve Messages in DeliveryStateDate Component 

### DIFF
--- a/components/__snapshots__/delivery-start-date.spec.js.snap
+++ b/components/__snapshots__/delivery-start-date.spec.js.snap
@@ -464,6 +464,158 @@ exports[`DeliveryStartDate renders with an error 2`] = `
 </label>
 `;
 
+exports[`DeliveryStartDate renders with appropriate start description example when address type is weekend 1`] = `
+<label id="deliveryStartDateField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="deliveryStartDate"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery start date
+    </span>
+    <span class="o-forms-title__prompt">
+      Earliest available delivery date:
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="date"
+           id="deliveryStartDate"
+           name="deliveryStartDate"
+           data-trackable="field-deliveryStartDate"
+           aria-required="true"
+           required
+           value
+    >
+    <span class="o-forms-input__error">
+      Please select a valid start date
+    </span>
+  </span>
+  <p>
+    Your print subscription will start from:
+    <strong class="js-start-date-text">
+    </strong>
+  </p>
+  <p>
+    NB. This will  be the closest date we can supply your newspaper based on your selected date e.g. if you select a Sunday then we&#x27;ll start your deliveries on the following Saturday.
+  </p>
+</label>
+`;
+
+exports[`DeliveryStartDate renders with appropriate start description example when address type is weekend 2`] = `
+<label id="deliveryStartDateField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="deliveryStartDate"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery start date
+    </span>
+    <span class="o-forms-title__prompt">
+      Earliest available delivery date:
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="date"
+           id="deliveryStartDate"
+           name="deliveryStartDate"
+           data-trackable="field-deliveryStartDate"
+           aria-required="true"
+           required
+           value
+    >
+    <span class="o-forms-input__error">
+      Please select a valid start date
+    </span>
+  </span>
+  <p>
+    Your print subscription will start from:
+    <strong class="js-start-date-text">
+    </strong>
+  </p>
+  <p>
+    NB. This will  be the closest date we can supply your newspaper based on your selected date e.g. if you select a Sunday then we&#x27;ll start your deliveries on the following Saturday.
+  </p>
+</label>
+`;
+
+exports[`DeliveryStartDate renders with appropriate start message when isAddressUpdate 1`] = `
+<label id="deliveryStartDateField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="deliveryStartDate"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery start date
+    </span>
+    <span class="o-forms-title__prompt">
+      Earliest available delivery date:
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="date"
+           id="deliveryStartDate"
+           name="deliveryStartDate"
+           data-trackable="field-deliveryStartDate"
+           aria-required="true"
+           required
+           value
+    >
+    <span class="o-forms-input__error">
+      Please select a valid start date
+    </span>
+  </span>
+  <p>
+    We’ll start delivering to this address from:
+    <strong class="js-start-date-text">
+    </strong>
+  </p>
+  <p>
+    NB. This will  be the closest date we can supply your newspaper based on your selected date e.g. if you select a Sunday then we can start your supply on the Monday.
+  </p>
+</label>
+`;
+
+exports[`DeliveryStartDate renders with appropriate start message when isAddressUpdate 2`] = `
+<label id="deliveryStartDateField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="deliveryStartDate"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery start date
+    </span>
+    <span class="o-forms-title__prompt">
+      Earliest available delivery date:
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="date"
+           id="deliveryStartDate"
+           name="deliveryStartDate"
+           data-trackable="field-deliveryStartDate"
+           aria-required="true"
+           required
+           value
+    >
+    <span class="o-forms-input__error">
+      Please select a valid start date
+    </span>
+  </span>
+  <p>
+    We’ll start delivering to this address from:
+    <strong class="js-start-date-text">
+    </strong>
+  </p>
+  <p>
+    NB. This will  be the closest date we can supply your newspaper based on your selected date e.g. if you select a Sunday then we can start your supply on the Monday.
+  </p>
+</label>
+`;
+
 exports[`DeliveryStartDate renders with default props 1`] = `
 <label id="deliveryStartDateField"
        class="o-forms-field ncf__validation-error"

--- a/components/__snapshots__/delivery-start-date.spec.js.snap
+++ b/components/__snapshots__/delivery-start-date.spec.js.snap
@@ -497,7 +497,7 @@ exports[`DeliveryStartDate renders with appropriate start description example wh
     </strong>
   </p>
   <p>
-    NB. This will  be the closest date we can supply your newspaper based on your selected date e.g. if you select a Sunday then we&#x27;ll start your deliveries on the following Saturday.
+    NB. This will  be the closest date we can supply your newspaper based on your selected date e.g. if you select a Sunday then we’ll start your deliveries on the following Saturday.
   </p>
 </label>
 `;
@@ -535,7 +535,7 @@ exports[`DeliveryStartDate renders with appropriate start description example wh
     </strong>
   </p>
   <p>
-    NB. This will  be the closest date we can supply your newspaper based on your selected date e.g. if you select a Sunday then we&#x27;ll start your deliveries on the following Saturday.
+    NB. This will  be the closest date we can supply your newspaper based on your selected date e.g. if you select a Sunday then we’ll start your deliveries on the following Saturday.
   </p>
 </label>
 `;

--- a/components/delivery-start-date.jsx
+++ b/components/delivery-start-date.jsx
@@ -10,7 +10,7 @@ export function DeliveryStartDate ({
 	max = null,
 	isDisabled = false,
 	isAddressUpdate = false,
-	addressType = 'primary'
+	isWeekendOnly = false
 }) {
 	const inputWrapperClassNames = classNames([
 		'o-forms-input',
@@ -38,7 +38,7 @@ export function DeliveryStartDate ({
 
 	// Primary Address deliveries start on Monday (default) while Weekend Address deliveries start on Saturday.
 	const startDescriptionExample =
-		addressType === 'weekend'
+		isWeekendOnly
 			? 'if you select a Sunday then we’ll start your deliveries on the following Saturday.'
 			: 'if you select a Sunday then we can start your supply on the Monday.';
 
@@ -74,5 +74,5 @@ DeliveryStartDate.propTypes = {
 	max: PropTypes.string,
 	isDisabled: PropTypes.bool,
 	isAddressUpdate: PropTypes.bool,
-	addressType: PropTypes.oneOf(['primary', 'weekend']),
+	isWeekendOnly: PropTypes.bool,
 };

--- a/components/delivery-start-date.jsx
+++ b/components/delivery-start-date.jsx
@@ -8,7 +8,9 @@ export function DeliveryStartDate ({
 	value = '',
 	min = null,
 	max = null,
-	isDisabled = false
+	isDisabled = false,
+	isAddressUpdate = false,
+	addressType = 'primary'
 }) {
 	const inputWrapperClassNames = classNames([
 		'o-forms-input',
@@ -29,6 +31,17 @@ export function DeliveryStartDate ({
 		defaultValue: value
 	};
 
+	const startMessage =
+		isAddressUpdate
+			? 'We’ll start delivering to this address from:'
+			: 'Your print subscription will start from:';
+
+	// Primary Address deliveries start on Monday (default) while Weekend Address deliveries start on Saturday.
+	const startDescriptionExample =
+		addressType === 'weekend'
+			? 'if you select a Sunday then we’ll start your deliveries on the following Saturday.'
+			: 'if you select a Sunday then we can start your supply on the Monday.';
+
 	return (
 		<label
 			id="deliveryStartDateField"
@@ -46,9 +59,9 @@ export function DeliveryStartDate ({
 				<span className="o-forms-input__error">Please select a valid start date</span>
 			</span>
 
-			<p>Your print subscription will start from: <strong className="js-start-date-text">{date}</strong></p>
+			<p>{startMessage} <strong className="js-start-date-text">{date}</strong></p>
 
-			<p>NB. This will  be the closest date we can supply your newspaper based on your selected date e.g. if you select a Sunday then we can start your supply on the Monday.</p>
+			<p>NB. This will  be the closest date we can supply your newspaper based on your selected date e.g. {startDescriptionExample}</p>
 		</label>
 	);
 }
@@ -59,5 +72,7 @@ DeliveryStartDate.propTypes = {
 	value: PropTypes.string,
 	min: PropTypes.string,
 	max: PropTypes.string,
-	isDisabled: PropTypes.bool
+	isDisabled: PropTypes.bool,
+	isAddressUpdate: PropTypes.bool,
+	addressType: PropTypes.oneOf(['primary', 'weekend']),
 };

--- a/components/delivery-start-date.spec.js
+++ b/components/delivery-start-date.spec.js
@@ -60,7 +60,7 @@ describe('DeliveryStartDate', () => {
 	});
 
 	it('renders with appropriate start description example when address type is weekend', () => {
-		const props = { addressType: 'weekend' };
+		const props = { isWeekendOnly: true };
 
 		expect(DeliveryStartDate).toRenderAs(context, props);
 	});

--- a/components/delivery-start-date.spec.js
+++ b/components/delivery-start-date.spec.js
@@ -52,4 +52,17 @@ describe('DeliveryStartDate', () => {
 
 		expect(DeliveryStartDate).toRenderAs(context, props);
 	});
+
+	it('renders with appropriate start message when isAddressUpdate', () => {
+		const props = { isAddressUpdate: true };
+
+		expect(DeliveryStartDate).toRenderAs(context, props);
+	});
+
+	it('renders with appropriate start description example when address type is weekend', () => {
+		const props = { addressType: 'weekend' };
+
+		expect(DeliveryStartDate).toRenderAs(context, props);
+	});
+
 });

--- a/partials/delivery-start-date.html
+++ b/partials/delivery-start-date.html
@@ -18,6 +18,6 @@
 	<p>{{#if isAddressUpdate}}We’ll start delivering to this address from:{{else}}Your print subscription will start from:{{/if}} <strong class="js-start-date-text">{{date}}</strong></p>
 
 	<p>
-		NB. This will  be the closest date we can supply your newspaper based on your selected date e.g. {{#ifEquals addressType 'weekend'}}if you select a Sunday then we’ll start your deliveries on the following Saturday.{{else}}if you select a Sunday then we can start your supply on the Monday.{{/ifEquals}}
+		NB. This will  be the closest date we can supply your newspaper based on your selected date e.g. {{#if isWeekendOnly}}if you select a Sunday then we’ll start your deliveries on the following Saturday.{{else}}if you select a Sunday then we can start your supply on the Monday.{{/if}}
 	</p>
 </label>

--- a/partials/delivery-start-date.html
+++ b/partials/delivery-start-date.html
@@ -15,9 +15,9 @@
 		<span class="o-forms-input__error">Please select a valid start date</span>
 	</span>
 
-	<p>Your print subscription will start from: <strong class="js-start-date-text">{{date}}</strong></p>
+	<p>{{#if isAddressUpdate}}We’ll start delivering to this address from:{{else}}Your print subscription will start from:{{/if}} <strong class="js-start-date-text">{{date}}</strong></p>
 
 	<p>
-		NB. This will  be the closest date we can supply your newspaper based on your selected date e.g. if you select a Sunday then we can start your supply on the Monday.
+		NB. This will  be the closest date we can supply your newspaper based on your selected date e.g. {{#ifEquals addressType 'weekend'}}if you select a Sunday then we’ll start your deliveries on the following Saturday.{{else}}if you select a Sunday then we can start your supply on the Monday.{{/ifEquals}}
 	</p>
 </label>


### PR DESCRIPTION
## Description
The PR adds support for address update messages to DeliveryStateDate Component 

[Ticket](https://financialtimes.atlassian.net/browse/ACC-401)

### Screenshots

| Before |
| ------ |
|<img width="500" alt="Screenshot 2020-06-03 at 18 09 35" src="https://user-images.githubusercontent.com/17183724/83666833-76e3c380-a5c5-11ea-973d-9de97f894ba6.png">| 

| After (Default - Same as before) |
| ------ |
|<img width="500" alt="Screenshot 2020-06-03 at 18 09 35" src="https://user-images.githubusercontent.com/17183724/83666960-9e3a9080-a5c5-11ea-893c-c18c805b188e.png">| 

| After (when isAddressUpdate) | 
| ------ |
|<img width="500" alt="Screenshot 2020-06-03 at 18 22 01" src="https://user-images.githubusercontent.com/17183724/83667991-2e2d0a00-a5c7-11ea-875e-dae44d749987.png">|

| After (when isAddressUpdate and address type is weekend) |
| ------ |
|<img width="500" alt="Screenshot 2020-06-03 at 18 26 52" src="https://user-images.githubusercontent.com/17183724/83668429-da6ef080-a5c7-11ea-892f-e0ed16450bc1.png">|

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [ ] **Demos** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer 
- [ ] **Product Review** ran past the product owner
