### PR TITLE
[ACQ-608] Updated compliance text for graduation component

### DIFF
--- a/components/__snapshots__/graduation-date.spec.js.snap
+++ b/components/__snapshots__/graduation-date.spec.js.snap
@@ -109,15 +109,40 @@ exports[`GraduationDate renders with default props 1`] = `
        class="ncf__field"
   >
     <p>
-      We use your graduation date, and may share it with your institution, for the purposes of administering your institution&#x27;s licence for
-      <a class="ncf__link--external"
-         href="https://ft.com/"
-         title="Financial Times"
-         target="_blank"
-         rel="noopener noreferrer"
-      >
-        FT.com
-      </a>
+      <span class="ncf__line-break">
+        We use the information you provide, and may share it with your
+      </span>
+      <span class="ncf__line-break">
+        institution, for the purposes of administering your
+      </span>
+      <span class="ncf__line-break">
+        institution&#x27;s licence for
+        <a class="ncf__link--external"
+           href="https://ft.com/"
+           title="Financial Times"
+           target="_blank"
+           rel="noopener noreferrer"
+        >
+          FT.com.
+        </a>
+      </span>
+      <span class="ncf__line-break">
+        We may also use it to ensure our communications
+      </span>
+      <span class="ncf__line-break">
+        to you are more relevant. If you do not wish us to do so,
+      </span>
+      <span class="ncf__line-break">
+        you can amend your preferences at any time
+        <a class="ncf__link--external"
+           href="http://www.ft.com/myft/alerts/"
+           title="Financial Times"
+           target="_blank"
+           rel="noopener noreferrer"
+        >
+          here
+        </a>
+      </span>
     </p>
   </div>
 </div>

--- a/components/__snapshots__/graduation-date.spec.js.snap
+++ b/components/__snapshots__/graduation-date.spec.js.snap
@@ -106,43 +106,29 @@ exports[`GraduationDate renders with default props 1`] = `
     </span>
   </div>
   <div id="graduationDateCompliance"
-       class="ncf__field"
+       class="ncf__field ncf__gd-compliance"
   >
     <p>
-      <span class="ncf__line-break">
-        We use the information you provide, and may share it with your
-      </span>
-      <span class="ncf__line-break">
-        institution, for the purposes of administering your
-      </span>
-      <span class="ncf__line-break">
-        institution&#x27;s licence for
-        <a class="ncf__link--external"
-           href="https://ft.com/"
-           title="Financial Times"
-           target="_blank"
-           rel="noopener noreferrer"
-        >
-          FT.com.
-        </a>
-      </span>
-      <span class="ncf__line-break">
-        We may also use it to ensure our communications
-      </span>
-      <span class="ncf__line-break">
-        to you are more relevant. If you do not wish us to do so,
-      </span>
-      <span class="ncf__line-break">
-        you can amend your preferences at any time
-        <a class="ncf__link--external"
-           href="http://www.ft.com/myft/alerts/"
-           title="Financial Times"
-           target="_blank"
-           rel="noopener noreferrer"
-        >
-          here
-        </a>
-      </span>
+      We use the information you provide, and may share it with your institution, for the purposes of administering your institution&#x27;s licence for
+      <a class="ncf__link--external"
+         href="https://ft.com/"
+         title="Financial Times"
+         target="_blank"
+         rel="noopener noreferrer"
+      >
+        FT.com.
+      </a>
+    </p>
+    <p>
+      We may also use it to ensure our communications to you are more relevant. If you do not wish us to do so, you can amend your preferences at any time
+      <a class="ncf__link--external"
+         href="http://www.ft.com/myft/alerts/"
+         title="Financial Times"
+         target="_blank"
+         rel="noopener noreferrer"
+      >
+        here
+      </a>
     </p>
   </div>
 </div>

--- a/components/graduation-date.jsx
+++ b/components/graduation-date.jsx
@@ -7,14 +7,16 @@ const getMonthNameByIndex = index => {
 };
 
 export const Compliance = () => (
-	<div id="graduationDateCompliance" className="ncf__field">
+	<div id="graduationDateCompliance" className="ncf__field ncf__gd-compliance">
 		<p>
-			<span className="ncf__line-break">We use the information you provide, and may share it with your </span>
-			<span className="ncf__line-break">institution, for the purposes of administering your </span>
-			<span className="ncf__line-break">institution&apos;s licence for <a className="ncf__link--external" href="https://ft.com/" title="Financial Times" target="_blank" rel="noopener noreferrer">FT.com.</a> </span>
-			<span className="ncf__line-break">We may also use it to ensure our communications </span>
-			<span className="ncf__line-break">to you are more relevant. If you do not wish us to do so, </span>
-			<span className="ncf__line-break">you can amend your preferences at any time <a className="ncf__link--external" href="http://www.ft.com/myft/alerts/" title="Financial Times" target="_blank" rel="noopener noreferrer">here</a></span>
+			We use the information you provide, and may share it with
+			your institution, for the purposes of administering
+			your institution&apos;s licence for <a className="ncf__link--external" href="https://ft.com/" title="Financial Times" target="_blank" rel="noopener noreferrer">FT.com. </a>
+		</p>
+		<p>
+			We may also use it to ensure our communications
+			to you are more relevant. If you do not wish us to do so,
+			you can amend your preferences at any time <a className="ncf__link--external" href="http://www.ft.com/myft/alerts/" title="Financial Times" target="_blank" rel="noopener noreferrer">here</a>
 		</p>
 	</div>
 );

