### PR TITLE
[ACQ-734[ Added ability to set Message target property

### DIFF
--- a/components/__snapshots__/message.spec.jsx.snap
+++ b/components/__snapshots__/message.spec.jsx.snap
@@ -199,6 +199,31 @@ exports[`Message can render some actions as secondary 1`] = `
 </div>
 `;
 
+exports[`Message can set the action link target of call to action buttons 1`] = `
+<div class="ncf__message">
+  <div class="o-message o-message--inner o-message--alert o-message--neutral"
+       data-o-component="o-message"
+  >
+    <div class="o-message__container">
+      <div class="o-message__content">
+        <p class="o-message__content-main">
+          <span class="o-message__content-detail">
+          </span>
+        </p>
+        <div class="o-message__actions">
+          <a href="https://open.spotify.com/album/2EpuND32cO7CX0gXZl2NB6"
+             target="_top"
+             class="o-message__actions__primary"
+          >
+            Listen on Spotify
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Message render a message 1`] = `
 <div class="ncf__message">
   <div class="o-message o-message--inner o-message--alert o-message--neutral"

--- a/components/message.jsx
+++ b/components/message.jsx
@@ -8,6 +8,7 @@ export function Message({
 	additional = [],
 	actions = null,
 	name,
+	target,
 	isNotice,
 	isError,
 	isSuccess,
@@ -45,6 +46,7 @@ export function Message({
 					<a
 						href={link}
 						key={index}
+						target={target}
 						className={
 							isSecondary
 								? 'o-message__actions__secondary'
@@ -85,13 +87,16 @@ const actionType = PropTypes.shape({
 	link: PropTypes.string.isRequired,
 	isSecondary: PropTypes.bool,
 	text: PropTypes.string,
+	target: '_self',
 });
+
 Message.propTypes = {
 	title: PropTypes.string,
 	message: PropTypes.string.isRequired,
 	additional: PropTypes.arrayOf(PropTypes.string),
 	actions: PropTypes.arrayOf(actionType),
 	name: PropTypes.string,
+	target: PropTypes.string,
 	isStaticMessage: PropTypes.bool,
 	isNotice: PropTypes.bool,
 	isError: PropTypes.bool,

--- a/components/message.spec.jsx
+++ b/components/message.spec.jsx
@@ -3,6 +3,11 @@ import { expectToRenderCorrectly } from '../test-jest/helpers/expect-to-render-c
 
 expect.extend(expectToRenderCorrectly);
 
+const ACTION_MOCK = {
+	text: 'Listen on Spotify',
+	link: 'https://open.spotify.com/album/2EpuND32cO7CX0gXZl2NB6',
+};
+
 describe('Message', () => {
 	it('render a message', () => {
 		const props = {
@@ -35,12 +40,7 @@ describe('Message', () => {
 		const props = {
 			title: 'Reggatta de Blanc',
 			message: 'My message in a bottle',
-			actions: [
-				{
-					text: 'Listen on Spotify',
-					link: 'https://open.spotify.com/album/2EpuND32cO7CX0gXZl2NB6',
-				},
-			],
+			actions: [ACTION_MOCK],
 		};
 
 		expect(Message).toRenderCorrectly(props);
@@ -50,13 +50,7 @@ describe('Message', () => {
 		const props = {
 			title: 'Reggatta de Blanc',
 			message: 'My message in a bottle',
-			actions: [
-				{
-					text: 'Listen on Spotify',
-					link: 'https://open.spotify.com/album/2EpuND32cO7CX0gXZl2NB6',
-					isSecondary: true,
-				},
-			],
+			actions: [{...ACTION_MOCK, isSecondary: true}],
 		};
 
 		expect(Message).toRenderCorrectly(props);
@@ -102,6 +96,15 @@ describe('Message', () => {
 		const props = {
 			message: 'My message in a bottle',
 			name: 'The Police best album ever',
+		};
+
+		expect(Message).toRenderCorrectly(props);
+	});
+
+	it('can set the action link target of call to action buttons', () => {
+		const props = {
+			target: '_top',
+			actions: [ACTION_MOCK],
 		};
 
 		expect(Message).toRenderCorrectly(props);


### PR DESCRIPTION
### Description
We have some Messages rendered inside an IFRAME and clicking on them, leads to even more serious issues, than not loading in the `_top` frame - we get rejected by Access service based off referer and users see an error screen instead of the actual login.

![image](https://user-images.githubusercontent.com/1992987/101774513-e39cc500-3af6-11eb-8538-83f498ef4e06.png)
* openning in a new tab/window solves this, since referer URL is empty then

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-734
