### PR TITLE
UG-254 add CTA to return user to article they were reading

### DIFF
--- a/components/__snapshots__/confirmation.spec.js.snap
+++ b/components/__snapshots__/confirmation.spec.js.snap
@@ -1,6 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Confirmation renders Call To Action (CTA) for non-print-only 1`] = `
+exports[`Confirmation renders Call To Action (CTA) for non-print-only with article return 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <p class="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">
+      You are now subscribed to:
+    </p>
+    <h1 class="ncf__header ncf__header--confirmation">
+      Offer text
+    </h1>
+  </div>
+  <p class="ncf__paragraph">
+    We’ve sent confirmation to your email. Make sure you check your spam folder if you don’t receive it.
+  </p>
+  <p class="ncf__paragraph">
+    Here’s a summary of your Offer text subscription:
+  </p>
+  <div class="ncf__headed-paragraph">
+    <h3 class="ncf__header">
+      Something not right?
+    </h3>
+    <p class="ncf__paragraph">
+      Go to your
+      <a class="ncf__link ncf__link--external"
+         href="https://myaccount.ft.com/details/core/view"
+         target="_blank"
+         rel="noopener"
+         data-trackable="yourAccount"
+      >
+        account settings
+      </a>
+      to view or edit your account. If you need to get in touch call us on
+      <a href="tel:+442077556248"
+         class="ncf__link ncf__link--external"
+      >
+        +44 (0) 207 755 6248
+      </a>
+      . Or contact us for additional support.
+    </p>
+  </div>
+  <p class="ncf__paragraph">
+    We will automatically renew your subscription using the payment method provided unless you cancel before your renewal date. See our
+    <a class="ncf__link ncf__link--external"
+       href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+       target="_top"
+       rel="noopener"
+    >
+      Terms &amp; Conditions
+    </a>
+    for details on how to cancel.
+  </p>
+  <p class="ncf__center">
+    <div>
+      <a href="/content/article uuid"
+         class="ncf__button ncf__button--submit ncf__button--margin"
+      >
+        Return to your article
+      </a>
+    </div>
+    <div>
+      <a href="/"
+         class="ncf__link"
+      >
+        Explore the FT
+      </a>
+    </div>
+  </p>
+</div>
+`;
+
+exports[`Confirmation renders Call To Action (CTA) for non-print-only without article return 1`] = `
 <div class="ncf ncf__wrapper">
   <div class="ncf__center">
     <div class="ncf__icon ncf__icon--tick ncf__icon--large">

--- a/components/confirmation.jsx
+++ b/components/confirmation.jsx
@@ -12,7 +12,8 @@ export function Confirmation ({
 	details = null,
 	directDebitMandateUrl = null,
 	hideCta = false,
-	isPrintOnly = false
+	isPrintOnly = false,
+	contentUuid = '',
 }) {
 	const containerDivProps = {
 		className: 'ncf ncf__wrapper',
@@ -45,12 +46,23 @@ export function Confirmation ({
 		</div>
 	);
 
+	const returnToArticleCta = (<>
+		<div>
+			<a href={`/content/${contentUuid}`} className="ncf__button ncf__button--submit ncf__button--margin">Return to your article</a>
+		</div>
+		<div>
+			<a href="/" className="ncf__link">Explore the FT</a>
+		</div>
+	</>);
+
 	const ctaElement = !hideCta && (
 		<p className="ncf__center">
 			{
 				isPrintOnly
 					? (<a href="/todaysnewspaper " className="ncf__button ncf__button--submit">Explore our E-Paper</a>)
-					: (<a href="/" className="ncf__button ncf__button--submit">Start exploring</a>)
+					: contentUuid
+						? returnToArticleCta
+						: <a href={"/"} className="ncf__button ncf__button--submit">Start exploring</a>
 			}
 		</p>
 	);
@@ -94,6 +106,7 @@ export function Confirmation ({
 }
 
 Confirmation.propTypes = {
+	contentUuid: PropTypes.string,
 	isTrial: PropTypes.bool,
 	isB2cPartnership: PropTypes.bool,
 	offer: PropTypes.string.isRequired,

--- a/components/confirmation.spec.js
+++ b/components/confirmation.spec.js
@@ -4,6 +4,7 @@ import { expectToRenderCorrectly } from '../test-jest/helpers/expect-to-render-c
 expect.extend(expectToRenderCorrectly);
 
 const OFFER_TEXT = 'Offer text';
+const UUID = 'article uuid';
 
 describe('Confirmation', () => {
 	it('renders with default props', () => {
@@ -73,7 +74,13 @@ describe('Confirmation', () => {
 		expect(Confirmation).toRenderCorrectly(props);
 	});
 
-	it('renders Call To Action (CTA) for non-print-only', () => {
+	it('renders Call To Action (CTA) for non-print-only with article return', () => {
+		const props = { offer: OFFER_TEXT, isPrintOnly: false, contentUuid: UUID };
+
+		expect(Confirmation).toRenderCorrectly(props);
+	});
+
+	it('renders Call To Action (CTA) for non-print-only without article return', () => {
 		const props = { offer: OFFER_TEXT, isPrintOnly: false };
 
 		expect(Confirmation).toRenderCorrectly(props);

--- a/main.scss
+++ b/main.scss
@@ -259,6 +259,10 @@
 			width: 30%;
 		}
 
+		&--margin {
+			margin-bottom: 20px;
+		}
+
 	}
 
 	&__center {


### PR DESCRIPTION
### Description
This PR enables users that hit the 'Bernie barrier' to return to the article they were reading after signing up to the $1 trial.

### Ticket
[Voila!](https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1128&projectKey=UG&modal=detail&selectedIssue=UG-254)

### Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/25018001/93819015-0be0fa00-fc53-11ea-8006-d4663837dee3.png)|![image](https://user-images.githubusercontent.com/25018001/93818991-01befb80-fc53-11ea-8488-0ea0d55900bb.png)|

### Reminder
Have you completed these common tasks?

- [n/a now that storybook exists] **Documentation** updated or created
- [X] **Tests** written for new or updated for existing functionality
- [X] **Stories** updated to use this change
- [X] **Accessibility** checked for screen readers and contrast - no change to previous styling uses
- [X] **Design Review** ran past the designer
- [X] **Product Review** ran past the product owner