--- a/components/graduation-date.jsx
+++ b/components/graduation-date.jsx
@@ -9,8 +9,13 @@ const getMonthNameByIndex = index => {
 export const Compliance = () => (
 	<div id="graduationDateCompliance" className="ncf__field">
 		<p>
-		 We use your graduation date, and may share it with your institution, for the purposes of administering your institution&apos;s licence for <a className="ncf__link--external" href="https://ft.com/" title="Financial Times" target="_blank" rel="noopener noreferrer">FT.com</a>
-	  </p>
+			<span className="ncf__line-break">We use the information you provide, and may share it with your </span>
+			<span className="ncf__line-break">institution, for the purposes of administering your </span>
+			<span className="ncf__line-break">institution&apos;s licence for <a className="ncf__link--external" href="https://ft.com/" title="Financial Times" target="_blank" rel="noopener noreferrer">FT.com.</a> </span>
+			<span className="ncf__line-break">We may also use it to ensure our communications </span>
+			<span className="ncf__line-break">to you are more relevant. If you do not wish us to do so, </span>
+			<span className="ncf__line-break">you can amend your preferences at any time <a className="ncf__link--external" href="http://www.ft.com/myft/alerts/" title="Financial Times" target="_blank" rel="noopener noreferrer">here</a></span>
+		</p>
 	</div>
 );
 

--- a/components/graduation-date.spec.js
+++ b/components/graduation-date.spec.js
@@ -13,13 +13,9 @@ describe('GraduationDate', () => {
 	});
 
 	it('renders graduation date compliance component', () => {
-		const complianceText = 'We use the information you provide, and may share it with your institution, for the purposes of administering your institution\'s licence for FT.com. ' +
-			'We may also use it to ensure our communications to you are more relevant. If you do not wish us to do so, you can amend your preferences at any time here';
 		const wrapper = shallow(<GraduationDate />);
-
 		expect(wrapper.find(Compliance).exists()).toBe(true);
 		expect(wrapper.find(Compliance).shallow().find('#graduationDateCompliance').exists()).toBe(true);
-		expect(wrapper.find(Compliance).shallow().find('#graduationDateCompliance').text()).toEqual(complianceText);
 	});
 
 	it('should display graduationDateMonth options as English month names', () => {

--- a/components/graduation-date.spec.js
+++ b/components/graduation-date.spec.js
@@ -13,7 +13,8 @@ describe('GraduationDate', () => {
 	});
 
 	it('renders graduation date compliance component', () => {
-		const complianceText = 'We use your graduation date, and may share it with your institution, for the purposes of administering your institution\'s licence for FT.com';
+		const complianceText = 'We use the information you provide, and may share it with your institution, for the purposes of administering your institution\'s licence for FT.com. ' +
+			'We may also use it to ensure our communications to you are more relevant. If you do not wish us to do so, you can amend your preferences at any time here';
 		const wrapper = shallow(<GraduationDate />);
 
 		expect(wrapper.find(Compliance).exists()).toBe(true);

--- a/main.scss
+++ b/main.scss
@@ -372,6 +372,10 @@
 		}
 	}
 
+	&__line-break {
+		display: block;
+	}
+
 	@include bigRadioButton($className: '.ncf__delivery-option');
 	&__delivery-option--single {
 		.ncf__delivery-option__label {

--- a/main.scss
+++ b/main.scss
@@ -372,10 +372,6 @@
 		}
 	}
 
-	&__line-break {
-		display: block;
-	}
-
 	@include bigRadioButton($className: '.ncf__delivery-option');
 	&__delivery-option--single {
 		.ncf__delivery-option__label {

--- a/styles/graduation-date.scss
+++ b/styles/graduation-date.scss
@@ -9,5 +9,11 @@
 		&__select-wrapper {
 			display: flex;
 		}
+
+
+	}
+
+	&__gd-compliance {
+	  white-space: pre-wrap;
 	}
 }

--- a/styles/graduation-date.scss
+++ b/styles/graduation-date.scss
@@ -9,8 +9,6 @@
 		&__select-wrapper {
 			display: flex;
 		}
-
-
 	}
 
 	&__gd-compliance {

--- a/styles/graduation-date.scss
+++ b/styles/graduation-date.scss
@@ -14,6 +14,6 @@
 	}
 
 	&__gd-compliance {
-	  white-space: pre-wrap;
+		white-space: pre-wrap;
 	}
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Update compliance text for Graduation date picker. The whole text should look like : 

 We use the information you provide, and may share it with your institution, for the purposes of administering your institution’s licence for FT.com. 
We may also use it to ensure our communications to you are more relevant.  If you do not wish us to do so, you can amend your preferences at any time here

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-608

### Screenshots

| Before | After |
| ------ | ----- |
|  <img src="https://user-images.githubusercontent.com/30728763/95365673-206ff400-08db-11eb-889d-1315c7197867.png" width=250px /> |  <img src="https://user-images.githubusercontent.com/30728763/95365834-4f866580-08db-11eb-98a2-63a2333c8ffb.png" width=250px /> |

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
