### PR TITLE
Center return to article Cta buttons

### DIFF
--- a/components/__snapshots__/confirmation.spec.js.snap
+++ b/components/__snapshots__/confirmation.spec.js.snap
@@ -53,19 +53,21 @@ exports[`Confirmation renders Call To Action (CTA) for non-print-only with artic
     for details on how to cancel.
   </p>
   <p class="ncf__center">
-    <div>
-      <a href="/content/article uuid"
-         class="ncf__button ncf__button--submit ncf__button--margin"
-      >
-        Return to your article
-      </a>
-    </div>
-    <div>
-      <a href="/"
-         class="ncf__link"
-      >
-        Explore the FT
-      </a>
+    <div class="ncf__field--center">
+      <div>
+        <a href="/content/article uuid"
+           class="ncf__button ncf__button--submit ncf__button--margin"
+        >
+          Return to your article
+        </a>
+      </div>
+      <div>
+        <a href="/"
+           class="ncf__link"
+        >
+          Explore the FT
+        </a>
+      </div>
     </div>
   </p>
 </div>

--- a/components/confirmation.jsx
+++ b/components/confirmation.jsx
@@ -46,14 +46,16 @@ export function Confirmation ({
 		</div>
 	);
 
-	const returnToArticleCta = (<>
-		<div>
-			<a href={`/content/${contentUuid}`} className="ncf__button ncf__button--submit ncf__button--margin">Return to your article</a>
+	const returnToArticleCta = (
+		<div className="ncf__field--center">
+			<div>
+				<a href={`/content/${contentUuid}`} className="ncf__button ncf__button--submit ncf__button--margin">Return to your article</a>
+			</div>
+			<div>
+				<a href="/" className="ncf__link">Explore the FT</a>
+			</div>
 		</div>
-		<div>
-			<a href="/" className="ncf__link">Explore the FT</a>
-		</div>
-	</>);
+	);
 
 	const ctaElement = !hideCta && (
 		<p className="ncf__center">


### PR DESCRIPTION
### Description
The return-to-article Cta buttons in the confirmation component are not centred when used inside the next-subscribe app.

### Ticket
Blocking this ticket:
 https://financialtimes.atlassian.net/browse/UG-254


### Screenshots

| Before | After |
| ------ | ----- |
|      
<img width="637" alt="Screenshot 2020-09-25 at 13 09 44" src="https://user-images.githubusercontent.com/13418091/94268485-25c15c00-ff35-11ea-9d25-2ce2f304f553.png">

  |     
<img width="605" alt="Screenshot 2020-09-25 at 13 20 10" src="https://user-images.githubusercontent.com/13418091/94268508-2eb22d80-ff35-11ea-8257-40343ae6fa3e.png">
  |

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [x] **Stories** updated to use this change
- [x] **Accessibility** checked for screen readers and contrast
- [x] **Design Review** ran past the designer
- [x] **Product Review** ran past the product owner
