### PR TITLE
ACQ-233: add optional signup security note 🐿 v2.13.0

### DIFF
--- a/components/delivery-instructions.jsx
+++ b/components/delivery-instructions.jsx
@@ -10,7 +10,8 @@ export function DeliveryInstructions ({
 	rows = null,
 	isDisabled = false,
 	placeholder = '',
-	value = ''
+	hasSignupSecurityNote = false,
+	value = '',
 }) {
 	const textAreaWrapperClassNames = classNames([
 		'o-forms-input',
@@ -32,6 +33,15 @@ export function DeliveryInstructions ({
 		defaultValue: value
 	};
 
+	const signupSecurityNote = hasSignupSecurityNote && (
+		<>
+			Either add them to the Security Notes section at{" "}
+			<a href="https://ft.com/myaccount">ft.com/myaccount</a>{" "}
+			after purchase, or contact{" "}
+			<a href="https://help.ft.com/contact/">FT Customer Care</a>.{" "}
+		</>
+	);
+
 	return (
 		<label
 			id={fieldId}
@@ -45,7 +55,7 @@ export function DeliveryInstructions ({
 					For newspaper delivery, we can only deliver to the ground floor, so if you live in an apartment, we’ll leave the newspaper at reception or by the entrance. We deliver in the early hours of the morning so our drivers won’t be able to contact you or ring your doorbell.
 				</span>
 				<span className="o-forms-title__prompt">
-					If your property requires security codes that will help our drivers deliver your newspaper safely, please do not add them here as they may be printed on your newspaper label. If you do add them here you do so at your own risk as these will appear on your label.
+					If your property requires security codes that will help our drivers deliver your newspaper safely, please do not add them here as they may be printed on your newspaper label. {signupSecurityNote}If you do add them here you do so at your own risk as these will appear on your label.
 				</span>
 			</span>
 
@@ -61,5 +71,6 @@ DeliveryInstructions.propTypes = {
 	maxlength: PropTypes.number,
 	rows: PropTypes.number,
 	isDisabled: PropTypes.bool,
+	hasSignupSecurityNote: PropTypes.bool,
 	value: PropTypes.string
 };

--- a/demos/data.json
+++ b/demos/data.json
@@ -97,6 +97,7 @@
   },
   "delivery-instructions": {
     "params": {
+      "hasSignupSecurityNote": true,
       "maxlength": "200",
       "rows": "5",
       "value": "Foo bar baz"

--- a/demos/init-jsx.js
+++ b/demos/init-jsx.js
@@ -22,7 +22,7 @@ function initDemo () {
 			<ncf.DeliveryAddress />
 			<ncf.DeliveryCity />
 			<ncf.DeliveryCounty />
-			<ncf.DeliveryInstructions />
+			<ncf.DeliveryInstructions hasSignupSecurityNote={true} />
 			<ncf.DeliveryOption options={[
 				{
 					value: 'PV',

--- a/partials/delivery-instructions.html
+++ b/partials/delivery-instructions.html
@@ -5,7 +5,7 @@
 			For newspaper delivery, we can only deliver to the ground floor, so if you live in an apartment, we’ll leave the newspaper at reception or by the entrance. We deliver in the early hours of the morning so our drivers won’t be able to contact you or ring your doorbell.
 		</span>
 		<span class="o-forms-title__prompt">
-			If your property requires security codes that will help our drivers deliver your newspaper safely, please do not add them here as they may be printed on your newspaper label. If you do add them here you do so at your own risk as these will appear on your label.
+			If your property requires security codes that will help our drivers deliver your newspaper safely, please do not add them here as they may be printed on your newspaper label. {{#if hasSignupSecurityNote}}Either add them to the Security Notes section at <a href="https://ft.com/myaccount">ft.com/myaccount</a> after purchase, or contact <a href="https://help.ft.com/contact/">FT Customer Care</a>. {{/if}}If you do add them here you do so at your own risk as these will appear on your label.
 		</span>
 	</span>
 

--- a/test/partials/delivery-instructions.spec.js
+++ b/test/partials/delivery-instructions.spec.js
@@ -26,6 +26,22 @@ describe('delivery-instructions template', () => {
 		expect($('textarea').text().trim()).to.equal('');
 	});
 
+	it('should have security note if hasSignupSecurityNote = true', () => {
+		const $ = context.template({
+			hasSignupSecurityNote: true
+		});
+
+		expect($.text()).to.contain('Security Notes section');
+	});
+
+	it('should not have security note if hasSignupSecurityNote = false', () => {
+		const $ = context.template({
+			hasSignupSecurityNote: false
+		});
+
+		expect($.text()).not.to.contain('Security Notes section');
+	});
+
 	it('should populate the correct value', () => {
 		const value = 'ThisIsAValue';
 		const $ = context.template({


### PR DESCRIPTION
### Description
“Either add them to the Security Notes section at ft.com/myaccount after purchase, or contact FT Customer Care.” shall be visible on the SignUp only.
It shall not be visible when user logs into MMA (because user is already logged in ft.com/myaccount and sees "Security Notes")

### Ticket
https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1035&projectKey=ACQ&modal=detail&selectedIssue=ACQ-233

### Screenshots
before
![image](https://user-images.githubusercontent.com/6513313/84932790-beda0e80-b0cc-11ea-89e4-d302b8a6ae63.png)

after 
![image](https://user-images.githubusercontent.com/6513313/84933285-90a8fe80-b0cd-11ea-857c-31f14941a56a.png)
