### PR TITLE
UG-286 Update confirmation component to show a ‘Tailor the FT..." button

### DIFF
--- a/components/__snapshots__/confirmation.spec.js.snap
+++ b/components/__snapshots__/confirmation.spec.js.snap
@@ -225,6 +225,117 @@ exports[`Confirmation renders appropriately if nextActionBottom is supplied 1`] 
 </div>
 `;
 
+exports[`Confirmation renders appropriately if nextActionTop is not supplied 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <p class="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">
+      You are now subscribed to:
+    </p>
+    <h1 class="ncf__header ncf__header--confirmation">
+      Offer text
+    </h1>
+  </div>
+  <p class="ncf__paragraph">
+    We’ve sent confirmation to your email. Make sure you check your spam folder if you don’t receive it.
+  </p>
+  <p class="ncf__paragraph">
+    Here’s a summary of your Offer text subscription:
+  </p>
+  <div class="ncf__headed-paragraph">
+    <h3 class="ncf__header">
+      Something not right?
+    </h3>
+    <p class="ncf__paragraph">
+      Go to your
+      <a class="ncf__link ncf__link--external"
+         href="https://myaccount.ft.com/details/core/view"
+         target="_blank"
+         rel="noopener"
+         data-trackable="yourAccount"
+      >
+        account settings
+      </a>
+      to view or edit your account. If you need to get in touch call us on
+      <a href="tel:+442077556248"
+         class="ncf__link ncf__link--external"
+      >
+        +44 (0) 207 755 6248
+      </a>
+      . Or contact us for additional support.
+    </p>
+  </div>
+  <p class="ncf__paragraph">
+    We will automatically renew your subscription using the payment method provided unless you cancel before your renewal date. See our
+    <a class="ncf__link ncf__link--external"
+       href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+       target="_top"
+       rel="noopener"
+    >
+      Terms &amp; Conditions
+    </a>
+    for details on how to cancel.
+  </p>
+</div>
+`;
+
+exports[`Confirmation renders appropriately if nextActionTop is supplied 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <p class="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">
+      You are now subscribed to:
+    </p>
+    <h1 class="ncf__header ncf__header--confirmation">
+      Offer text
+    </h1>
+  </div>
+  i might take you to tailor your experience
+  <p class="ncf__paragraph">
+    We’ve sent confirmation to your email. Make sure you check your spam folder if you don’t receive it.
+  </p>
+  <p class="ncf__paragraph">
+    Here’s a summary of your Offer text subscription:
+  </p>
+  <div class="ncf__headed-paragraph">
+    <h3 class="ncf__header">
+      Something not right?
+    </h3>
+    <p class="ncf__paragraph">
+      Go to your
+      <a class="ncf__link ncf__link--external"
+         href="https://myaccount.ft.com/details/core/view"
+         target="_blank"
+         rel="noopener"
+         data-trackable="yourAccount"
+      >
+        account settings
+      </a>
+      to view or edit your account. If you need to get in touch call us on
+      <a href="tel:+442077556248"
+         class="ncf__link ncf__link--external"
+      >
+        +44 (0) 207 755 6248
+      </a>
+      . Or contact us for additional support.
+    </p>
+  </div>
+  <p class="ncf__paragraph">
+    We will automatically renew your subscription using the payment method provided unless you cancel before your renewal date. See our
+    <a class="ncf__link ncf__link--external"
+       href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+       target="_top"
+       rel="noopener"
+    >
+      Terms &amp; Conditions
+    </a>
+    for details on how to cancel.
+  </p>
+</div>
+`;
+
 exports[`Confirmation renders with complete details 1`] = `
 <div class="ncf ncf__wrapper">
   <div class="ncf__center">

