### PR TITLE
 USG-208 Update the B2C Partnership Confirmation Component (again)

### DIFF
--- a/components/__snapshots__/b2c-partnership-confirmation.spec.js.snap
+++ b/components/__snapshots__/b2c-partnership-confirmation.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`B2CPartnershipConfirmation renders when FT is not the host 1`] = `
+exports[`B2CPartnershipConfirmation renders aß default 1`] = `
 <div class="ncf ncf__wrapper">
   <div class="ncf__center">
     <div class="ncf__icon ncf__icon--tick ncf__icon--large">
@@ -16,49 +16,6 @@ exports[`B2CPartnershipConfirmation renders when FT is not the host 1`] = `
   </p>
   <p class="ncf__paragraph">
     Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
-  </p>
-  <p class="ncf__paragraph ncf__center">
-    <a href="/myft"
-       class="ncf__button ncf__button--submit"
-    >
-      Go to myFT
-    </a>
-  </p>
-  <p class="ncf__paragraph ncf__center">
-    <a href="/"
-       class="ncf__link"
-    >
-      Start reading
-    </a>
-  </p>
-  <p class="ncf__paragraph">
-    <div class="ncf__strong">
-      Can we help?
-    </div>
-    For any queries about your Premium subscription please
-    <a href="https://help.ft.com/"
-       class="ncf__link"
-    >
-      contact Customer Care
-    </a>
-    .
-  </p>
-</div>
-`;
-
-exports[`B2CPartnershipConfirmation renders with default props 1`] = `
-<div class="ncf ncf__wrapper">
-  <div class="ncf__center">
-    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
-    </div>
-    <div class="ncf__paragraph">
-      <h1 class="ncf__header ncf__header--confirmation">
-        Welcome to your Digital subscription
-      </h1>
-    </div>
-  </div>
-  <p class="ncf__paragraph">
-    We have sent you an email to start your 90-day All Access Digital subscription with The Washington Post
   </p>
   <p class="ncf__paragraph ncf__center">
     <a href="/myft"

--- a/components/__snapshots__/confirmation.spec.js.snap
+++ b/components/__snapshots__/confirmation.spec.js.snap
@@ -124,6 +124,70 @@ exports[`Confirmation renders Call To Action (CTA) for print-only 1`] = `
 </div>
 `;
 
+exports[`Confirmation renders appropriately if is B2C Partnership 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <p class="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">
+      You are now subscribed to:
+    </p>
+    <h1 class="ncf__header ncf__header--confirmation">
+    </h1>
+  </div>
+  <p class="ncf__paragraph">
+    We’ve sent confirmation to your email. Make sure you check your spam folder if you don’t receive it.
+  </p>
+  <p>
+    We&#x27;ve also sent you an email to start your 90-day All Access Digital subscription with The Washington Post.
+  </p>
+  <p class="ncf__paragraph">
+    Here’s a summary of your  subscription:
+  </p>
+  <div class="ncf__headed-paragraph">
+    <h3 class="ncf__header">
+      Something not right?
+    </h3>
+    <p class="ncf__paragraph">
+      Go to your
+      <a class="ncf__link ncf__link--external"
+         href="https://myaccount.ft.com/details/core/view"
+         target="_blank"
+         rel="noopener"
+         data-trackable="yourAccount"
+      >
+        account settings
+      </a>
+      to view or edit your account. If you need to get in touch call us on
+      <a href="tel:+442077556248"
+         class="ncf__link ncf__link--external"
+      >
+        +44 (0) 207 755 6248
+      </a>
+      . Or contact us for additional support.
+    </p>
+  </div>
+  <p class="ncf__paragraph">
+    We will automatically renew your subscription using the payment method provided unless you cancel before your renewal date. See our
+    <a class="ncf__link ncf__link--external"
+       href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+       target="_top"
+       rel="noopener"
+    >
+      Terms &amp; Conditions
+    </a>
+    for details on how to cancel.
+  </p>
+  <p class="ncf__center">
+    <a href="/"
+       class="ncf__button ncf__button--submit"
+    >
+      Start exploring
+    </a>
+  </p>
+</div>
+`;
+
 exports[`Confirmation renders appropriately if is trial 1`] = `
 <div class="ncf ncf__wrapper"
      data-signup-is-trial="true"

