### PR TITLE
ACQ-305 Move CSRF token from body to head in delivery date check

### DIFF
--- a/test/utils/email.spec.js
+++ b/test/utils/email.spec.js
@@ -153,11 +153,11 @@ describe('Email', () => {
 				method: 'POST',
 				credentials: 'include',
 				headers: {
-					'Content-Type': 'application/json'
+					'Content-Type': 'application/json',
+					'CSRF-Token': '1234567890'
 				},
 				body: JSON.stringify({
-					email: 'test@example.com',
-					csrfToken: '1234567890'
+					email: 'test@example.com'
 				})
 			});
 		});

--- a/utils/email.js
+++ b/utils/email.js
@@ -77,11 +77,11 @@ class Email {
 				method: 'POST',
 				credentials: 'include',
 				headers: {
-					'Content-Type': 'application/json'
+					'Content-Type': 'application/json',
+					'CSRF-Token': this.$csrfToken && this.$csrfToken.value,
 				},
 				body: JSON.stringify({
 					email: this.$email.value,
-					csrfToken: this.$csrfToken && this.$csrfToken.value
 				})
 			})
 				.then(fetchres.json)


### PR DESCRIPTION
Next subscribe is now using csruf for CSRF protection. This requires the token to be passed in the head under the key 'CSRF-Token'.

Documentation: https://github.com/expressjs/csurf#using-ajax 🐿 v2.13.0

Must be released with: https://github.com/Financial-Times/next-subscribe/pull/1162

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Demos** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer 
- [ ] **Product Review** ran past the product owner
