### PR TITLE
Reintroduce make test to pre-commit husky hook 🐿 v2.13.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const config = {
 	'env': {
 		'browser': true,
@@ -47,8 +46,8 @@ const config = {
 	'overrides': [
 		{
 			'files': [ 'test/**/*.js', 'tests/**/*.js', 'cypress/**/*.js' ],
-			"env": {
-				"jest": true
+			'env': {
+				'jest': true
 			},
 			'rules': {
 				'no-only-tests/no-only-tests': 'error'
@@ -66,8 +65,8 @@ const packageJsonContainsPackage = packageName => {
 		(dependencies && dependencies[packageName])
 		|| (devDependencies && devDependencies[packageName])
 		|| (peerDependencies && peerDependencies[packageName])
-	)
-}
+	);
+};
 
 if ((packageJsonContainsPackage('react') || packageJsonContainsPackage('preact'))) {
 	config.plugins.push('react');

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,102 @@
+const fs = require('fs');
+const config = {
+	'env': {
+		'browser': true,
+		'es6': true,
+		'mocha': true,
+		'node': true
+	},
+	'parserOptions': {
+		'ecmaVersion': 2018,
+		'sourceType': 'module'
+	},
+	'rules': {
+		'eqeqeq': 'error',
+		'guard-for-in': 'error',
+		'indent': ['error', 'tab', {'SwitchCase': 1}],
+		'new-cap': 'off',
+		'no-caller': 'error',
+		'no-console': 'error',
+		'no-extend-native': 'error',
+		'no-irregular-whitespace': 'error',
+		'no-loop-func': 'error',
+		'no-multi-spaces': 'error',
+		'no-return-await': 'warn',
+		'no-trailing-spaces': 'error',
+		'no-undef': 'error',
+		'no-underscore-dangle': 'off',
+		'no-unused-vars': 'error',
+		'no-var': 'error',
+		'one-var': ['error', 'never'],
+		'quotes': ['error', 'single'],
+		'semi': ['warn', 'always'],
+		'space-before-function-paren': ['error', 'always'],
+		'wrap-iife': 'error'
+	},
+	'globals': {
+		'cy': true,
+		'cypress': true,
+		'Cypress': true,
+		'fetch': true,
+		'requireText': true
+	},
+	'plugins': [
+		'no-only-tests'
+	],
+	'extends': [],
+	'overrides': [
+		{
+			'files': [ 'test/**/*.js', 'tests/**/*.js', 'cypress/**/*.js' ],
+			"env": {
+				"jest": true
+			},
+			'rules': {
+				'no-only-tests/no-only-tests': 'error'
+			}
+		}
+	],
+	'settings' : {}
+};
+
+const packageJson = require('./package.json');
+
+const packageJsonContainsPackage = packageName => {
+	const { dependencies, devDependencies, peerDependencies } = packageJson;
+	return (
+		(dependencies && dependencies[packageName])
+		|| (devDependencies && devDependencies[packageName])
+		|| (peerDependencies && peerDependencies[packageName])
+	)
+}
+
+if ((packageJsonContainsPackage('react') || packageJsonContainsPackage('preact'))) {
+	config.plugins.push('react');
+	config.extends.push('plugin:react/recommended');
+
+	Object.assign(config.rules, {
+		'react/display-name': 'off',
+		'react/prop-types': 'off',
+		'react/no-danger': 'off',
+		'react/no-render-return-value': 'off'
+	});
+
+	Object.assign(config.settings, {
+		react: {
+			version: 'detect'
+		}
+	});
+}
+
+if (packageJsonContainsPackage('jest')) {
+	config.env.jest = true;
+}
+
+if (packageJson && packageJson.eslintConfig) {
+	Object.assign(config.env, packageJson.eslintConfig.env);
+	Object.assign(config.parserOptions, packageJson.eslintConfig.parserOptions);
+	Object.assign(config.rules, packageJson.eslintConfig.rules);
+	Object.assign(config.globals, packageJson.eslintConfig.globals);
+	Object.assign(config.settings, packageJson.eslintConfig.settings);
+}
+
+module.exports = config;

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ npm-debug.log
 /pa11y_screenCapture/
 package-lock.json
 .editorconfig
-.eslintrc.js
+# .eslintrc.js
 .pa11yci.js
 .stylelintrc
 dist

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@babel/runtime": "^7.11.2",
     "classnames": "2.2.6",
+    "eslint-plugin-no-only-tests": "^2.4.0",
     "fetchres": "1.7.2",
     "lodash.get": "4.4.2",
     "n-common-static-data": "financial-times/n-common-static-data#v1.6.1"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "node_modules/.bin/secret-squirrel-commitmsg",
-      "pre-commit": "node_modules/.bin/secret-squirrel",
+      "pre-commit": "node_modules/.bin/secret-squirrel && make test",
       "pre-push": "make verify -j3"
     }
   }


### PR DESCRIPTION
This got removed in the #465 but tests should be run before committing.

ESLint dependency has been added to fix unit tests. Related PR for same fix: https://github.com/Financial-Times/next-tour-page/pull/291