--- a/components/b2c-partnership-confirmation.jsx
+++ b/components/b2c-partnership-confirmation.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-export function B2CPartnershipConfirmation ({
-	hostPartner = true,
-}
-) {
+export function B2CPartnershipConfirmation () {
 	const myFtLinkProps = {
 		href: '/myft',
 		className: 'ncf__button ncf__button--submit'
@@ -20,30 +16,24 @@ export function B2CPartnershipConfirmation ({
 		className: 'ncf__link'
 	};
 
-	const b2cSubscriptionType = hostPartner ? 'Digital subscription' : 'three months\' Premium access';
-
-	const subscriptionAction = hostPartner ? 'We have sent you an email to start your 90-day All Access Digital subscription with The Washington Post' : 'Please check your email to confirm your account and set your password.';
-
 	return (
 		<div className="ncf ncf__wrapper">
 			<div className="ncf__center">
 				<div className="ncf__icon ncf__icon--tick ncf__icon--large"/>
 				<div className="ncf__paragraph">
 					{
-						<h1 className="ncf__header ncf__header--confirmation">Welcome to your {b2cSubscriptionType}</h1>
+						<h1 className="ncf__header ncf__header--confirmation">{'Welcome to your three months\' Premium access'}</h1>
 					}
 				</div>
 			</div>
 
 			<p className="ncf__paragraph">
-				{subscriptionAction}
+				Please check your email to confirm your account and set your password.
 			</p>
 
-			{!hostPartner &&
-				<p className="ncf__paragraph">
+			<p className="ncf__paragraph">
 					Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
-				</p>
-			}
+			</p>
 
 			<p className="ncf__paragraph ncf__center">
 				<a {...myFtLinkProps}>Go to myFT</a>
@@ -60,7 +50,3 @@ export function B2CPartnershipConfirmation ({
 		</div>
 	);
 }
-
-B2CPartnershipConfirmation.propTypes = {
-	hostPartner: PropTypes.bool,
-};

--- a/components/b2c-partnership-confirmation.spec.js
+++ b/components/b2c-partnership-confirmation.spec.js
@@ -4,13 +4,7 @@ import { expectToRenderCorrectly } from '../test-jest/helpers/expect-to-render-c
 expect.extend(expectToRenderCorrectly);
 
 describe('B2CPartnershipConfirmation', () => {
-	it('renders with default props', () => {
-		const props = {};
-		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
-	});
-
-	it('renders when FT is not the host', () => {
-		const props = { hostPartner: false };
-		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
+	it('renders aß default', () => {
+		expect(B2CPartnershipConfirmation).toRenderCorrectly();
 	});
 });

--- a/components/confirmation.jsx
+++ b/components/confirmation.jsx
@@ -6,6 +6,7 @@ const EMAIL_DEFAULT_TEXT = 'your email';
 export function Confirmation ({
 	// isTrial prop is needed for the floodlight pixel tracking.
 	isTrial = false,
+	isB2cPartnership = false,
 	offer = '',
 	email = EMAIL_DEFAULT_TEXT,
 	details = null,
@@ -65,6 +66,10 @@ export function Confirmation ({
 			<p className="ncf__paragraph">
 				We’ve sent confirmation to {email}. Make sure you check your spam folder if you don’t receive it.
 			</p>
+			{ isB2cPartnership ?
+				<p>We&apos;ve also sent you an email to start your 90-day All Access Digital subscription with The Washington Post.</p>
+				: ''
+			}
 			<p className="ncf__paragraph">
 				Here’s a summary of your {offer} subscription:
 			</p>
@@ -90,6 +95,7 @@ export function Confirmation ({
 
 Confirmation.propTypes = {
 	isTrial: PropTypes.bool,
+	isB2cPartnership: PropTypes.bool,
 	offer: PropTypes.string.isRequired,
 	email: PropTypes.string,
 	details: PropTypes.arrayOf(PropTypes.shape({

--- a/components/confirmation.spec.js
+++ b/components/confirmation.spec.js
@@ -18,6 +18,12 @@ describe('Confirmation', () => {
 		expect(Confirmation).toRenderCorrectly(props);
 	});
 
+	it('renders appropriately if is B2C Partnership', () => {
+		const props = { isB2cPartnership: true };
+
+		expect(Confirmation).toRenderCorrectly(props);
+	});
+
 	it('renders with custom email', () => {
 		const props = { offer: OFFER_TEXT, email: 'test@example.com' };
 


### PR DESCRIPTION
Basically undoes #455 and adjusts the current confirmation component for subscriptions bought.

### Description
There are 2 types of B2C Partnership.  

- If FT is the vendor, we show one confirmation page after the subscription is purchased.
- If FT is the partner, we show a different confirmation page after the user has registered their 3-month access.

[Ticket](https://financialtimes.atlassian.net/browse/UG-208)

### Screenshots

| Before | After |
| ------ | ------ |
|![image](https://user-images.githubusercontent.com/25018001/92131124-7bef2380-edfd-11ea-92a5-c7571e31af56.png) | ![image](https://user-images.githubusercontent.com/25018001/92131276-b5279380-edfd-11ea-9022-0d3b28ce778d.png) |

Example of a B2CPartnership Conf:
![image](https://user-images.githubusercontent.com/25018001/92246595-e36ca800-eebd-11ea-956f-85f52e888e56.png)

### Reminder
Have you completed these common tasks?

Ye, obvs

- [X] **Documentation** THERE ARE NO LONGER ANY DOCS TO UPDATE WAAAA
- [X] **Tests** written for new or updated for existing functionality
- [X] **Stories** updated to use this change
- [X] **Design Review** ran past the designer - Jess Martin