### PR TITLE
ACQ-761 Add base amount getter for PSD2

### DIFF
--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -207,7 +207,7 @@ PaymentTerm.propTypes = {
 			selected: PropTypes.bool,
 			trialDuration: PropTypes.string,
 			trialPrice: PropTypes.string,
-			amount: PropTypes.string,
+			amount: PropTypes.number,
 			value: PropTypes.string.isRequired,
 			monthlyPrice: PropTypes.string,
 		})

--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -97,6 +97,7 @@ export function PaymentTerm({
 		const props = {
 			type: 'radio',
 			id: option.value,
+			'data-base-amount': option.amount,
 			name: inputName,
 			value: option.value,
 			className:
@@ -206,6 +207,7 @@ PaymentTerm.propTypes = {
 			selected: PropTypes.bool,
 			trialDuration: PropTypes.string,
 			trialPrice: PropTypes.string,
+			amount: PropTypes.string,
 			value: PropTypes.string.isRequired,
 			monthlyPrice: PropTypes.string,
 		})

--- a/test/utils/payment-term.spec.js
+++ b/test/utils/payment-term.spec.js
@@ -19,6 +19,9 @@ describe('PaymentTerm', () => {
 			parentElement: elementStub,
 			addEventListener: sandbox.stub(),
 			value: 'test',
+			dataset: {
+				baseAmount: 100,
+			},
 		};
 		documentStub = {
 			querySelector: sandbox.stub(),
@@ -133,6 +136,21 @@ describe('PaymentTerm', () => {
 					},
 				]);
 				expect(monthlyPriceStub.innerHTML).to.equal('£1.01');
+			});
+
+			describe('getBaseAmount', () => {
+				it('should throw an error if nothing selected', () => {
+					elementStub.querySelector.returns(false);
+					expect(() => {
+						paymentTerm.getBaseAmount();
+					}).to.throw();
+				});
+
+				it('should return base amount of the selected term', () => {
+					elementStub.querySelector.returns(elementStub);
+					const returnedAmount = paymentTerm.getBaseAmount();
+					expect(returnedAmount).to.equal(elementStub.dataset.baseAmount);
+				});
 			});
 		});
 	});

--- a/utils/payment-term.js
+++ b/utils/payment-term.js
@@ -54,6 +54,14 @@ class PaymentTerm {
 		return checked.getAttribute('value');
 	}
 
+	getBaseAmount () {
+		const checked = this.$paymentTerm.querySelector('input:checked');
+		if (!checked) {
+			throw new Error('No payment term has been selected');
+		}
+		return checked.dataset.baseAmount;
+	}
+
 	/**
 	 * Register on change an event listener
 	 * @param {Function} callback Called with event when changed

--- a/utils/payment-term.js
+++ b/utils/payment-term.js
@@ -54,6 +54,11 @@ class PaymentTerm {
 		return checked.getAttribute('value');
 	}
 
+	/**
+	 * Returns the base amount for the selected payment term
+	 * @return {Number}
+	 * @throws If no payment term has been selected
+	 */
 	getBaseAmount () {
 		const checked = this.$paymentTerm.querySelector('input:checked');
 		if (!checked) {


### PR DESCRIPTION
Add base amount in a data attribute (without currency) for PSD2 requirements.
[ticket](https://financialtimes.atlassian.net/browse/ACQ-761)
