### PR TITLE
ACQ-485 payment term wording for trial

### DIFF
--- a/components/__snapshots__/payment-term.spec.js.snap
+++ b/components/__snapshots__/payment-term.spec.js.snap
@@ -217,7 +217,7 @@ exports[`PaymentTerm annual option render option with isTrial 1`] = `
            class="o-forms-input__label ncf__payment-term__label"
     >
       <span class="ncf__payment-term__title">
-        Try the FT - Annual
+        Trial: Digital Premium - Annual
       </span>
       <div class="ncf__payment-term__description">
         4 weeks for
@@ -267,7 +267,7 @@ exports[`PaymentTerm annual option render option with isTrial 2`] = `
            class="o-forms-input__label ncf__payment-term__label"
     >
       <span class="ncf__payment-term__title">
-        Try the FT - Annual
+        Trial: Digital Premium - Annual
       </span>
       <div class="ncf__payment-term__description">
         4 weeks for
@@ -529,7 +529,7 @@ exports[`PaymentTerm annual option render option with trial 1`] = `
            class="o-forms-input__label ncf__payment-term__label"
     >
       <span class="ncf__payment-term__title">
-        Try the FT - Annual
+        Trial: Digital Premium - Annual
       </span>
       <div class="ncf__payment-term__description">
         6 weeks for
@@ -580,7 +580,7 @@ exports[`PaymentTerm annual option render option with trial 2`] = `
            class="o-forms-input__label ncf__payment-term__label"
     >
       <span class="ncf__payment-term__title">
-        Try the FT - Annual
+        Trial: Digital Premium - Annual
       </span>
       <div class="ncf__payment-term__description">
         6 weeks for
@@ -829,7 +829,7 @@ exports[`PaymentTerm monthly option render option with isTrial 1`] = `
            class="o-forms-input__label ncf__payment-term__label"
     >
       <span class="ncf__payment-term__title">
-        Try the FT - Monthly
+        Trial: Digital Premium - Monthly
       </span>
       <div class="ncf__payment-term__description">
         4 weeks for
@@ -879,7 +879,7 @@ exports[`PaymentTerm monthly option render option with isTrial 2`] = `
            class="o-forms-input__label ncf__payment-term__label"
     >
       <span class="ncf__payment-term__title">
-        Try the FT - Monthly
+        Trial: Digital Premium - Monthly
       </span>
       <div class="ncf__payment-term__description">
         4 weeks for
@@ -1123,7 +1123,7 @@ exports[`PaymentTerm monthly option render option with trial 1`] = `
            class="o-forms-input__label ncf__payment-term__label"
     >
       <span class="ncf__payment-term__title">
-        Try the FT - Monthly
+        Trial: Digital Premium - Monthly
       </span>
       <div class="ncf__payment-term__description">
         6 weeks for
@@ -1174,7 +1174,7 @@ exports[`PaymentTerm monthly option render option with trial 2`] = `
            class="o-forms-input__label ncf__payment-term__label"
     >
       <span class="ncf__payment-term__title">
-        Try the FT - Monthly
+        Trial: Digital Premium - Monthly
       </span>
       <div class="ncf__payment-term__description">
         6 weeks for
@@ -1423,7 +1423,7 @@ exports[`PaymentTerm quarterly option render option with isTrial 1`] = `
            class="o-forms-input__label ncf__payment-term__label"
     >
       <span class="ncf__payment-term__title">
-        Try the FT - Quarterly
+        Trial: Digital Premium - Quarterly
       </span>
       <div class="ncf__payment-term__description">
         4 weeks for
@@ -1473,7 +1473,7 @@ exports[`PaymentTerm quarterly option render option with isTrial 2`] = `
            class="o-forms-input__label ncf__payment-term__label"
     >
       <span class="ncf__payment-term__title">
-        Try the FT - Quarterly
+        Trial: Digital Premium - Quarterly
       </span>
       <div class="ncf__payment-term__description">
         4 weeks for
@@ -1717,7 +1717,7 @@ exports[`PaymentTerm quarterly option render option with trial 1`] = `
            class="o-forms-input__label ncf__payment-term__label"
     >
       <span class="ncf__payment-term__title">
-        Try the FT - Quarterly
+        Trial: Digital Premium - Quarterly
       </span>
       <div class="ncf__payment-term__description">
         6 weeks for
@@ -1768,7 +1768,7 @@ exports[`PaymentTerm quarterly option render option with trial 2`] = `
            class="o-forms-input__label ncf__payment-term__label"
     >
       <span class="ncf__payment-term__title">
-        Try the FT - Quarterly
+        Trial: Digital Premium - Quarterly
       </span>
       <div class="ncf__payment-term__description">
         6 weeks for