--- a/components/__snapshots__/confirmation.spec.js.snap
+++ b/components/__snapshots__/confirmation.spec.js.snap
@@ -1,202 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Confirmation renders Call To Action (CTA) for non-print-only with article return 1`] = `
-<div class="ncf ncf__wrapper">
-  <div class="ncf__center">
-    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
-    </div>
-    <p class="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">
-      You are now subscribed to:
-    </p>
-    <h1 class="ncf__header ncf__header--confirmation">
-      Offer text
-    </h1>
-  </div>
-  <p class="ncf__paragraph">
-    We’ve sent confirmation to your email. Make sure you check your spam folder if you don’t receive it.
-  </p>
-  <p class="ncf__paragraph">
-    Here’s a summary of your Offer text subscription:
-  </p>
-  <div class="ncf__headed-paragraph">
-    <h3 class="ncf__header">
-      Something not right?
-    </h3>
-    <p class="ncf__paragraph">
-      Go to your
-      <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
-         target="_blank"
-         rel="noopener"
-         data-trackable="yourAccount"
-      >
-        account settings
-      </a>
-      to view or edit your account. If you need to get in touch call us on
-      <a href="tel:+442077556248"
-         class="ncf__link ncf__link--external"
-      >
-        +44 (0) 207 755 6248
-      </a>
-      . Or contact us for additional support.
-    </p>
-  </div>
-  <p class="ncf__paragraph">
-    We will automatically renew your subscription using the payment method provided unless you cancel before your renewal date. See our
-    <a class="ncf__link ncf__link--external"
-       href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-       target="_top"
-       rel="noopener"
-    >
-      Terms &amp; Conditions
-    </a>
-    for details on how to cancel.
-  </p>
-  <p class="ncf__center">
-    <div class="ncf__field--center">
-      <div>
-        <a href="/content/article uuid"
-           class="ncf__button ncf__button--submit ncf__button--margin"
-        >
-          Return to your article
-        </a>
-      </div>
-      <div>
-        <a href="/"
-           class="ncf__link"
-        >
-          Explore the FT
-        </a>
-      </div>
-    </div>
-  </p>
-</div>
-`;
-
-exports[`Confirmation renders Call To Action (CTA) for non-print-only without article return 1`] = `
-<div class="ncf ncf__wrapper">
-  <div class="ncf__center">
-    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
-    </div>
-    <p class="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">
-      You are now subscribed to:
-    </p>
-    <h1 class="ncf__header ncf__header--confirmation">
-      Offer text
-    </h1>
-  </div>
-  <p class="ncf__paragraph">
-    We’ve sent confirmation to your email. Make sure you check your spam folder if you don’t receive it.
-  </p>
-  <p class="ncf__paragraph">
-    Here’s a summary of your Offer text subscription:
-  </p>
-  <div class="ncf__headed-paragraph">
-    <h3 class="ncf__header">
-      Something not right?
-    </h3>
-    <p class="ncf__paragraph">
-      Go to your
-      <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
-         target="_blank"
-         rel="noopener"
-         data-trackable="yourAccount"
-      >
-        account settings
-      </a>
-      to view or edit your account. If you need to get in touch call us on
-      <a href="tel:+442077556248"
-         class="ncf__link ncf__link--external"
-      >
-        +44 (0) 207 755 6248
-      </a>
-      . Or contact us for additional support.
-    </p>
-  </div>
-  <p class="ncf__paragraph">
-    We will automatically renew your subscription using the payment method provided unless you cancel before your renewal date. See our
-    <a class="ncf__link ncf__link--external"
-       href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-       target="_top"
-       rel="noopener"
-    >
-      Terms &amp; Conditions
-    </a>
-    for details on how to cancel.
-  </p>
-  <p class="ncf__center">
-    <a href="/"
-       class="ncf__button ncf__button--submit"
-    >
-      Start exploring
-    </a>
-  </p>
-</div>
-`;
-
-exports[`Confirmation renders Call To Action (CTA) for print-only 1`] = `
-<div class="ncf ncf__wrapper">
-  <div class="ncf__center">
-    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
-    </div>
-    <p class="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">
-      You are now subscribed to:
-    </p>
-    <h1 class="ncf__header ncf__header--confirmation">
-      Offer text
-    </h1>
-  </div>
-  <p class="ncf__paragraph">
-    We’ve sent confirmation to your email. Make sure you check your spam folder if you don’t receive it.
-  </p>
-  <p class="ncf__paragraph">
-    Here’s a summary of your Offer text subscription:
-  </p>
-  <div class="ncf__headed-paragraph">
-    <h3 class="ncf__header">
-      Something not right?
-    </h3>
-    <p class="ncf__paragraph">
-      Go to your
-      <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
-         target="_blank"
-         rel="noopener"
-         data-trackable="yourAccount"
-      >
-        account settings
-      </a>
-      to view or edit your account. If you need to get in touch call us on
-      <a href="tel:+442077556248"
-         class="ncf__link ncf__link--external"
-      >
-        +44 (0) 207 755 6248
-      </a>
-      . Or contact us for additional support.
-    </p>
-  </div>
-  <p class="ncf__paragraph">
-    We will automatically renew your subscription using the payment method provided unless you cancel before your renewal date. See our
-    <a class="ncf__link ncf__link--external"
-       href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-       target="_top"
-       rel="noopener"
-    >
-      Terms &amp; Conditions
-    </a>
-    for details on how to cancel.
-  </p>
-  <p class="ncf__center">
-    <a href="/todaysnewspaper "
-       class="ncf__button ncf__button--submit"
-    >
-      Explore our E-Paper
-    </a>
-  </p>
-</div>
-`;
-
 exports[`Confirmation renders appropriately if is B2C Partnership 1`] = `
 <div class="ncf ncf__wrapper">
   <div class="ncf__center">
