### PR TITLE
Offer different b2cp-confirmation component for when FT is vendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ make run # build and start documentation app at http://local.ft.com:5005/
 * [Usage](#usage)
 * [Utilities](#utilities)
 * [Contributing](CONTRIBUTING.md)
-* [Components](docs/COMPONENTS.md)
 
 ## Requirements
 

--- a/components/__snapshots__/b2c-partnership-confirmation.spec.js.snap
+++ b/components/__snapshots__/b2c-partnership-confirmation.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`B2CPartnershipConfirmation renders with default props 1`] = `
+exports[`B2CPartnershipConfirmation renders when FT is not the host 1`] = `
 <div class="ncf ncf__wrapper">
   <div class="ncf__center">
     <div class="ncf__icon ncf__icon--tick ncf__icon--large">
@@ -16,6 +16,49 @@ exports[`B2CPartnershipConfirmation renders with default props 1`] = `
   </p>
   <p class="ncf__paragraph">
     Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
+  </p>
+  <p class="ncf__paragraph ncf__center">
+    <a href="/myft"
+       class="ncf__button ncf__button--submit"
+    >
+      Go to myFT
+    </a>
+  </p>
+  <p class="ncf__paragraph ncf__center">
+    <a href="/"
+       class="ncf__link"
+    >
+      Start reading
+    </a>
+  </p>
+  <p class="ncf__paragraph">
+    <div class="ncf__strong">
+      Can we help?
+    </div>
+    For any queries about your Premium subscription please
+    <a href="https://help.ft.com/"
+       class="ncf__link"
+    >
+      contact Customer Care
+    </a>
+    .
+  </p>
+</div>
+`;
+
+exports[`B2CPartnershipConfirmation renders with default props 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <div class="ncf__paragraph">
+      <h1 class="ncf__header ncf__header--confirmation">
+        Welcome to your Digital subscription
+      </h1>
+    </div>
+  </div>
+  <p class="ncf__paragraph">
+    We have sent you an email to start your 90-day All Access Digital with The Washington Post
   </p>
   <p class="ncf__paragraph ncf__center">
     <a href="/myft"

--- a/components/b2c-partnership-confirmation.jsx
+++ b/components/b2c-partnership-confirmation.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-export function B2CPartnershipConfirmation () {
+export function B2CPartnershipConfirmation ({
+	hostPartner = true,
+}
+) {
 	const myFtLinkProps = {
 		href: '/myft',
 		className: 'ncf__button ncf__button--submit'
@@ -16,24 +20,30 @@ export function B2CPartnershipConfirmation () {
 		className: 'ncf__link'
 	};
 
+	const b2cSubscriptionType = hostPartner ? 'Digital subscription' : 'three months\' Premium access';
+
+	const subscriptionAction = hostPartner ? 'We have sent you an email to start your 90-day All Access Digital with The Washington Post' : 'Please check your email to confirm your account and set your password.';
+
 	return (
 		<div className="ncf ncf__wrapper">
 			<div className="ncf__center">
 				<div className="ncf__icon ncf__icon--tick ncf__icon--large"/>
 				<div className="ncf__paragraph">
 					{
-						<h1 className="ncf__header ncf__header--confirmation">{'Welcome to your three months\' Premium access'}</h1>
+						<h1 className="ncf__header ncf__header--confirmation">Welcome to your {b2cSubscriptionType}</h1>
 					}
 				</div>
 			</div>
 
 			<p className="ncf__paragraph">
-				Please check your email to confirm your account and set your password.
+				{subscriptionAction}
 			</p>
 
-			<p className="ncf__paragraph">
-				Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
-			</p>
+			{!hostPartner &&
+				<p className="ncf__paragraph">
+					Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
+				</p>
+			}
 
 			<p className="ncf__paragraph ncf__center">
 				<a {...myFtLinkProps}>Go to myFT</a>
@@ -50,3 +60,7 @@ export function B2CPartnershipConfirmation () {
 		</div>
 	);
 }
+
+B2CPartnershipConfirmation.propTypes = {
+	hostPartner: PropTypes.bool,
+};

--- a/components/b2c-partnership-confirmation.spec.js
+++ b/components/b2c-partnership-confirmation.spec.js
@@ -5,6 +5,12 @@ expect.extend(expectToRenderCorrectly);
 
 describe('B2CPartnershipConfirmation', () => {
 	it('renders with default props', () => {
-		expect(B2CPartnershipConfirmation).toRenderCorrectly();
+		const props = {};
+		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
+	});
+
+	it('renders when FT is not the host', () => {
+		const props = { hostPartner: false };
+		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
 	});
 });


### PR DESCRIPTION
If FT is the B2CP vendor, one confirmation is shown. If the vendor is WaPo, another confirmation is shown

### Description
There are 2 types of B2C Partnership.  

- If FT is the vendor, we show one confirmation page after the subscription is purchased.
- If FT is the partner, we show a different confirmation page after the user has registered their 3-month access.

[Ticket](https://financialtimes.atlassian.net/browse/UG-208)

### Screenshots

Screenshots are from the storybook, so will look better when the components are implemented in `next-subscribe` :)

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/25018001/91989947-06198800-ed29-11ea-97b0-facb178c83ef.png) | ![image](https://user-images.githubusercontent.com/25018001/91990019-20536600-ed29-11ea-997f-379fa349324c.png) |

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [X] **Documentation** THERE ARE NO LONGER ANY DOCS TO UPDATE WAAAA
- [X] **Tests** written for new or updated for existing functionality
- [X] **Stories** updated to use this change
- [X] **Design Review** ran past the designer - Jess Martin
