### PR TITLE
UG-341: extend LicenceConfirmation to take a different CTA

### DIFF
--- a/components/licence-confirmation.jsx
+++ b/components/licence-confirmation.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export function LicenceConfirmation({
+export function LicenceConfirmation ({
 	isTrial = false,
 	isEmbedded = false,
 	duration = null,
 	isEducationalLicence = false,
 	contentId = '',
+	ctaText = 'Go to myFT',
+	ctaHref = '/myft',
 }) {
-	const myFtLinkProps = {
-		href: '/myft',
+	const ctaProps = {
+		href: ctaHref,
 		className: 'ncf__button ncf__button--submit',
 		...(isEmbedded && { target: '_top' }),
 	};
@@ -49,7 +51,7 @@ export function LicenceConfirmation({
 			</p>
 
 			<p className="ncf__paragraph ncf__center">
-				<a {...myFtLinkProps}>Go to myFT</a>
+				<a {...ctaProps}>{ctaText}</a>
 			</p>
 
 			<p className="ncf__paragraph ncf__center">
@@ -65,4 +67,6 @@ LicenceConfirmation.propTypes = {
 	duration: PropTypes.string,
 	isEducationalLicence: PropTypes.bool,
 	contentId: PropTypes.string,
+	ctaText: PropTypes.string,
+	ctaHref: PropTypes.string
 };


### PR DESCRIPTION
### Description
This extends the capability of the LicenceConfirmation component to alter the CTA for B2B users who join their company's licence.

It will be used by the activation journey to send users to `/activate/bundles` on completion of their journey through `next-subscribe`.

### [Ticket](https://financialtimes.atlassian.net/browse/UG-341)

### Screenshots

| Before | After |
| ------ | ----- |
|![image](https://user-images.githubusercontent.com/25018001/102373827-84d4c100-3fb8-11eb-8584-ee0d029170a3.png)|![image](https://user-images.githubusercontent.com/25018001/102373745-71295a80-3fb8-11eb-8d45-2da553559f82.png)|

### Reminder
Have you completed these common tasks?
- [X] **Tests** written for new or updated for existing functionality
- [X] **Stories** updated to use this change
- [X] **Design Review** ran past the designer
- [X] **Product Review** ran past the product owner