@@ -250,13 +53,6 @@ exports[`Confirmation renders appropriately if is B2C Partnership 1`] = `
       Terms &amp; Conditions
     </a>
     for details on how to cancel.
-  </p>
-  <p class="ncf__center">
-    <a href="/"
-       class="ncf__button ncf__button--submit"
-    >
-      Start exploring
-    </a>
   </p>
 </div>
 `;
@@ -315,13 +111,117 @@ exports[`Confirmation renders appropriately if is trial 1`] = `
     </a>
     for details on how to cancel.
   </p>
-  <p class="ncf__center">
-    <a href="/"
-       class="ncf__button ncf__button--submit"
-    >
-      Start exploring
-    </a>
+</div>
+`;
+
+exports[`Confirmation renders appropriately if nextActionBottom is not supplied 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <p class="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">
+      You are now subscribed to:
+    </p>
+    <h1 class="ncf__header ncf__header--confirmation">
+      Offer text
+    </h1>
+  </div>
+  <p class="ncf__paragraph">
+    We’ve sent confirmation to your email. Make sure you check your spam folder if you don’t receive it.
   </p>
+  <p class="ncf__paragraph">
+    Here’s a summary of your Offer text subscription:
+  </p>
+  <div class="ncf__headed-paragraph">
+    <h3 class="ncf__header">
+      Something not right?
+    </h3>
+    <p class="ncf__paragraph">
+      Go to your
+      <a class="ncf__link ncf__link--external"
+         href="https://myaccount.ft.com/details/core/view"
+         target="_blank"
+         rel="noopener"
+         data-trackable="yourAccount"
+      >
+        account settings
+      </a>
+      to view or edit your account. If you need to get in touch call us on
+      <a href="tel:+442077556248"
+         class="ncf__link ncf__link--external"
+      >
+        +44 (0) 207 755 6248
+      </a>
+      . Or contact us for additional support.
+    </p>
+  </div>
+  <p class="ncf__paragraph">
+    We will automatically renew your subscription using the payment method provided unless you cancel before your renewal date. See our
+    <a class="ncf__link ncf__link--external"
+       href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+       target="_top"
+       rel="noopener"
+    >
+      Terms &amp; Conditions
+    </a>
+    for details on how to cancel.
+  </p>
+</div>
+`;
+
+exports[`Confirmation renders appropriately if nextActionBottom is supplied 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <p class="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">
+      You are now subscribed to:
+    </p>
+    <h1 class="ncf__header ncf__header--confirmation">
+      Offer text
+    </h1>
+  </div>
+  <p class="ncf__paragraph">
+    We’ve sent confirmation to your email. Make sure you check your spam folder if you don’t receive it.
+  </p>
+  <p class="ncf__paragraph">
+    Here’s a summary of your Offer text subscription:
+  </p>
+  <div class="ncf__headed-paragraph">
+    <h3 class="ncf__header">
+      Something not right?
+    </h3>
+    <p class="ncf__paragraph">
+      Go to your
+      <a class="ncf__link ncf__link--external"
+         href="https://myaccount.ft.com/details/core/view"
+         target="_blank"
+         rel="noopener"
+         data-trackable="yourAccount"
+      >
+        account settings
+      </a>
+      to view or edit your account. If you need to get in touch call us on
+      <a href="tel:+442077556248"
+         class="ncf__link ncf__link--external"
+      >
+        +44 (0) 207 755 6248
+      </a>
+      . Or contact us for additional support.
+    </p>
+  </div>
+  <p class="ncf__paragraph">
+    We will automatically renew your subscription using the payment method provided unless you cancel before your renewal date. See our
+    <a class="ncf__link ncf__link--external"
+       href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+       target="_top"
+       rel="noopener"
+    >
+      Terms &amp; Conditions
+    </a>
+    for details on how to cancel.
+  </p>
+  i might take you to the ePaper
 </div>
 `;
 
@@ -391,13 +291,6 @@ exports[`Confirmation renders with complete details 1`] = `
     </a>
     for details on how to cancel.
   </p>
-  <p class="ncf__center">
-    <a href="/"
-       class="ncf__button ncf__button--submit"
-    >
-      Start exploring
-    </a>
-  </p>
 </div>
 `;
 
@@ -453,13 +346,6 @@ exports[`Confirmation renders with custom email 1`] = `
     </a>
     for details on how to cancel.
   </p>
-  <p class="ncf__center">
-    <a href="/"
-       class="ncf__button ncf__button--submit"
-    >
-      Start exploring
-    </a>
-  </p>
 </div>
 `;
 
@@ -514,13 +400,6 @@ exports[`Confirmation renders with default props 1`] = `
       Terms &amp; Conditions
     </a>
     for details on how to cancel.
-  </p>
-  <p class="ncf__center">
-    <a href="/"
-       class="ncf__button ncf__button--submit"
-    >
-      Start exploring
-    </a>
   </p>
 </div>
 `;
@@ -588,13 +467,6 @@ exports[`Confirmation renders with details missing a description 1`] = `
     </a>
     for details on how to cancel.
   </p>
-  <p class="ncf__center">
-    <a href="/"
-       class="ncf__button ncf__button--submit"
-    >
-      Start exploring
-    </a>
-  </p>
 </div>
 `;
 
@@ -629,68 +501,6 @@ exports[`Confirmation renders with direct debit mandate URL 1`] = `
       </i>
     </p>
   </div>
-  <div class="ncf__headed-paragraph">
-    <h3 class="ncf__header">
-      Something not right?
-    </h3>
-    <p class="ncf__paragraph">
-      Go to your
-      <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
-         target="_blank"
-         rel="noopener"
-         data-trackable="yourAccount"
-      >
-        account settings
-      </a>
-      to view or edit your account. If you need to get in touch call us on
-      <a href="tel:+442077556248"
-         class="ncf__link ncf__link--external"
-      >
-        +44 (0) 207 755 6248
-      </a>
-      . Or contact us for additional support.
-    </p>
-  </div>
-  <p class="ncf__paragraph">
-    We will automatically renew your subscription using the payment method provided unless you cancel before your renewal date. See our
-    <a class="ncf__link ncf__link--external"
-       href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-       target="_top"
-       rel="noopener"
-    >
-      Terms &amp; Conditions
-    </a>
-    for details on how to cancel.
-  </p>
-  <p class="ncf__center">
-    <a href="/"
-       class="ncf__button ncf__button--submit"
-    >
-      Start exploring
-    </a>
-  </p>
-</div>
-`;
-
-exports[`Confirmation renders with hidden Call To Action (CTA) 1`] = `
-<div class="ncf ncf__wrapper">
-  <div class="ncf__center">
-    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
-    </div>
-    <p class="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">
-      You are now subscribed to:
-    </p>
-    <h1 class="ncf__header ncf__header--confirmation">
-      Offer text
-    </h1>
-  </div>
-  <p class="ncf__paragraph">
-    We’ve sent confirmation to your email. Make sure you check your spam folder if you don’t receive it.
-  </p>
-  <p class="ncf__paragraph">
-    Here’s a summary of your Offer text subscription:
-  </p>
   <div class="ncf__headed-paragraph">
     <h3 class="ncf__header">
       Something not right?

--- a/components/confirmation.jsx
+++ b/components/confirmation.jsx
@@ -11,9 +11,7 @@ export function Confirmation ({
 	email = EMAIL_DEFAULT_TEXT,
 	details = null,
 	directDebitMandateUrl = null,
-	hideCta = false,
-	isPrintOnly = false,
-	contentUuid = '',
+	nextActionBottom = null,
 }) {
 	const containerDivProps = {
 		className: 'ncf ncf__wrapper',
@@ -44,29 +42,6 @@ export function Confirmation ({
 			<p className="ncf__paragraph--reduced-padding">Download your <a href={directDebitMandateUrl} data-trackable="dd-mandate-link" id="encryptedMandateLink">direct debit mandate</a><i className="ncf__icon-download"></i>
 			</p>
 		</div>
-	);
-
-	const returnToArticleCta = (
-		<div className="ncf__field--center">
-			<div>
-				<a href={`/content/${contentUuid}`} className="ncf__button ncf__button--submit ncf__button--margin">Return to your article</a>
-			</div>
-			<div>
-				<a href="/" className="ncf__link">Explore the FT</a>
-			</div>
-		</div>
-	);
-
-	const ctaElement = !hideCta && (
-		<p className="ncf__center">
-			{
-				isPrintOnly
-					? (<a href="/todaysnewspaper " className="ncf__button ncf__button--submit">Explore our E-Paper</a>)
-					: contentUuid
-						? returnToArticleCta
-						: <a href={"/"} className="ncf__button ncf__button--submit">Start exploring</a>
-			}
-		</p>
 	);
 
 	return (
@@ -102,13 +77,12 @@ export function Confirmation ({
 				We will automatically renew your subscription using the payment method provided unless you cancel before your renewal date. See our <a className="ncf__link ncf__link--external" href="http://help.ft.com/help/legal-privacy/terms-conditions/" target="_top" rel="noopener">Terms &amp; Conditions</a> for details on how to cancel.
 			</p>
 
-			{ ctaElement }
+			{ nextActionBottom }
 		</div>
 	);
 }
 
 Confirmation.propTypes = {
-	contentUuid: PropTypes.string,
 	isTrial: PropTypes.bool,
 	isB2cPartnership: PropTypes.bool,
 	offer: PropTypes.string.isRequired,
@@ -119,6 +93,5 @@ Confirmation.propTypes = {
 		description: PropTypes.string
 	})),
 	directDebitMandateUrl: PropTypes.string,
-	hideCta: PropTypes.bool,
-	isPrintOnly: PropTypes.bool
+	nextActionBottom: PropTypes.node
 };

--- a/components/confirmation.jsx
+++ b/components/confirmation.jsx
@@ -11,6 +11,7 @@ export function Confirmation ({
 	email = EMAIL_DEFAULT_TEXT,
 	details = null,
 	directDebitMandateUrl = null,
+	nextActionTop = null,
 	nextActionBottom = null,
 }) {
 	const containerDivProps = {
@@ -51,6 +52,8 @@ export function Confirmation ({
 				<p className="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">You are now subscribed to:</p>
 				<h1 className="ncf__header ncf__header--confirmation">{offer}</h1>
 			</div>
+
+			{nextActionTop}
 
 			<p className="ncf__paragraph">
 				We’ve sent confirmation to {email}. Make sure you check your spam folder if you don’t receive it.
@@ -93,5 +96,6 @@ Confirmation.propTypes = {
 		description: PropTypes.string
 	})),
 	directDebitMandateUrl: PropTypes.string,
+	nextActionTop: PropTypes.node,
 	nextActionBottom: PropTypes.node
 };

--- a/components/confirmation.spec.js
+++ b/components/confirmation.spec.js
@@ -4,6 +4,7 @@ import { expectToRenderCorrectly } from '../test-jest/helpers/expect-to-render-c
 expect.extend(expectToRenderCorrectly);
 
 const OFFER_TEXT = 'Offer text';
+const nextActionTop = ['i might take you to tailor your experience'];
 const nextActionBottom = ['i might take you to the ePaper'];
 
 describe('Confirmation', () => {
@@ -58,6 +59,18 @@ describe('Confirmation', () => {
 
 	it('renders with direct debit mandate URL', () => {
 		const props = { offer: OFFER_TEXT, directDebitMandateUrl: 'https://foo.com' };
+
+		expect(Confirmation).toRenderCorrectly(props);
+	});
+
+	it('renders appropriately if nextActionTop is supplied', () => {
+		const props = { offer: OFFER_TEXT, nextActionTop };
+
+		expect(Confirmation).toRenderCorrectly(props);
+	});
+
+	it('renders appropriately if nextActionTop is not supplied', () => {
+		const props = { offer: OFFER_TEXT };
 
 		expect(Confirmation).toRenderCorrectly(props);
 	});

--- a/components/confirmation.spec.js
+++ b/components/confirmation.spec.js
@@ -4,7 +4,7 @@ import { expectToRenderCorrectly } from '../test-jest/helpers/expect-to-render-c
 expect.extend(expectToRenderCorrectly);
 
 const OFFER_TEXT = 'Offer text';
-const UUID = 'article uuid';
+const nextActionBottom = ['i might take you to the ePaper'];
 
 describe('Confirmation', () => {
 	it('renders with default props', () => {
@@ -62,26 +62,14 @@ describe('Confirmation', () => {
 		expect(Confirmation).toRenderCorrectly(props);
 	});
 
-	it('renders with hidden Call To Action (CTA)', () => {
-		const props = { offer: OFFER_TEXT, hideCta: true };
+	it('renders appropriately if nextActionBottom is supplied', () => {
+		const props = { offer: OFFER_TEXT, nextActionBottom };
 
 		expect(Confirmation).toRenderCorrectly(props);
 	});
 
-	it('renders Call To Action (CTA) for print-only', () => {
-		const props = { offer: OFFER_TEXT, isPrintOnly: true };
-
-		expect(Confirmation).toRenderCorrectly(props);
-	});
-
-	it('renders Call To Action (CTA) for non-print-only with article return', () => {
-		const props = { offer: OFFER_TEXT, isPrintOnly: false, contentUuid: UUID };
-
-		expect(Confirmation).toRenderCorrectly(props);
-	});
-
-	it('renders Call To Action (CTA) for non-print-only without article return', () => {
-		const props = { offer: OFFER_TEXT, isPrintOnly: false };
+	it('renders appropriately if nextActionBottom is not supplied', () => {
+		const props = { offer: OFFER_TEXT };
 
 		expect(Confirmation).toRenderCorrectly(props);
 	});

--- a/components/confirmation.stories.js
+++ b/components/confirmation.stories.js
@@ -9,6 +9,10 @@ export default {
 	},
 };
 
+const nextActionTop = <p className="ncf__center">
+	<a href="/myft/" className="ncf__button ncf__button--submit ncf__button--margin">An example child: this is the tailor my experience button</a>
+</p>;
+
 const nextActionBottom = <div className="ncf__field--center">
 	<div>
 		<a href={'/contentuuid'} className="ncf__button ncf__button--submit ncf__button--margin">Return to your article</a>
@@ -33,5 +37,6 @@ Basic.args = {
 			data: 'Dec 25, 2020',
 		}
 	],
+	nextActionTop,
 	nextActionBottom
 };

--- a/components/confirmation.stories.js
+++ b/components/confirmation.stories.js
@@ -9,6 +9,15 @@ export default {
 	},
 };
 
+const nextActionBottom = <div className="ncf__field--center">
+	<div>
+		<a href={'/contentuuid'} className="ncf__button ncf__button--submit ncf__button--margin">Return to your article</a>
+	</div>
+	<div>
+		<a href="/" className="ncf__link">Explore the FT</a>
+	</div>
+</div>;
+
 export const Basic = (args) => <Confirmation {...args} />;
 Basic.args = {
 	offer: 'Premium Digital',
@@ -23,5 +32,6 @@ Basic.args = {
 			description: 'The date your subscription will auto renew',
 			data: 'Dec 25, 2020',
 		}
-	]
+	],
+	nextActionBottom
 };

--- a/main.scss
+++ b/main.scss
@@ -260,7 +260,7 @@
 		}
 
 		&--margin {
-			margin-bottom: 20px;
+			margin: 20px 0;
 		}
 
 	}


### PR DESCRIPTION
Tailor the FT to meet your goals!

### Description
As iteration 1 of the new [Activation Journey](https://ftnext.invisionapp.com/share/VSYOMW245BA#/screens/430946496), users will simply be taken to myFT on clicking the 'Tailor the FT to meet your goals' link.  This PR updates the confirmation component to include that button  when it's provided. The implementation is deliberately flexible so that the new `nextActionTop` prop can provide this component with anything, should we wish to alter what's used as the next action.

### [Ticket](https://financialtimes.atlassian.net/browse/UG-286)

### Screenshots
These screenshots are from the storybook and hence look weird 😂  but they do show the new button.

| Before | After |
| ------ | ----- |
|![image](https://user-images.githubusercontent.com/25018001/95753143-12cebb80-0c99-11eb-91ce-3c12713a2fe1.png)|![image](https://user-images.githubusercontent.com/25018001/95753173-1eba7d80-0c99-11eb-84ff-d4c1dfa58fa1.png)|

### Reminder
Have you completed these common tasks (remove those that don't apply)?
- [X] **Tests** written for new or updated for existing functionality
- [X] **Stories** updated to use this change
- [X] **Design Review** ran past the designer
