### PR TITLE
Rename preferences trackable fields

### DIFF
--- a/components/__snapshots__/industry.spec.js.snap
+++ b/components/__snapshots__/industry.spec.js.snap
@@ -13,7 +13,7 @@ exports[`Industry can render a disable select 1`] = `
   <span class="o-forms-input o-forms-input--select">
     <select id="industry"
             name="industry"
-            data-trackable="field-industry"
+            data-trackable="industry"
             aria-required="true"
             required
             disabled
@@ -132,7 +132,7 @@ exports[`Industry can render an error message 1`] = `
   <span class="o-forms-input o-forms-input--select o-forms-input--invalid">
     <select id="industry"
             name="industry"
-            data-trackable="field-industry"
+            data-trackable="industry"
             aria-required="true"
             required
     >
@@ -250,7 +250,7 @@ exports[`Industry can render an initial selected value 1`] = `
   <span class="o-forms-input o-forms-input--select">
     <select id="industry"
             name="industry"
-            data-trackable="field-industry"
+            data-trackable="industry"
             aria-required="true"
             required
     >
@@ -370,7 +370,7 @@ exports[`Industry render a select with a label 1`] = `
   <span class="o-forms-input o-forms-input--select">
     <select id="industry"
             name="industry"
-            data-trackable="field-industry"
+            data-trackable="industry"
             aria-required="true"
             required
     >

--- a/components/__snapshots__/position.spec.js.snap
+++ b/components/__snapshots__/position.spec.js.snap
@@ -14,7 +14,7 @@ exports[`Position can render a disable select 1`] = `
   <span class="o-forms-input o-forms-input--select">
     <select id="position"
             name="position"
-            data-trackable="field-position"
+            data-trackable="position"
             aria-required="true"
             required
             disabled
@@ -107,7 +107,7 @@ exports[`Position can render an error message 1`] = `
   <span class="o-forms-input o-forms-input--select o-forms-input--invalid">
     <select id="position"
             name="position"
-            data-trackable="field-position"
+            data-trackable="position"
             aria-required="true"
             required
     >
@@ -199,7 +199,7 @@ exports[`Position can render an initial selected value 1`] = `
   <span class="o-forms-input o-forms-input--select">
     <select id="position"
             name="position"
-            data-trackable="field-position"
+            data-trackable="position"
             aria-required="true"
             required
     >
@@ -293,7 +293,7 @@ exports[`Position render a select with a label 1`] = `
   <span class="o-forms-input o-forms-input--select">
     <select id="position"
             name="position"
-            data-trackable="field-position"
+            data-trackable="position"
             aria-required="true"
             required
     >

--- a/components/__snapshots__/responsibility.spec.js.snap
+++ b/components/__snapshots__/responsibility.spec.js.snap
@@ -14,7 +14,7 @@ exports[`Responsibility can render a disable select 1`] = `
   <span class="o-forms-input o-forms-input--select">
     <select id="responsibility"
             name="responsibility"
-            data-trackable="field-responsibility"
+            data-trackable="responsibility"
             aria-required="true"
             required
             disabled
@@ -125,7 +125,7 @@ exports[`Responsibility can render an error message 1`] = `
   <span class="o-forms-input o-forms-input--select o-forms-input--invalid">
     <select id="responsibility"
             name="responsibility"
-            data-trackable="field-responsibility"
+            data-trackable="responsibility"
             aria-required="true"
             required
     >
@@ -235,7 +235,7 @@ exports[`Responsibility can render an initial selected value 1`] = `
   <span class="o-forms-input o-forms-input--select">
     <select id="responsibility"
             name="responsibility"
-            data-trackable="field-responsibility"
+            data-trackable="responsibility"
             aria-required="true"
             required
     >
@@ -347,7 +347,7 @@ exports[`Responsibility render a select with a label 1`] = `
   <span class="o-forms-input o-forms-input--select">
     <select id="responsibility"
             name="responsibility"
-            data-trackable="field-responsibility"
+            data-trackable="responsibility"
             aria-required="true"
             required
     >

--- a/components/industry.jsx
+++ b/components/industry.jsx
@@ -34,7 +34,7 @@ export function Industry ({
 			<span className={inpiutWrapperClassName}>
 				<select id={selectId}
 					name={selectName}
-					data-trackable="field-industry"
+					data-trackable="industry"
 					aria-required={isRequired}
 					required={isRequired}
 					disabled={isDisabled}

--- a/components/position.jsx
+++ b/components/position.jsx
@@ -35,7 +35,7 @@ export function Position ({
 			<span className={inputWrapperClassNames}>
 				<select id={selectId}
 					name={selectName}
-					data-trackable="field-position"
+					data-trackable="position"
 					aria-required={isRequired}
 					required={isRequired}
 					disabled={isDisabled}

--- a/components/responsibility.jsx
+++ b/components/responsibility.jsx
@@ -29,7 +29,7 @@ export function Responsibility ({
 				<select
 					id={selectId}
 					name={selectName}
-					data-trackable="field-responsibility"
+					data-trackable="responsibility"
 					aria-required="true"
 					required
 					disabled={isDisabled}


### PR DESCRIPTION
### Description
As a part of B2C Prefenect AB testing, we would like to rename new variant data-tracking fields for the Preference section to make it consistent with the existing Preference fields. See requirement documentation on Control and Variant actions https://docs.google.com/spreadsheets/d/13AvBzMiH4Syq0o2sjhSsNi5euTpIASUTFvaWy5C27To/edit?usp=sharing

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-526 

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Stories** updated to use this change
- [x] **Product Review** ran past the product owner
