### PR TITLE
UG-317 Customise payment-term component for lite subs

### DIFF
--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -2,11 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+const isoDurationToEnglish = {
+	P3M: '3 months',
+};
+
 export function PaymentTerm({
 	fieldId = 'paymentTermField',
 	inputName = 'paymentTerm',
 	isPrintOrBundle = false,
 	options = [],
+	isFixedTermOffer = false,
+	subscriptionDuration,
 }) {
 	const nameMap = {
 		annual: {
@@ -121,7 +127,10 @@ export function PaymentTerm({
 				<div className="ncf__payment-term__description">
 					{nameMap[option.name].price(option.price)}
 					{nameMap[option.name].monthlyPrice(option.monthlyPrice)}
-					{nameMap[option.name].renewsText()}
+					{isFixedTermOffer ?
+						<p className="ncf__payment-term__renews-text">This subscription is for {isoDurationToEnglish[subscriptionDuration]} and will not renew</p> :
+						nameMap[option.name].renewsText()
+					}
 					{/* Remove this discount text temporarily in favour of monthly price */}
 					{/* <br />Save up to 25% when you pay annually */}
 				</div>
@@ -153,26 +162,32 @@ export function PaymentTerm({
 			{options.map((option) => createPaymentTerm(option))}
 
 			<div className="ncf__payment-term__legal">
-				<p>
-					With all subscription types, we will automatically renew your
-					subscription using the payment method provided unless you cancel
-					before your renewal date.
-				</p>
-				<p>
-					We will notify you at least 14 days in advance of any changes to the
-					price in your subscription that would apply upon next renewal. Find
-					out more about our cancellation policy in our{' '}
-					<a
-						className="ncf__link--external"
-						href="https://help.ft.com/help/legal-privacy/terms-conditions/"
-						title="FT Legal Terms and Conditions help page"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						Terms &amp; Conditions
-					</a>
-					.
-				</p>
+				{
+					isFixedTermOffer ?
+						<p>Find out more about our cancellation policy in our <a className="ncf__link--external" href="https://help.ft.com/help/legal-privacy/terms-conditions/" title="FT Legal Terms and Conditions help page" target="_blank" rel="noopener noreferrer">Terms &amp; Conditions</a>.</p> :
+						<React.Fragment>
+							<p>
+								With all subscription types, we will automatically renew your
+								subscription using the payment method provided unless you cancel
+								before your renewal date.
+							</p>
+							<p>
+								We will notify you at least 14 days in advance of any changes to the
+								price in your subscription that would apply upon next renewal. Find
+								out more about our cancellation policy in our{' '}
+								<a
+									className="ncf__link--external"
+									href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+									title="FT Legal Terms and Conditions help page"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									Terms &amp; Conditions
+								</a>
+								.
+							</p>
+						</React.Fragment>
+				}
 			</div>
 		</div>
 	);

--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -210,4 +210,6 @@ PaymentTerm.propTypes = {
 			monthlyPrice: PropTypes.string,
 		})
 	),
+	isFixedTermOffer: PropTypes.bool,
+	subscriptionDuration: PropTypes.string,
 };

--- a/components/payment-term.spec.js
+++ b/components/payment-term.spec.js
@@ -1,7 +1,11 @@
 import { PaymentTerm } from './index';
 import { expectToRenderCorrectly } from '../test-jest/helpers/expect-to-render-correctly';
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 
 expect.extend(expectToRenderCorrectly);
+Enzyme.configure({ adapter: new Adapter() });
 
 describe('PaymentTerm', () => {
 	it('render with defaults', () => {
@@ -110,6 +114,26 @@ describe('PaymentTerm', () => {
 
 				expect(PaymentTerm).toRenderCorrectly(props);
 			});
+		});
+	});
+
+	describe('given isFixedTermOffer prop is set to true', () => {
+		const options = [
+			{
+				name: 'monthly',
+				price: '$5.00',
+				value: 'monthly',
+				monthlyPrice: '$5.00',
+			}
+		];
+		const wrapper = shallow(<PaymentTerm isFixedTermOffer={true} options={options} subscriptionDuration='P3M' />);
+
+		it('should not include renewal text', () => {
+			expect(wrapper.find('.ncf__payment-term__renews-text').text()).not.toMatch(/Renews (annually|monthly|quarterly) unless cancelled/);
+		});
+
+		it('should render the subscriptionDuration in English', () => {
+			expect(wrapper.find('.ncf__payment-term__renews-text').text()).toMatch(/3 months/);
 		});
 	});
 });

--- a/components/payment-term.stories.js
+++ b/components/payment-term.stories.js
@@ -32,3 +32,15 @@ Basic.args = {
 		},
 	],
 };
+
+export const FixedTermOffer = (args) => <Fieldset><PaymentTerm {...args} subscriptionDuration='P3M' /></Fieldset>;
+FixedTermOffer.args = {
+	options: [
+		{
+			name: 'monthly',
+			price: '$5.00',
+			value: 5.00,
+		}
+	],
+	isFixedTermOffer: true,
+};


### PR DESCRIPTION
### Description
A lite subscription gives access to the subset of the FT for a fraction of the cost of a regular sub. Due to the low cost of the subscription, we don’t want to subscription to auto-renew.

Amends the payment-term component to remove mentions of auto-renewal if the offer is fixed term (e.g. in the case of lite subscription).

See https://github.com/Financial-Times/next-subscribe/pull/1416 for more info.

### Ticket
https://financialtimes.atlassian.net/browse/UG-317

### Screenshots

| Basic component | Fixed-term offer |
| ------ | ----- |
|  ![Screenshot 2020-11-24 at 11 45 29](https://user-images.githubusercontent.com/1705375/100090174-af64ab80-2e4a-11eb-94e5-d4fde8573fff.png)|![Screenshot 2020-11-24 at 11 45 44](https://user-images.githubusercontent.com/1705375/100090205-b986aa00-2e4a-11eb-9814-46ed1de57c3c.png)|

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Tests** written for new or updated for existing functionality
- [x] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast