### PR TITLE
extend B2CPartnershipConfirmation to take a different CTA

### DIFF
--- a/components/__snapshots__/b2c-partnership-confirmation.spec.js.snap
+++ b/components/__snapshots__/b2c-partnership-confirmation.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`B2CPartnershipConfirmation renders aß default 1`] = `
+exports[`B2CPartnershipConfirmation renders as default 1`] = `
 <div class="ncf ncf__wrapper">
   <div class="ncf__center">
     <div class="ncf__icon ncf__icon--tick ncf__icon--large">
@@ -17,13 +17,7 @@ exports[`B2CPartnershipConfirmation renders aß default 1`] = `
   <p class="ncf__paragraph">
     Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
   </p>
-  <p class="ncf__paragraph ncf__center">
-    <a href="/myft"
-       class="ncf__button ncf__button--submit"
-    >
-      Go to myFT
-    </a>
-  </p>
+  hello
   <p class="ncf__paragraph ncf__center">
     <a href="/"
        class="ncf__link"

--- a/components/b2c-partnership-confirmation.jsx
+++ b/components/b2c-partnership-confirmation.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-export function B2CPartnershipConfirmation() {
-	const myFtLinkProps = {
-		href: '/myft',
-		className: 'ncf__button ncf__button--submit',
-	};
+export function B2CPartnershipConfirmation ({
+	ctaElement = null,
+}) {
 
 	const readingLinkProps = {
 		href: '/',
@@ -23,7 +22,7 @@ export function B2CPartnershipConfirmation() {
 				<div className="ncf__paragraph">
 					{
 						<h1 className="ncf__header ncf__header--confirmation">
-							{"Welcome to your three months' Premium access"}
+							{'Welcome to your three months\' Premium access'}
 						</h1>
 					}
 				</div>
@@ -38,9 +37,7 @@ export function B2CPartnershipConfirmation() {
 				content.
 			</p>
 
-			<p className="ncf__paragraph ncf__center">
-				<a {...myFtLinkProps}>Go to myFT</a>
-			</p>
+			{ctaElement}
 
 			<p className="ncf__paragraph ncf__center">
 				<a {...readingLinkProps}>Start reading</a>
@@ -54,3 +51,8 @@ export function B2CPartnershipConfirmation() {
 		</div>
 	);
 }
+
+
+B2CPartnershipConfirmation.propTypes = {
+	ctaElement: PropTypes.node,
+};

--- a/components/b2c-partnership-confirmation.spec.js
+++ b/components/b2c-partnership-confirmation.spec.js
@@ -4,7 +4,9 @@ import { expectToRenderCorrectly } from '../test-jest/helpers/expect-to-render-c
 expect.extend(expectToRenderCorrectly);
 
 describe('B2CPartnershipConfirmation', () => {
-	it('renders aß default', () => {
-		expect(B2CPartnershipConfirmation).toRenderCorrectly();
+	it('renders as default', () => {
+		const props = {ctaElement: 'hello'};
+
+		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
 	});
 });

--- a/components/b2c-partnership-confirmation.stories.js
+++ b/components/b2c-partnership-confirmation.stories.js
@@ -6,7 +6,13 @@ export default {
 	component: B2CPartnershipConfirmation,
 };
 
+const goToMyFtElement = (
+	<p className="ncf__paragraph ncf__center">
+		<a className="ncf__button ncf__button--submit" href="/myft">Go to myFT</a>
+	</p>
+);
+
 export const Basic = (args) => <B2CPartnershipConfirmation {...args} />;
-Basic.parameters = {
-	controls: { hideNoControlsWarning: true },
+Basic.args = {
+	ctaElement: goToMyFtElement,
 };


### PR DESCRIPTION
### Description
This extends the capability of the B2CPartnershipConfirmation component to alter the CTA for B2C Partnership users who join the partner's licence.

It will be used by the activation journey to send users to `/activate/bundles` on completion of their journey through `next-subscribe`.

### [Ticket]
TBC

### Screenshots

| Before | After |
| ------ | ----- |
|![image](https://user-images.githubusercontent.com/25018001/102532781-60eaab80-409c-11eb-8684-acf001676d09.png)|![image](https://user-images.githubusercontent.com/25018001/102532961-ad35eb80-409c-11eb-846b-15f1c6fffa1e.png)|

### Reminder
Have you completed these common tasks?
- [X] **Tests** written for new or updated for existing functionality
- [X] **Stories** updated to use this change
- [X] **Design Review** ran past the designer
- [X] **Product Review** ran past the product owner
