### PR TITLE
ACQ-123 BillingCountry and PaymentTerm JSX proptype fixes

### DIFF
--- a/components/billing-country.jsx
+++ b/components/billing-country.jsx
@@ -62,11 +62,7 @@ export function BillingCountry ({
 
 BillingCountry.propTypes = {
 	fieldId: PropTypes.string,
-	filterList: PropTypes.arrayOf(PropTypes.shape({
-		code: PropTypes.string,
-		label: PropTypes.string,
-		name: PropTypes.string
-	})),
+	filterList: PropTypes.arrayOf(PropTypes.string),
 	hasError: PropTypes.bool,
 	inputId: PropTypes.string,
 	isDisabled: PropTypes.bool,

--- a/components/country.jsx
+++ b/components/country.jsx
@@ -63,9 +63,9 @@ export function Country ({
 			<span className={selectWrapperClassName}>
 				{createSelect(countries)}
 				<span className={fieldErrorClassNames}>{error}</span>
-					{additionalFieldInformation ? (
-						<p className="additional-field-information">{additionalFieldInformation}</p>
-					) : null}
+				{additionalFieldInformation ? (
+					<p className="additional-field-information">{additionalFieldInformation}</p>
+				) : null}
 			</span>
 		</label>
 	);

--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -103,7 +103,7 @@ PaymentTerm.propTypes = {
 	inputName: PropTypes.string,
 	isPrintOrBundle: PropTypes.bool,
 	options: PropTypes.arrayOf(PropTypes.shape({
-		discount: PropTypes.string,
+		discount: PropTypes.bool,
 		isTrial: PropTypes.bool,
 		name: PropTypes.string.isRequired,
 		price: PropTypes.string.isRequired,

--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -102,11 +102,7 @@ PaymentTerm.propTypes = {
 	fieldId: PropTypes.string,
 	inputName: PropTypes.string,
 	isPrintOrBundle: PropTypes.bool,
-	options: PropTypes.arrayOf(PropTypes.shape({
-		discount: PropTypes.oneOfType([
-			PropTypes.bool,
-			PropTypes.string
-		]),
+	options: PropTypes.string,
 		isTrial: PropTypes.bool,
 		name: PropTypes.string.isRequired,
 		price: PropTypes.string.isRequired,

--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -103,7 +103,10 @@ PaymentTerm.propTypes = {
 	inputName: PropTypes.string,
 	isPrintOrBundle: PropTypes.bool,
 	options: PropTypes.arrayOf(PropTypes.shape({
-		discount: PropTypes.bool,
+		discount: PropTypes.oneOfType([
+			PropTypes.bool,
+			PropTypes.string
+		]),
 		isTrial: PropTypes.bool,
 		name: PropTypes.string.isRequired,
 		price: PropTypes.string.isRequired,

--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -102,7 +102,8 @@ PaymentTerm.propTypes = {
 	fieldId: PropTypes.string,
 	inputName: PropTypes.string,
 	isPrintOrBundle: PropTypes.bool,
-	options: PropTypes.string,
+	options: PropTypes.arrayOf(PropTypes.shape({
+		discount: PropTypes.string,
 		isTrial: PropTypes.bool,
 		name: PropTypes.string.isRequired,
 		price: PropTypes.string.isRequired,


### PR DESCRIPTION
### Description
PropType definitions for billingCountry and PaymentTerm were wrong, PaymentTerm.option.discount should be a boolean, and BillingCountry.filterList an array of strings

errors from `next-subscribe`:
```
Warning: Failed prop type: Invalid prop `paymentTerms[0].discount` of type `boolean` supplied to `Payment`, expected `string`.
    in Payment
Warning: Failed prop type: Invalid prop `options[0].discount` of type `boolean` supplied to `PaymentTerm`, expected `string`.
    in PaymentTerm (at payment.jsx:79)
    in Payment
Warning: Failed prop type: Invalid prop `filterList[0]` of type `string` supplied to `BillingCountry`, expected `object`.
    in BillingCountry (at payment.jsx:83)
    in Payment
```

might help with the build issues of https://github.com/Financial-Times/next-subscribe/pull/1187

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Tests** written for new or updated for existing functionality
