### PR TITLE
add `isUSContract` propType

### DIFF
--- a/components/education-job-title.jsx
+++ b/components/education-job-title.jsx
@@ -60,4 +60,5 @@ EducationJobTitle.propTypes = {
 	fieldId: PropTypes.string,
 	inputId: PropTypes.string,
 	inputName: PropTypes.string,
+	isUSContract: PropTypes.bool,
 };


### PR DESCRIPTION

### Description
Previously there was no control on the storybook for `isUSContract`. This is now added:
![image](https://user-images.githubusercontent.com/25018001/93326247-6a037c80-f810-11ea-9662-f35f162b7949.png)

So we can see the educationalJobTitles available in the US.
![image](https://user-images.githubusercontent.com/25018001/93326179-535d2580-f810-11ea-85f8-e2fd91bdc8a0.png)
