### PR TITLE
ACQ-550 Change licence title for B2B sign-in forms with not presented company name

### DIFF
--- a/components/__snapshots__/licence-header.spec.js.snap
+++ b/components/__snapshots__/licence-header.spec.js.snap
@@ -14,15 +14,7 @@ exports[`LicenceHeader renders if is trial 1`] = `
 
 exports[`LicenceHeader renders if url is defined 1`] = `
 <h1 class="ncf__header ncf__center">
-  <span class="ncf__light-licence-text">
-    Great news!
-  </span>
-  <span class="ncf__light-licence-text">
-    Your company
-  </span>
-  <span class="ncf__light-licence-text">
-    has an FT Subscription you can join
-  </span>
+  Join your FT.com subscription
 </h1>
 <div class="ncf__center">
   <p>
@@ -47,7 +39,13 @@ exports[`LicenceHeader renders with custom display name 1`] = `
     Display name text
   </span>
   <span class="ncf__light-licence-text">
-    has an FT Subscription you can join
+    has an
+  </span>
+  <span class="ncf__bold-licence-text">
+    FT subscription
+  </span>
+  <span class="ncf__light-licence-text">
+    you can join
   </span>
 </h1>
 <div class="ncf__center">
@@ -67,15 +65,7 @@ exports[`LicenceHeader renders with custom display name 1`] = `
 
 exports[`LicenceHeader renders with custom welcome text (that requires escaping, e.g. ampersand) 1`] = `
 <h1 class="ncf__header ncf__center">
-  <span class="ncf__light-licence-text">
-    Great news!
-  </span>
-  <span class="ncf__light-licence-text">
-    Your company
-  </span>
-  <span class="ncf__light-licence-text">
-    has an FT Subscription you can join
-  </span>
+  Join your FT.com subscription
 </h1>
 <div class="ncf__center">
   <p>
@@ -89,15 +79,7 @@ exports[`LicenceHeader renders with custom welcome text (that requires escaping,
 
 exports[`LicenceHeader renders with default props 1`] = `
 <h1 class="ncf__header ncf__center">
-  <span class="ncf__light-licence-text">
-    Great news!
-  </span>
-  <span class="ncf__light-licence-text">
-    Your company
-  </span>
-  <span class="ncf__light-licence-text">
-    has an FT Subscription you can join
-  </span>
+  Join your FT.com subscription
 </h1>
 <div class="ncf__center">
   <p>

--- a/components/__snapshots__/licence-header.spec.js.snap
+++ b/components/__snapshots__/licence-header.spec.js.snap
@@ -34,17 +34,13 @@ exports[`LicenceHeader renders with custom display name 1`] = `
 <h1 class="ncf__header ncf__center">
   <span class="ncf__light-licence-text">
     Great news!
-  </span>
-  <span class="ncf__bold-licence-text">
-    Display name text
-  </span>
-  <span class="ncf__light-licence-text">
+    <span class="ncf__bold-licence-text">
+      Display name text
+    </span>
     has an
-  </span>
-  <span class="ncf__bold-licence-text">
-    FT subscription
-  </span>
-  <span class="ncf__light-licence-text">
+    <span class="ncf__bold-licence-text">
+      FT subscription
+    </span>
     you can join
   </span>
 </h1>

--- a/components/__snapshots__/licence-title.spec.js.snap
+++ b/components/__snapshots__/licence-title.spec.js.snap
@@ -21,21 +21,19 @@ exports[`LicenceTitle renders with custom display name 1`] = `
     Display name text
   </span>
   <span class="ncf__light-licence-text">
-    has an FT Subscription you can join
+    has an
+  </span>
+  <span class="ncf__bold-licence-text">
+    FT subscription
+  </span>
+  <span class="ncf__light-licence-text">
+    you can join
   </span>
 </h1>
 `;
 
 exports[`LicenceTitle renders with default props 1`] = `
 <h1 class="ncf__header ncf__center">
-  <span class="ncf__light-licence-text">
-    Great news!
-  </span>
-  <span class="ncf__light-licence-text">
-    Your company
-  </span>
-  <span class="ncf__light-licence-text">
-    has an FT Subscription you can join
-  </span>
+  Join your FT.com subscription
 </h1>
 `;

--- a/components/__snapshots__/licence-title.spec.js.snap
+++ b/components/__snapshots__/licence-title.spec.js.snap
@@ -16,17 +16,13 @@ exports[`LicenceTitle renders with custom display name 1`] = `
 <h1 class="ncf__header ncf__center">
   <span class="ncf__light-licence-text">
     Great news!
-  </span>
-  <span class="ncf__bold-licence-text">
-    Display name text
-  </span>
-  <span class="ncf__light-licence-text">
+    <span class="ncf__bold-licence-text">
+      Display name text
+    </span>
     has an
-  </span>
-  <span class="ncf__bold-licence-text">
-    FT subscription
-  </span>
-  <span class="ncf__light-licence-text">
+    <span class="ncf__bold-licence-text">
+      FT subscription
+    </span>
     you can join
   </span>
 </h1>

--- a/components/licence-title.jsx
+++ b/components/licence-title.jsx
@@ -27,14 +27,20 @@ export function LicenceTitle ({
 }
 
 function renderB2BTitle (displayName) {
-	const companyName = displayName ? displayName : 'Your company';
-	const boldTextClassName = (displayName !== '') ? 'ncf__bold-licence-text' : 'ncf__light-licence-text';
-	const template =
-		<h1 className="ncf__header ncf__center">
-			<span className="ncf__light-licence-text">Great news! </span>
-			<span className={boldTextClassName}>{companyName}</span>
-			<span className="ncf__light-licence-text"> has an FT Subscription you can join</span>
-		</h1>;
+	let template;
+	if(displayName) {
+		template =
+				<h1 className="ncf__header ncf__center">
+					<span className="ncf__light-licence-text">Great news! </span>
+					<span className="ncf__bold-licence-text">{displayName}</span>
+					<span className="ncf__light-licence-text"> has an </span>
+					<span className="ncf__bold-licence-text">FT subscription </span>
+					<span className="ncf__light-licence-text">you can join</span>
+            	</h1>;
+	} else {
+		template =
+				<h1 className="ncf__header ncf__center">Join your FT.com subscription</h1>;
+	}
 
 	return template;
 }

--- a/components/licence-title.jsx
+++ b/components/licence-title.jsx
@@ -34,11 +34,13 @@ function renderB2BTitle (displayName) {
 
 	return (
 		<h1 className="ncf__header ncf__center">
-			<span className="ncf__light-licence-text">Great news! </span>
-			<span className="ncf__bold-licence-text">{displayName}</span>
-			<span className="ncf__light-licence-text"> has an </span>
-			<span className="ncf__bold-licence-text">FT subscription </span>
-			<span className="ncf__light-licence-text">you can join</span>
+			<span className="ncf__light-licence-text">
+				Great news!
+				<span className="ncf__bold-licence-text"> {displayName} </span>
+				has an
+				<span className="ncf__bold-licence-text"> FT subscription </span>
+				you can join
+			</span>
 		</h1>
 	);
 }

--- a/components/licence-title.jsx
+++ b/components/licence-title.jsx
@@ -28,19 +28,19 @@ export function LicenceTitle ({
 
 function renderB2BTitle (displayName) {
 
-	if(displayName) {
-		return (
-			<h1 className="ncf__header ncf__center">
-				<span className="ncf__light-licence-text">Great news! </span>
-				<span className="ncf__bold-licence-text">{displayName}</span>
-				<span className="ncf__light-licence-text"> has an </span>
-				<span className="ncf__bold-licence-text">FT subscription </span>
-				<span className="ncf__light-licence-text">you can join</span>
-			</h1>
-		);
+	if(!displayName) {
+		return (<h1 className="ncf__header ncf__center">Join your FT.com subscription</h1>);
 	}
 
-	return (<h1 className="ncf__header ncf__center">Join your FT.com subscription</h1>);
+	return (
+		<h1 className="ncf__header ncf__center">
+			<span className="ncf__light-licence-text">Great news! </span>
+			<span className="ncf__bold-licence-text">{displayName}</span>
+			<span className="ncf__light-licence-text"> has an </span>
+			<span className="ncf__bold-licence-text">FT subscription </span>
+			<span className="ncf__light-licence-text">you can join</span>
+		</h1>
+	);
 }
 
 LicenceTitle.propTypes = {

--- a/components/licence-title.jsx
+++ b/components/licence-title.jsx
@@ -27,22 +27,20 @@ export function LicenceTitle ({
 }
 
 function renderB2BTitle (displayName) {
-	let template;
+
 	if(displayName) {
-		template =
-				<h1 className="ncf__header ncf__center">
-					<span className="ncf__light-licence-text">Great news! </span>
-					<span className="ncf__bold-licence-text">{displayName}</span>
-					<span className="ncf__light-licence-text"> has an </span>
-					<span className="ncf__bold-licence-text">FT subscription </span>
-					<span className="ncf__light-licence-text">you can join</span>
-            	</h1>;
-	} else {
-		template =
-				<h1 className="ncf__header ncf__center">Join your FT.com subscription</h1>;
+		return (
+			<h1 className="ncf__header ncf__center">
+				<span className="ncf__light-licence-text">Great news! </span>
+				<span className="ncf__bold-licence-text">{displayName}</span>
+				<span className="ncf__light-licence-text"> has an </span>
+				<span className="ncf__bold-licence-text">FT subscription </span>
+				<span className="ncf__light-licence-text">you can join</span>
+			</h1>
+		);
 	}
 
-	return template;
+	return (<h1 className="ncf__header ncf__center">Join your FT.com subscription</h1>);
 }
 
 LicenceTitle.propTypes = {


### PR DESCRIPTION
### Description
Change licence title for B2B sign-in forms with not presented display name of the company
### Ticket
https://financialtimes.atlassian.net/browse/ACQ-550

### Screenshots

| Before | After |
| ------ | ----- |
| <img src="https://user-images.githubusercontent.com/30728763/92238468-00a37580-eec2-11ea-8416-4bdae8eac51c.png" width=350px/> |   <img src="https://user-images.githubusercontent.com/30728763/92238264-81ae3d00-eec1-11ea-8e68-bdca1751294b.png" width=350px />   |
| <img src="https://user-images.githubusercontent.com/30728763/92249997-8f6cbe00-eed3-11ea-9578-a398452ddb40.png" width=350px/> |   <img src="https://user-images.githubusercontent.com/30728763/92250093-b4613100-eed3-11ea-9beb-f8f361067b15.png" width=350px/>



### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
