### PR TITLE
Change licence-header and email components for us with B2C Partnerships

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,13 +37,13 @@
     "o-header-services": "^4.0.0"
   },
   "dependencies": {
-    "o-forms": "^8.1.9",
+    "o-forms": "^8.3.10",
     "o-buttons": "^6.0.2",
     "o-message": "^4.0.1",
     "o-colors": "^5.0.2",
     "o-icons": "^6.0.0",
     "o-stepped-progress": "^2.0.0",
-    "o-expander": "^5.0.1",
+    "o-expander": "^5.0.7",
     "o-loading": "^4.0.0",
     "o-grid": "^5.0.0",
     "o-typography": "^6.1.0",

--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -1340,6 +1340,72 @@ exports[`AcceptTerms renders appropriately if is B2B 2`] = `
 </div>
 `;
 
+exports[`AcceptTerms renders appropriately if is B2C Partnership 1`] = `
+<div id="acceptTermsField"
+     class="o-forms-field o-layout-typography ncf__validation-error"
+     data-validate="required,checked"
+>
+  <label class="o-forms-input o-forms-input--checkbox checkbox-two-lines">
+    <input type="checkbox"
+           id="termsAcceptance"
+           name="termsAcceptance"
+           value="true"
+           data-trackable="field-terms"
+           aria-required="true"
+           required
+    >
+    <span class="o-forms-input__label">
+      I confirm I am 16 years or older and have read and agree to the
+      <a class="ncf__link--external"
+         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+         target="_blank"
+         rel="noopener noreferrer"
+         data-trackable="terms-and-conditions"
+      >
+        Terms &amp; Conditions
+      </a>
+      .
+    </span>
+    <p class="o-forms-input__error">
+      Please accept our terms &amp; conditions
+    </p>
+  </label>
+</div>
+`;
+
+exports[`AcceptTerms renders appropriately if is B2C Partnership 2`] = `
+<div id="acceptTermsField"
+     class="o-forms-field o-layout-typography ncf__validation-error"
+     data-validate="required,checked"
+>
+  <label class="o-forms-input o-forms-input--checkbox checkbox-two-lines">
+    <input type="checkbox"
+           id="termsAcceptance"
+           name="termsAcceptance"
+           value="true"
+           data-trackable="field-terms"
+           aria-required="true"
+           required
+    >
+    <span class="o-forms-input__label">
+      I confirm I am 16 years or older and have read and agree to the
+      <a class="ncf__link--external"
+         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+         target="_blank"
+         rel="noopener noreferrer"
+         data-trackable="terms-and-conditions"
+      >
+        Terms &amp; Conditions
+      </a>
+      .
+    </span>
+    <p class="o-forms-input__error">
+      Please accept our terms &amp; conditions
+    </p>
+  </label>
+</div>
+`;
+
 exports[`AcceptTerms renders appropriately if is corporate signup 1`] = `
 <div id="acceptTermsField"
      class="o-forms-field o-layout-typography ncf__validation-error"

--- a/components/__snapshots__/email.spec.js.snap
+++ b/components/__snapshots__/email.spec.js.snap
@@ -513,3 +513,67 @@ exports[`Email with confirmation render default label if B2B and educational lic
   </span>
 </label>
 `;
+
+exports[`Email with confirmation render default label if isB2cPartnershipLicence 1`] = `
+<label id="emailField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required,email"
+       for="email"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Email address
+    </span>
+    <span class="o-forms-title__prompt">
+      Please enter an email address
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           value
+    >
+    <span class="o-forms-input__error">
+      This email address is not valid
+    </span>
+  </span>
+</label>
+`;
+
+exports[`Email with confirmation render default label if isB2cPartnershipLicence 2`] = `
+<label id="emailField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required,email"
+       for="email"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Email address
+    </span>
+    <span class="o-forms-title__prompt">
+      Please enter an email address
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           value
+    >
+    <span class="o-forms-input__error">
+      This email address is not valid
+    </span>
+  </span>
+</label>
+`;

--- a/components/__snapshots__/licence-header.spec.js.snap
+++ b/components/__snapshots__/licence-header.spec.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`LicenceHeader renders if is isB2cPartnershipLicence 1`] = `
+<h1 class="ncf__header">
+  Welcome to the Financial Times
+</h1>
+`;
+
+exports[`LicenceHeader renders if is isB2cPartnershipLicence 2`] = `
+<h1 class="ncf__header">
+  Welcome to the Financial Times
+</h1>
+`;
+
 exports[`LicenceHeader renders if is trial 1`] = `
 <h1 class="ncf__header">
   Start your free trial

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -10,6 +10,7 @@ export function AcceptTerms({
 	isRegister = false,
 	isChecked = false,
 	isB2b = false,
+	isB2cPartnership = false,
 	ageRestriction = DEFAULT_AGE_RESTRICTION,
 	isEmbedded = false,
 	isCorpSignup = false,
@@ -264,10 +265,33 @@ export function AcceptTerms({
 		</>
 	);
 
+	const b2cPartnershipTerms = (
+			<label className={[labelClassName, "checkbox-two-lines"].join(" ")}>
+				<input {...inputProps}/>
+				<span className="o-forms-input__label">
+					I confirm I am {ageRestriction} years or older and have read and
+					agree to the{" "}
+					<a
+						className="ncf__link--external"
+						href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+						target={isEmbedded ? "_top" : "_blank"}
+						rel="noopener noreferrer"
+						data-trackable="terms-and-conditions"
+					>
+						Terms &amp; Conditions
+					</a>
+					.
+				</span>
+				<p className="o-forms-input__error">Please accept our terms &amp; conditions</p>
+			</label>
+		)
+
 	return (
 		<div {...divProps}>
-			{isRegister ?
-				registerTerms
+			{ isB2cPartnership
+			? b2cPartnershipTerms
+			: isRegister
+				? registerTerms
 				: (
 					<>
 						<ul className="o-typography-list ncf__accept-terms-list">
@@ -296,6 +320,7 @@ AcceptTerms.propTypes = {
 	isRegister: PropTypes.bool,
 	isChecked: PropTypes.bool,
 	isB2b: PropTypes.bool,
+	isB2cPartnership: PropTypes.bool,
 	ageRestriction: PropTypes.string,
 	isEmbedded: PropTypes.bool,
 	isCorpSignup: PropTypes.bool,

--- a/components/accept-terms.spec.js
+++ b/components/accept-terms.spec.js
@@ -151,4 +151,10 @@ describe('AcceptTerms', () => {
 
 		expect(AcceptTerms).toRenderAs(context, props);
 	});
+
+	it('renders appropriately if is B2C Partnership', () => {
+		const props = { isB2cPartnership: true };
+
+		expect(AcceptTerms).toRenderAs(context, props);
+	});
 });

--- a/components/email.jsx
+++ b/components/email.jsx
@@ -15,8 +15,9 @@ export function Email ({
 	placeHolder = 'Enter your email address',
 	value = '',
 	isEducationalLicence = false,
+	isB2cPartnershipLicence = false,
 }) {
-	const labelText = label || (isB2b && !isEducationalLicence ? 'Work email address' : 'Email address');
+	const labelText = label || (isB2b && !(isEducationalLicence || isB2cPartnershipLicence) ? 'Work email address' : 'Email address');
 	const inputWrapperClassNames = classNames([
 		'o-forms-input',
 		'o-forms-input--text',
@@ -70,4 +71,5 @@ Email.propTypes = {
 	readonly: PropTypes.bool,
 	value: PropTypes.string,
 	isEducationalLicence: PropTypes.bool,
+	isB2cPartnershipLicence: PropTypes.bool,
 };

--- a/components/email.spec.js
+++ b/components/email.spec.js
@@ -51,6 +51,15 @@ describe('Email with confirmation', () => {
 		expect(Email).toRenderAs(context, props);
 	});
 
+	it('render default label if isB2cPartnershipLicence', () => {
+		const props = {
+			pattern: 'whatever',
+			isB2cPartnershipLicence: true,
+		};
+
+		expect(Email).toRenderAs(context, props);
+	});
+
 	it('render a email input with given description', () => {
 		const props = {
 			description: 'some description',

--- a/components/licence-header.jsx
+++ b/components/licence-header.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 export function LicenceHeader ({
 	displayName = null,
 	isTrial = false,
+	isB2cPartnershipLicence = false,
 	welcomeText = null
 }) {
 	function createMarkup (text) {
@@ -13,12 +14,13 @@ export function LicenceHeader ({
 	return (
 		<React.Fragment>
 			<h1 className="ncf__header">
-				{ displayName && (`${displayName} | `) }
-
+			{ displayName && (`${displayName} | `) }
 				{
-					isTrial
-						? ('Start your free trial')
-						: ('Join your FT.com subscription')
+					isB2cPartnershipLicence
+						? ('Welcome to the Financial Times')
+						: isTrial
+							? ('Start your free trial')
+							: ('Join your FT.com subscription')
 				}
 			</h1>
 
@@ -30,5 +32,6 @@ export function LicenceHeader ({
 LicenceHeader.propTypes = {
 	displayName: PropTypes.string,
 	isTrial: PropTypes.bool,
-	welcomeText: PropTypes.string
+	welcomeText: PropTypes.string,
+	isB2cPartnershipLicence: PropTypes.bool,
 };

--- a/components/licence-header.spec.js
+++ b/components/licence-header.spec.js
@@ -29,6 +29,12 @@ describe('LicenceHeader', () => {
 		expect(LicenceHeader).toRenderAs(context, props);
 	});
 
+	it('renders if is isB2cPartnershipLicence', () => {
+		const props = { isB2cPartnershipLicence: true };
+
+		expect(LicenceHeader).toRenderAs(context, props);
+	});
+
 	it('renders with custom welcome text (that requires escaping, e.g. ampersand)', () => {
 		const props = { welcomeText: 'Welcome text & some more welcome text' };
 

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -2,6 +2,7 @@
 
 ## Content
 
+* [Accept Terms](#accept-terms)
 * [App Banner](#app-banner)
 * [Billing Country](#billing-country)
 * [Billing Postcode](#billing-postcode)
@@ -29,6 +30,31 @@
 * [Payment Term](#payment-term)
 * [Phone](#phone)
 * [Submit](#submit)
+
+## Accept Terms
+
+Renders the appropriate terms and conditions, based on the form that is shown to the user.
+
+```handlebars
+{{> n-conversion-forms/partials/accept-terms isCorpSignup=true isTrial=true isB2cParnership=true}}
+```
+
+### Options
+
++ `hasError`: boolean - default `false` - whether the terms and conditions checkbox has an error
++ `isSignup`: boolean - default `false` - whether the user is subscribing
++ `isRegister`: boolean - default `false` - whether the user is simply registering
++ `isChecked`: boolean - default `false` - whether the checkbox is already checked
++ `isB2b`: boolean - default `false` - whether the user is B2B
++ `isB2cPartnership`: boolean - default `false` - whether the licence is B2C Partnership
++ `ageRestriction`: string - default `16` - the minimum age a user must be to sign up
++ `isEmbedded`: boolean - default `false` - whether the form is embedded in a frame
++ `isCorpSignup`: boolean - default `false` - whether it's an individual signing up to a B2B licence
++ `isTrial`: boolean - default `false` - if the user is signing up to a trial
++ `isTransition`: boolean - default `false` - if the user is changing from one licence to another
++ `transitionType`: string - the type of transition from a previous licence (e.g. `immediate`)
++ `isPrintProduct`: boolean - default `false` - if the user is signing up to a print edition subscription
++ `specialTerms`: string - any special terms and conditions, in addition to the standard ones
 
 ## App Banner
 

--- a/docs/PARTIALS.md
+++ b/docs/PARTIALS.md
@@ -12,11 +12,12 @@
 * [Customer Care](#customer-care)
 * [Decision Maker](#decision-maker)
 * [Delivery Address](#delivery-address)
-* [Delivey City/town](#delivery-city-town)
+* [Delivery City/town](#delivery-city-town)
 * [Delivery Information](#delivery-information)
 * [Delivery Option](#delivery-option)
 * [Delivery Postcode](#delivery-postcode)
 * [Delivery Start Date](#delivery-start-date)
+* [Email](#email)
 * [Fieldset](#fieldset)
 * [Firstname](#firstname)
 * [Lastname](#lastname)
@@ -253,6 +254,21 @@ Renders a date field with a given start date (and accompanying copy).
 + `isDisabled`: boolean - Whether the field is disabled or not.
 + `hasError`: boolean - If true it adds `o-forms-input--invalid` class to display error.
 
+## Email
+
+A form field for adding a user's email.
+
+```handlebars
+{{> n-conversion-forms/partials/email value='Enter your email address'}}
+```
+### Options
++ value: string - the email address.
++ hasError: boolean - true - adds o-forms-input--invalid class
++ isDisabled: boolean - true - disables the field
++ isB2b: boolean - true - shows `work email address` label
++ isEducationalLicence: boolean - true removes `work` from field label
++ isB2cPartnershipLicence: boolean - true removes `work` from field label
+
 ## Error Page
 
 Renders a generic "error" page.
@@ -365,12 +381,17 @@ Header copy for licence pages.
 
 ### Options
 
-+ `isTrial`: boolean - Is the licence a trial or not
++ `isTrial`: boolean - Is the licence a trial or not, defaults false.
++ `isB2cPartnershipLicence`: boolean - Is the licence a B2C Partnership, default false.
 + `displayName`: string - Name of the company licence is for
 + `welcomeText`: string - Form welcome text
 
 ```handlebars
 {{> n-conversion-forms/partials/licence-header isTrial=false displayName="IBM" welcomeText="Join our FT.com licence" }}
+```
+
+```handlebars
+{{> n-conversion-forms/partials/licence-header isTrial=false isB2cPartnershipLicence=true }}
 ```
 
 ## Loader

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "jest-serializer-html": "7.0.0",
     "jsdom": "15.1.0",
     "mocha": "5.1.1",
-    "node-sass": "4.9.4",
+    "node-sass": "4.12.0",
     "nodemon": "1.17.5",
     "pa11y-ci": "2.1.1",
     "postcss-cli": "5.0.1",

--- a/partials/accept-terms.html
+++ b/partials/accept-terms.html
@@ -1,102 +1,122 @@
 <div id="acceptTermsField" class="o-forms-field o-layout-typography ncf__validation-error" data-validate="required,checked" {{#if isSignup}}data-trackable="sign-up-terms"{{/if}}{{#if isRegister}}data-trackable="register-up-terms"{{/if}}>
-	{{#if isRegister}}
-		<label class="o-forms-input o-forms-input--checkbox{{#if hasError}} o-forms-input--invalid{{/if}}" for="termsAcceptance">
-			<input type="checkbox" id="termsAcceptance" name="termsAcceptance" value="true" data-trackable="field-terms" aria-required="true" required {{#if isChecked}}checked{{/if}} />
-			<span class="o-forms-input__label terms-register">
-				I confirm I am {{#if ageRestriction}}{{ageRestriction}}{{else}}16{{/if}} years or older and have read and agree to the
-					<a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer" data-trackable="terms-and-conditions">Terms &amp; Conditions</a>.
-			</span>
-			<p class="o-forms-input__error">Please accept our terms &amp; conditions</p>
-		</label>
+	{{#if isB2cPartnership}}
+		<label class="o-forms-input o-forms-input--checkbox checkbox-two-lines">
+		<input type="checkbox" id="termsAcceptance" name="termsAcceptance" value="true" data-trackable="field-terms" aria-required="true" required {{#if isChecked}}checked{{/if}} />
+		<span class="o-forms-input__label">
+			I confirm I am 16 years or older and have read and agree to the
+			<a
+				class="ncf__link--external"
+				href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+				target="_blank"
+				rel="noopener noreferrer"
+				data-trackable="terms-and-conditions"
+			>
+				Terms &amp; Conditions
+			</a>
+			.
+		</span>
+		<p class="o-forms-input__error">Please accept our terms &amp; conditions</p>
+	</label>
 	{{else}}
-		<ul class="o-typography-list ncf__accept-terms-list">
-			<li>
-				{{#if isB2b }}
-					<span class="terms-b2b">
-						By submitting this form, you indicate your consent to also being contacted by Financial Times by email, post, or phone about our other products, services or special offers unless you untick this box.
-					</span>
-				{{else}}
-					<span class="terms-default">
-						I confirm I am {{#if ageRestriction}}{{ageRestriction}}{{else}}16{{/if}} years or older and have read and agree to the
-						<a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded }}_top{{else}}_blank{{/if}}" rel="noopener noreferrer" data-trackable="terms-and-conditions">Terms &amp; Conditions</a>.
-					</span>
-				{{/if}}
-			</li>
+		{{#if isRegister}}
+			<label class="o-forms-input o-forms-input--checkbox{{#if hasError}} o-forms-input--invalid{{/if}}" for="termsAcceptance">
+				<input type="checkbox" id="termsAcceptance" name="termsAcceptance" value="true" data-trackable="field-terms" aria-required="true" required {{#if isChecked}}checked{{/if}} />
+				<span class="o-forms-input__label terms-register">
+					I confirm I am {{#if ageRestriction}}{{ageRestriction}}{{else}}16{{/if}} years or older and have read and agree to the
+						<a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer" data-trackable="terms-and-conditions">Terms &amp; Conditions</a>.
+				</span>
+				<p class="o-forms-input__error">Please accept our terms &amp; conditions</p>
+			</label>
+		{{else}}
+			<ul class="o-typography-list ncf__accept-terms-list">
+				<li>
+					{{#if isB2b }}
+						<span class="terms-b2b">
+							By submitting this form, you indicate your consent to also being contacted by Financial Times by email, post, or phone about our other products, services or special offers unless you untick this box.
+						</span>
+					{{else}}
+						<span class="terms-default">
+							I confirm I am {{#if ageRestriction}}{{ageRestriction}}{{else}}16{{/if}} years or older and have read and agree to the
+							<a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded }}_top{{else}}_blank{{/if}}" rel="noopener noreferrer" data-trackable="terms-and-conditions">Terms &amp; Conditions</a>.
+						</span>
+					{{/if}}
+				</li>
 
-			{{#if isCorpSignup}}
-				<li>
-					<span class="terms-corp-signup">Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.</span>
-				</li>
-				<li>
-					<span class="terms-corp-signup">Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.</span>
-				</li>
-				<li>
-					<span class="terms-corp-signup">myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.</span>
-				</li>
-				{{#if isTrial}}
+				{{#if isCorpSignup}}
 					<li>
-						<span class="terms-corp-signup">This trial is to demonstrate the value of a group subscription and we’ll contact you during your trial.</span>
+						<span class="terms-corp-signup">Your organisation’s administrator(s) may view basic usage and profile data about your account and have the ability to set up myFT topic follows on your behalf.</span>
 					</li>
-				{{/if}}
-			{{/if}}
-
-			{{#if isTransition}}
-				<li>
-					<span class="terms-transition">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="_blank" rel="noopener noreferrer">customer care through chat, phone or email</a>.</span>
-				</li>
-				{{#ifEquals transitionType 'immediate'}}
 					<li>
-						<span class="terms-transition terms-transition--immediate">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</span>
+						<span class="terms-corp-signup">Basic usage and profile data about your account can include; for example, your job title and profile information, the date you last visited, volume of content consumed, etc.</span>
 					</li>
-				{{else}}
 					<li>
-						<span class="terms-transition terms-transition--other">By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.</span>
+						<span class="terms-corp-signup">myFT topics may be selected on your behalf by your company administrator or FT representative for you to follow. You can unfollow these topics or unsubscribe from the myFT digest through the Contact preferences section on myFT.</span>
 					</li>
-				{{/ifEquals}}
-				<li>
-					<span class="terms-transition">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="_blank" rel="noopener noreferrer">Terms &amp; Conditions</a>.</span>
-				</li>
-			{{/if}}
-
-			{{#if isSignup}}
-				{{#if isPrintProduct}}
 					{{#if isTrial}}
 						<li>
-							<span class="terms-print">Credits for delivery suspension or delivery failure are not available during introductory offer periods.</span>
+							<span class="terms-corp-signup">This trial is to demonstrate the value of a group subscription and we’ll contact you during your trial.</span>
+						</li>
+					{{/if}}
+				{{/if}}
+
+				{{#if isTransition}}
+					<li>
+						<span class="terms-transition">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="_blank" rel="noopener noreferrer">customer care through chat, phone or email</a>.</span>
+					</li>
+					{{#ifEquals transitionType 'immediate'}}
+						<li>
+							<span class="terms-transition terms-transition--immediate">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</span>
 						</li>
 					{{else}}
 						<li>
-							<span class="terms-print">Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).</span>
+							<span class="terms-transition terms-transition--other">By placing my order, I acknowledge that my subscription will start on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.</span>
+						</li>
+					{{/ifEquals}}
+					<li>
+						<span class="terms-transition">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="_blank" rel="noopener noreferrer">Terms &amp; Conditions</a>.</span>
+					</li>
+				{{/if}}
+
+				{{#if isSignup}}
+					{{#if isPrintProduct}}
+						{{#if isTrial}}
+							<li>
+								<span class="terms-print">Credits for delivery suspension or delivery failure are not available during introductory offer periods.</span>
+							</li>
+						{{else}}
+							<li>
+								<span class="terms-print">Credit for delivery suspensions is only available for hand-delivered subscriptions and is limited to a maximum of 24 issues per yearly subscription terms (4 issues per yearly FT Weekend subscription term).</span>
+							</li>
+						{{/if}}
+						<li>
+							<span class="terms-print">Find out more about your delivery start date in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer">Terms &amp; Conditions</a>.</span>
+						</li>
+					{{else}}
+						<li>
+							<span class="terms-signup">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer">customer care through chat, phone or email</a>.</span>
+						</li>
+						<li>
+							<span class="terms-signup">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</span>
+						</li>
+						<li>
+							<span class="terms-signup">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer">Terms &amp; Conditions</a>.</span>
 						</li>
 					{{/if}}
-					<li>
-						<span class="terms-print">Find out more about your delivery start date in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer">Terms &amp; Conditions</a>.</span>
-					</li>
-				{{else}}
-					<li>
-						<span class="terms-signup">I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting <a class="ncf__link--external" href="https://help.ft.com/help/contact-us/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer">customer care through chat, phone or email</a>.</span>
-					</li>
-					<li>
-						<span class="terms-signup">By placing my order, my subscription will start immediately. Cancellation notice would take effect at the end of the subscription period and previously paid amounts are non-refundable.</span>
-					</li>
-					<li>
-						<span class="terms-signup">Find out more about our cancellation policy in our <a class="ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="{{#if isEmbedded}}_top{{else}}_blank{{/if}}" rel="noopener noreferrer">Terms &amp; Conditions</a>.</span>
-					</li>
+					{{#if specialTerms}}
+						<li>
+							<span class="terms-special">{{specialTerms}}</span>
+						</li>
+					{{/if}}
 				{{/if}}
-				{{#if specialTerms}}
-					<li>
-						<span class="terms-special">{{specialTerms}}</span>
-					</li>
-				{{/if}}
-			{{/if}}
 
-		</ul>
-		<label class="o-forms-input o-forms-input--checkbox{{#if hasError}} o-forms-input--invalid{{/if}}" for="termsAcceptance">
-			<input type="checkbox" id="termsAcceptance" name="termsAcceptance" value="true" data-trackable="field-terms" aria-required="true" required {{#if isChecked}}checked{{/if}} />
-			<span class="o-forms-input__label">
-				I agree to the above terms &amp; conditions.
-			</span>
-			<p class="o-forms-input__error">Please accept our terms &amp; conditions</p>
-		</label>
+			</ul>
+			<label class="o-forms-input o-forms-input--checkbox{{#if hasError}} o-forms-input--invalid{{/if}}" for="termsAcceptance">
+				<input type="checkbox" id="termsAcceptance" name="termsAcceptance" value="true" data-trackable="field-terms" aria-required="true" required {{#if isChecked}}checked{{/if}} />
+				<span class="o-forms-input__label">
+					I agree to the above terms &amp; conditions.
+				</span>
+				<p class="o-forms-input__error">Please accept our terms &amp; conditions</p>
+			</label>
+		{{/if}}
 	{{/if}}
 </div>

--- a/partials/email.html
+++ b/partials/email.html
@@ -2,11 +2,13 @@
 	<span class="o-forms-title">
 		<span class="o-forms-title__main">
 			{{#if isB2b}}
-				{{#unless isEducationalLicence}}
-				Work email address
+				{{#if isEducationalLicence}}
+					Email address
+				{{else if isB2cPartnershipLicence}}
+						Email address
 				{{else}}
-				Email address
-				{{/unless}}
+					Work email address
+				{{/if}}
 			{{else}}
 			Email address
 			{{/if}}

--- a/partials/licence-header.html
+++ b/partials/licence-header.html
@@ -1,5 +1,6 @@
 <h1 class="ncf__header">
-{{#if displayName }}{{displayName}} | {{/if}}{{#if isTrial}}Start your free trial{{else}}Join your FT.com subscription{{/if}}
+{{#if displayName }}{{displayName}} | {{/if}}{{#if isB2cPartnershipLicence}} Welcome to the Financial Times{{else if isTrial}}Start your free trial{{else}}Join your FT.com subscription
+{{/if}}
 </h1>
 {{#if welcomeText}}
 <p>{{{ welcomeText }}}</p>

--- a/styles/accept-terms.scss
+++ b/styles/accept-terms.scss
@@ -9,7 +9,6 @@
 			padding-left: 0;
 		}
 	}
-}
 
 	.checkbox-two-lines {
 		margin-top: 10px;

--- a/styles/accept-terms.scss
+++ b/styles/accept-terms.scss
@@ -10,3 +10,12 @@
 		}
 	}
 }
+
+	.checkbox-two-lines {
+		margin-top: 10px;
+
+		.o-forms-input__label {
+			margin-top: -10px;
+		}
+	}
+}


### PR DESCRIPTION
### Description
We are soon going to be inviting users to sign up via a new type of licence: a B2C Partnership Licence.  Users will be purchasing access to the FT as part of a bundle with, for example, the Washington Post.  They will click on a URL that the Partner sends them and be taken to a customised sign up form, and so we need to alter some components that will be shown on the form.

I have altered the `email` component so that if a user is trying to sign up on a B2C Partnership Licence they are asked for their `email address` (no reference to work). They also get a different form header: this update removes and reference to trials and companies, as per the screenshots below.  The `accept-terms` component also now renders a simplified terms and checkbox.
[Ticket](https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1128&projectKey=UG&modal=detail&selectedIssue=UG-205)

### Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/25018001/89178212-0cc7aa80-d585-11ea-9343-32b978048596.png) | ![image](https://user-images.githubusercontent.com/25018001/89636644-d8affa80-d8a0-11ea-8357-eeeede665186.png)|
![image](https://user-images.githubusercontent.com/25018001/89535343-3a635c80-d7ee-11ea-9bf3-f7eff7890cd1.png)| ![image](https://user-images.githubusercontent.com/25018001/89532154-426ccd80-d7e9-11ea-82f6-8cfd0dd91707.png)

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Documentation** updated or created
- [X] **Tests** written for new or updated for existing functionality
- [X] **Demos** updated to use this change
- [X] **Design Review** ran past the designer 
- [x] **Product Review** ran past the product owner