--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -74,7 +74,7 @@ export function PaymentTerm ({
 				<label htmlFor={option.value} className="o-forms-input__label ncf__payment-term__label">
 					{createDiscount()}
 
-					<span className="ncf__payment-term__title">{showTrialCopyInTitle ? 'Try the FT - ': ''}{nameMap[option.name].title}</span>
+					<span className="ncf__payment-term__title">{showTrialCopyInTitle ? 'Trial: Digital Premium - ': ''}{nameMap[option.name].title}</span>
 
 					{createDescription()}
 				</label>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "preinstall": "npx npm-force-resolutions",
     "prepare": "(npx snyk protect || npx snyk protect -d || true) && npm run build",
     "build": "babel components/*.jsx -d dist --copy-files"
   },
@@ -68,9 +67,6 @@
   },
   "engines": {
     "node": "8.16.2"
-  },
-  "resolutions": {
-    "graceful-fs": "4.2.4"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "preinstall": "npx npm-force-resolutions",
     "prepare": "(npx snyk protect || npx snyk protect -d || true) && npm run build",
     "build": "babel components/*.jsx -d dist --copy-files"
   },
@@ -67,6 +68,9 @@
   },
   "engines": {
     "node": "8.16.2"
+  },
+  "resolutions": {
+    "graceful-fs": "4.2.4"
   },
   "husky": {
     "hooks": {

--- a/partials/payment-term.html
+++ b/partials/payment-term.html
@@ -8,7 +8,7 @@
 			{{/if}}
 
 			{{#ifEquals this.name 'annual'}}
-			<span class="ncf__payment-term__title">{{#unless ../isPrintOrBundle}}{{#if isTrial}}Try the FT - {{/if}}{{/unless}}Annual</span>
+			<span class="ncf__payment-term__title">{{#unless ../isPrintOrBundle}}{{#if isTrial}}Trial: Digital Premium - {{/if}}{{/unless}}Annual</span>
 			<div class="ncf__payment-term__description">
 				{{#if isTrial}}
 				{{#if trialDuration}}{{trialDuration}}{{else}}4 weeks{{/if}} for <span class="ncf__payment-term__trial-price">{{trialPrice}}</span><br />
@@ -24,7 +24,7 @@
 			{{/ifEquals}}
 
 			{{#ifEquals this.name 'quarterly'}}
-			<span class="ncf__payment-term__title">{{#unless ../isPrintOrBundle}}{{#if isTrial}}Try the FT - {{/if}}{{/unless}}Quarterly</span>
+			<span class="ncf__payment-term__title">{{#unless ../isPrintOrBundle}}{{#if isTrial}}Trial: Digital Premium - {{/if}}{{/unless}}Quarterly</span>
 			<div class="ncf__payment-term__description">
 				{{#if isTrial}}
 				{{#if trialDuration}}{{trialDuration}}{{else}}4 weeks{{/if}} for <span class="ncf__payment-term__trial-price">{{trialPrice}}</span><br />
@@ -37,7 +37,7 @@
 			{{/ifEquals}}
 
 			{{#ifEquals this.name 'monthly'}}
-			<span class="ncf__payment-term__title">{{#unless ../isPrintOrBundle}}{{#if isTrial}}Try the FT - {{/if}}{{/unless}}Monthly</span>
+			<span class="ncf__payment-term__title">{{#unless ../isPrintOrBundle}}{{#if isTrial}}Trial: Digital Premium - {{/if}}{{/unless}}Monthly</span>
 			<div class="ncf__payment-term__description">
 				{{#if isTrial}}
 				{{#if trialDuration}}{{trialDuration}}{{else}}4 weeks{{/if}} for <span class="ncf__payment-term__trial-price">{{trialPrice}}</span><br />

--- a/test/partials/payment-term.spec.js
+++ b/test/partials/payment-term.spec.js
@@ -171,10 +171,10 @@ describe('payment-term', () => {
 				name,
 				isTrial: true
 			}]});
-			expect($(TITLE_SELECTOR).text()).to.contain('Try the FT');
+			expect($(TITLE_SELECTOR).text()).to.contain('Trial: Digital Premium');
 		});
 
-		it('should not show Try the FT for print or bundle trials', () => {
+		it('should not show Trial: Digital Premium for print or bundle trials', () => {
 			const $ = context.template({
 				options: [{
 					name,
@@ -182,7 +182,7 @@ describe('payment-term', () => {
 				}],
 				isPrintOrBundle: true
 			});
-			expect($(TITLE_SELECTOR).text()).to.not.contain('Try the FT');
+			expect($(TITLE_SELECTOR).text()).to.not.contain('Trial: Digital Premium');
 		});
 
 		it('should show the price', () => {


### PR DESCRIPTION
### Description
* Fixes the version of `graceful-fs`, so the app dependencies are installed correctly when using Node 12+ (mocha and jest fail otherwise)
* Changing the `Try the FT` trial copy to `Trial: Premium Digital`

https://financialtimes.atlassian.net/browse/ACQ-485
