### PR TITLE
Usg/wapo 206

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ make run # build and start documentation app at http://local.ft.com:5005/
 * [Utilities](#utilities)
 * [Contributing](CONTRIBUTING.md)
 * [Partials](docs/PARTIALS.md)
+* [Components](docs/COMPONENTS.md)
 
 ## Requirements
 

--- a/components/b2c-partnership-confirmation.jsx
+++ b/components/b2c-partnership-confirmation.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+export function B2CPartnershipConfirmation () {
+	const myFtLinkProps = {
+		href: '/myft',
+		className: 'ncf__button ncf__button--submit'
+	};
+
+	const readingLinkProps = {
+		href: '/',
+		className: 'ncf__link',
+	};
+
+	const customerCareProps = {
+		href: 'https://help.ft.com/',
+		className: 'ncf__link'
+	};
+
+	return (
+		<div className="ncf ncf__wrapper">
+			<div className="ncf__center">
+				<div className="ncf__icon ncf__icon--tick ncf__icon--large"/>
+				<div className="ncf__paragraph">
+					{
+						<h1 className="ncf__header ncf__header--confirmation">{'Welcome to your three months\' Premium access'}</h1>
+					}
+				</div>
+			</div>
+
+			<p className="ncf__paragraph">
+				Please check your email to confirm your account and set your password.
+			</p>
+
+			<p className="ncf__paragraph">
+				Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
+			</p>
+
+			<p className="ncf__paragraph ncf__center">
+				<a {...myFtLinkProps}>Go to myFT</a>
+			</p>
+
+			<p className="ncf__paragraph ncf__center">
+				<a {...readingLinkProps}>Start reading</a>
+			</p>
+
+			<p className="ncf__paragraph">
+				<div className="ncf__strong">Can we help?</div>
+				For any queries about your Premium subscription please <a {...customerCareProps}>contact Customer Care</a>.
+			</p>
+		</div>
+	);
+}

--- a/components/index.jsx
+++ b/components/index.jsx
@@ -3,6 +3,7 @@ export { AppBanner } from'./app-banner';
 export { BillingCity } from './billing-city';
 export { BillingCountry } from './billing-country';
 export { BillingPostcode } from'./billing-postcode';
+export { B2CPartnershipConfirmation} from './b2c-partnership-confirmation';
 export { CompanyName } from'./company-name';
 export { Confirmation } from'./confirmation';
 export { ContinueReading } from'./continue-reading';

--- a/components/licence-header.jsx
+++ b/components/licence-header.jsx
@@ -14,7 +14,7 @@ export function LicenceHeader ({
 	return (
 		<React.Fragment>
 			<h1 className="ncf__header">
-			{ displayName && (`${displayName} | `) }
+				{ displayName && (`${displayName} | `) }
 				{
 					isB2cPartnershipLicence
 						? ('Welcome to the Financial Times')

--- a/components/package-change.jsx
+++ b/components/package-change.jsx
@@ -5,7 +5,6 @@ export function PackageChange ({
 	changePackageUrl,
 	currentPackage,
 }) {
-	
 	return (
 		<div className="ncf__package-change">
 			<div className="ncf__package-change__package">

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1,0 +1,15 @@
+# Components
+
+## Content
+
+* [B2C Partnership Conformation](#b2c-partnership-confirmation)
+
+
+
+## B2C Partnership Confirmation
+
+Renders the B2C Partnership confirmation page.
+
+```jsx
+{<B2CPartnershipConfirmation />}
+```


### PR DESCRIPTION
### Description
This change introduces a new `B2CPartnershipConfirmation` component which will be shown when users complete their registration onto a B2C Partnership licence.

[Ticket](https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1128&projectKey=UG&selectedIssue=UG-206)

### Screenshots

![image](https://user-images.githubusercontent.com/25018001/90373423-cc2e5d80-e069-11ea-8b8c-e2e85e8917ea.png)

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [X] **Documentation** updated or created
- [X] **Tests** written for new or updated for existing functionality
- [X] **Demos** updated to use this change
- [X] **Accessibility** checked for screen readers and contrast
- [X] **Design Review** ran past the designer 
