### PR TITLE
ACQ-751: Adding new components for US delivery Print Offers

### DIFF
--- a/components/__snapshots__/delivery-address-type.spec.js.snap
+++ b/components/__snapshots__/delivery-address-type.spec.js.snap
@@ -1,0 +1,249 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeliveryAddressType renders with company value selected 1`] = `
+<div id="deliveryAddressTypeField"
+     class="o-forms-field ncf__delivery-address-type"
+     role="group"
+     aria-label="Delivery Address Type"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Address type
+    </span>
+  </span>
+  <div class="o-forms-input o-forms-input--inline o-forms-input--radio-round">
+    <label for="home"
+           aria-label="Home Address"
+    >
+      <input type="radio"
+             id="home"
+             name="deliveryAddressType"
+             value="home"
+             class="ncf__delivery-address-type__input"
+      >
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        Home Address
+      </span>
+    </label>
+    <label for="company"
+           aria-label="Company Address"
+    >
+      <input type="radio"
+             id="company"
+             name="deliveryAddressType"
+             value="company"
+             class="ncf__delivery-address-type__input"
+             checked
+      >
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        Company Address
+      </span>
+    </label>
+    <label for="pobox"
+           aria-label="P.O. Box"
+    >
+      <input type="radio"
+             id="pobox"
+             name="deliveryAddressType"
+             value="pobox"
+             class="ncf__delivery-address-type__input"
+      >
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        P.O. Box
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`DeliveryAddressType renders with default props 1`] = `
+<div id="deliveryAddressTypeField"
+     class="o-forms-field ncf__delivery-address-type"
+     role="group"
+     aria-label="Delivery Address Type"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Address type
+    </span>
+  </span>
+  <div class="o-forms-input o-forms-input--inline o-forms-input--radio-round">
+    <label for="home"
+           aria-label="Home Address"
+    >
+      <input type="radio"
+             id="home"
+             name="deliveryAddressType"
+             value="home"
+             class="ncf__delivery-address-type__input"
+             checked
+      >
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        Home Address
+      </span>
+    </label>
+    <label for="company"
+           aria-label="Company Address"
+    >
+      <input type="radio"
+             id="company"
+             name="deliveryAddressType"
+             value="company"
+             class="ncf__delivery-address-type__input"
+      >
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        Company Address
+      </span>
+    </label>
+    <label for="pobox"
+           aria-label="P.O. Box"
+    >
+      <input type="radio"
+             id="pobox"
+             name="deliveryAddressType"
+             value="pobox"
+             class="ncf__delivery-address-type__input"
+      >
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        P.O. Box
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`DeliveryAddressType renders with home value selected 1`] = `
+<div id="deliveryAddressTypeField"
+     class="o-forms-field ncf__delivery-address-type"
+     role="group"
+     aria-label="Delivery Address Type"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Address type
+    </span>
+  </span>
+  <div class="o-forms-input o-forms-input--inline o-forms-input--radio-round">
+    <label for="home"
+           aria-label="Home Address"
+    >
+      <input type="radio"
+             id="home"
+             name="deliveryAddressType"
+             value="home"
+             class="ncf__delivery-address-type__input"
+             checked
+      >
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        Home Address
+      </span>
+    </label>
+    <label for="company"
+           aria-label="Company Address"
+    >
+      <input type="radio"
+             id="company"
+             name="deliveryAddressType"
+             value="company"
+             class="ncf__delivery-address-type__input"
+      >
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        Company Address
+      </span>
+    </label>
+    <label for="pobox"
+           aria-label="P.O. Box"
+    >
+      <input type="radio"
+             id="pobox"
+             name="deliveryAddressType"
+             value="pobox"
+             class="ncf__delivery-address-type__input"
+      >
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        P.O. Box
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`DeliveryAddressType renders with pobox value selected 1`] = `
+<div id="deliveryAddressTypeField"
+     class="o-forms-field ncf__delivery-address-type"
+     role="group"
+     aria-label="Delivery Address Type"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Address type
+    </span>
+  </span>
+  <div class="o-forms-input o-forms-input--inline o-forms-input--radio-round">
+    <label for="home"
+           aria-label="Home Address"
+    >
+      <input type="radio"
+             id="home"
+             name="deliveryAddressType"
+             value="home"
+             class="ncf__delivery-address-type__input"
+      >
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        Home Address
+      </span>
+    </label>
+    <label for="company"
+           aria-label="Company Address"
+    >
+      <input type="radio"
+             id="company"
+             name="deliveryAddressType"
+             value="company"
+             class="ncf__delivery-address-type__input"
+      >
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        Company Address
+      </span>
+    </label>
+    <label for="pobox"
+           aria-label="P.O. Box"
+    >
+      <input type="radio"
+             id="pobox"
+             name="deliveryAddressType"
+             value="pobox"
+             class="ncf__delivery-address-type__input"
+             checked
+      >
+      <span class="o-forms-input__label"
+            aria-hidden="true"
+      >
+        P.O. Box
+      </span>
+    </label>
+  </div>
+</div>
+`;

--- a/components/__snapshots__/delivery-address-type.spec.js.snap
+++ b/components/__snapshots__/delivery-address-type.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DeliveryAddressType renders with company value selected 1`] = `
-<div id="deliveryAddressTypeField"
+exports[`DeliveryAddressType renders with all props 1`] = `
+<div id="customField"
      class="o-forms-field ncf__delivery-address-type"
      role="group"
      aria-label="Delivery Address Type"
@@ -113,130 +113,6 @@ exports[`DeliveryAddressType renders with default props 1`] = `
              name="deliveryAddressType"
              value="pobox"
              class="ncf__delivery-address-type__input"
-      >
-      <span class="o-forms-input__label"
-            aria-hidden="true"
-      >
-        P.O. Box
-      </span>
-    </label>
-  </div>
-</div>
-`;
-
-exports[`DeliveryAddressType renders with home value selected 1`] = `
-<div id="deliveryAddressTypeField"
-     class="o-forms-field ncf__delivery-address-type"
-     role="group"
-     aria-label="Delivery Address Type"
->
-  <span class="o-forms-title">
-    <span class="o-forms-title__main">
-      Address type
-    </span>
-  </span>
-  <div class="o-forms-input o-forms-input--inline o-forms-input--radio-round">
-    <label for="home"
-           aria-label="Home Address"
-    >
-      <input type="radio"
-             id="home"
-             name="deliveryAddressType"
-             value="home"
-             class="ncf__delivery-address-type__input"
-             checked
-      >
-      <span class="o-forms-input__label"
-            aria-hidden="true"
-      >
-        Home Address
-      </span>
-    </label>
-    <label for="company"
-           aria-label="Company Address"
-    >
-      <input type="radio"
-             id="company"
-             name="deliveryAddressType"
-             value="company"
-             class="ncf__delivery-address-type__input"
-      >
-      <span class="o-forms-input__label"
-            aria-hidden="true"
-      >
-        Company Address
-      </span>
-    </label>
-    <label for="pobox"
-           aria-label="P.O. Box"
-    >
-      <input type="radio"
-             id="pobox"
-             name="deliveryAddressType"
-             value="pobox"
-             class="ncf__delivery-address-type__input"
-      >
-      <span class="o-forms-input__label"
-            aria-hidden="true"
-      >
-        P.O. Box
-      </span>
-    </label>
-  </div>
-</div>
-`;
-
-exports[`DeliveryAddressType renders with pobox value selected 1`] = `
-<div id="deliveryAddressTypeField"
-     class="o-forms-field ncf__delivery-address-type"
-     role="group"
-     aria-label="Delivery Address Type"
->
-  <span class="o-forms-title">
-    <span class="o-forms-title__main">
-      Address type
-    </span>
-  </span>
-  <div class="o-forms-input o-forms-input--inline o-forms-input--radio-round">
-    <label for="home"
-           aria-label="Home Address"
-    >
-      <input type="radio"
-             id="home"
-             name="deliveryAddressType"
-             value="home"
-             class="ncf__delivery-address-type__input"
-      >
-      <span class="o-forms-input__label"
-            aria-hidden="true"
-      >
-        Home Address
-      </span>
-    </label>
-    <label for="company"
-           aria-label="Company Address"
-    >
-      <input type="radio"
-             id="company"
-             name="deliveryAddressType"
-             value="company"
-             class="ncf__delivery-address-type__input"
-      >
-      <span class="o-forms-input__label"
-            aria-hidden="true"
-      >
-        Company Address
-      </span>
-    </label>
-    <label for="pobox"
-           aria-label="P.O. Box"
-    >
-      <input type="radio"
-             id="pobox"
-             name="deliveryAddressType"
-             value="pobox"
-             class="ncf__delivery-address-type__input"
-             checked
       >
       <span class="o-forms-input__label"
             aria-hidden="true"

--- a/components/__snapshots__/delivery-po-box.spec.js.snap
+++ b/components/__snapshots__/delivery-po-box.spec.js.snap
@@ -1,75 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DeliveryPOBox renders with a custom value 1`] = `
-<label id="deliveryPOBoxField"
+exports[`DeliveryPOBox renders with a custom props values 1`] = `
+<label id="customFieldId"
        class="o-forms-field ncf__validation-error"
        data-validate="required"
-       for="deliveryPOBox"
->
-  <span class="o-forms-title">
-    <span class="o-forms-title__main">
-      P.O. Box
-    </span>
-    <span class="o-forms-title__prompt">
-      A P.O. Box address is only deliverable by US Mail, and is subject to a delay of up to 3 business days. For delivery on the publication date, we recommend you enter a residential or business address.
-    </span>
-  </span>
-  <span class="o-forms-input o-forms-input--text">
-    <input type="text"
-           id="deliveryPOBox"
-           name="deliveryPOBox"
-           data-trackable="field-deliveryPOBox"
-           placeholder="e.g. PO Box 1033"
-           maxlength="50"
-           aria-required="true"
-           required
-           value="PO Box 1054"
-    >
-    <span class="o-forms-input__error">
-      Please enter a valid P.O. Box address
-    </span>
-  </span>
-</label>
-`;
-
-exports[`DeliveryPOBox renders with a disabled input element 1`] = `
-<label id="deliveryPOBoxField"
-       class="o-forms-field ncf__validation-error"
-       data-validate="required"
-       for="deliveryPOBox"
->
-  <span class="o-forms-title">
-    <span class="o-forms-title__main">
-      P.O. Box
-    </span>
-    <span class="o-forms-title__prompt">
-      A P.O. Box address is only deliverable by US Mail, and is subject to a delay of up to 3 business days. For delivery on the publication date, we recommend you enter a residential or business address.
-    </span>
-  </span>
-  <span class="o-forms-input o-forms-input--text">
-    <input type="text"
-           id="deliveryPOBox"
-           name="deliveryPOBox"
-           data-trackable="field-deliveryPOBox"
-           placeholder="e.g. PO Box 1033"
-           maxlength="50"
-           aria-required="true"
-           required
-           disabled
-           value
-    >
-    <span class="o-forms-input__error">
-      Please enter a valid P.O. Box address
-    </span>
-  </span>
-</label>
-`;
-
-exports[`DeliveryPOBox renders with an error 1`] = `
-<label id="deliveryPOBoxField"
-       class="o-forms-field ncf__validation-error"
-       data-validate="required"
-       for="deliveryPOBox"
+       for="customInputId"
 >
   <span class="o-forms-title">
     <span class="o-forms-title__main">
@@ -81,14 +16,15 @@ exports[`DeliveryPOBox renders with an error 1`] = `
   </span>
   <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
     <input type="text"
-           id="deliveryPOBox"
-           name="deliveryPOBox"
+           id="customInputId"
+           name="customInputId"
            data-trackable="field-deliveryPOBox"
            placeholder="e.g. PO Box 1033"
-           maxlength="50"
+           maxlength="30"
            aria-required="true"
            required
-           value
+           disabled
+           value="PO Box 1054"
     >
     <span class="o-forms-input__error">
       Please enter a valid P.O. Box address
@@ -108,7 +44,6 @@ exports[`DeliveryPOBox renders with default props 1`] = `
       P.O. Box
     </span>
     <span class="o-forms-title__prompt">
-      A P.O. Box address is only deliverable by US Mail, and is subject to a delay of up to 3 business days. For delivery on the publication date, we recommend you enter a residential or business address.
     </span>
   </span>
   <span class="o-forms-input o-forms-input--text">

--- a/components/__snapshots__/delivery-po-box.spec.js.snap
+++ b/components/__snapshots__/delivery-po-box.spec.js.snap
@@ -1,0 +1,130 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeliveryPOBox renders with a custom value 1`] = `
+<label id="deliveryPOBoxField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="deliveryPOBox"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      P.O. Box
+    </span>
+    <span class="o-forms-title__prompt">
+      A P.O. Box address is only deliverable by US Mail, and is subject to a delay of up to 3 business days. For delivery on the publication date, we recommend you enter a residential or business address.
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryPOBox"
+           name="deliveryPOBox"
+           data-trackable="field-deliveryPOBox"
+           placeholder="e.g. PO Box 1033"
+           maxlength="50"
+           aria-required="true"
+           required
+           value="PO Box 1054"
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid P.O. Box address
+    </span>
+  </span>
+</label>
+`;
+
+exports[`DeliveryPOBox renders with a disabled input element 1`] = `
+<label id="deliveryPOBoxField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="deliveryPOBox"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      P.O. Box
+    </span>
+    <span class="o-forms-title__prompt">
+      A P.O. Box address is only deliverable by US Mail, and is subject to a delay of up to 3 business days. For delivery on the publication date, we recommend you enter a residential or business address.
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryPOBox"
+           name="deliveryPOBox"
+           data-trackable="field-deliveryPOBox"
+           placeholder="e.g. PO Box 1033"
+           maxlength="50"
+           aria-required="true"
+           required
+           disabled
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid P.O. Box address
+    </span>
+  </span>
+</label>
+`;
+
+exports[`DeliveryPOBox renders with an error 1`] = `
+<label id="deliveryPOBoxField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="deliveryPOBox"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      P.O. Box
+    </span>
+    <span class="o-forms-title__prompt">
+      A P.O. Box address is only deliverable by US Mail, and is subject to a delay of up to 3 business days. For delivery on the publication date, we recommend you enter a residential or business address.
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+    <input type="text"
+           id="deliveryPOBox"
+           name="deliveryPOBox"
+           data-trackable="field-deliveryPOBox"
+           placeholder="e.g. PO Box 1033"
+           maxlength="50"
+           aria-required="true"
+           required
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid P.O. Box address
+    </span>
+  </span>
+</label>
+`;
+
+exports[`DeliveryPOBox renders with default props 1`] = `
+<label id="deliveryPOBoxField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="deliveryPOBox"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      P.O. Box
+    </span>
+    <span class="o-forms-title__prompt">
+      A P.O. Box address is only deliverable by US Mail, and is subject to a delay of up to 3 business days. For delivery on the publication date, we recommend you enter a residential or business address.
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryPOBox"
+           name="deliveryPOBox"
+           data-trackable="field-deliveryPOBox"
+           placeholder="e.g. PO Box 1033"
+           maxlength="50"
+           aria-required="true"
+           required
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid P.O. Box address
+    </span>
+  </span>
+</label>
+`;

--- a/components/delivery-address-type.jsx
+++ b/components/delivery-address-type.jsx
@@ -1,28 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 
-export function DeliveryAddressType({ value = 'home' }) {
-	const divClassName = classNames([
-		'o-forms-field',
-		'ncf__delivery-address-type',,
-	]);
+const addressTypes = [
+	{ id: 'home', label: 'Home Address' },
+	{ id: 'company', label: 'Company Address' },
+	{ id: 'pobox', label: 'P.O. Box' },
+];
 
-	const addressTypes = [
-		{ id: 'home',	label: 'Home Address'	},
-		{ id: 'company',	label: 'Company Address'	},
-		{ id: 'pobox',	label: 'P.O. Box'	},
-	];
-
-	const className = classNames([
-		'o-forms-input',
-		'o-forms-input--inline',
-		'o-forms-input--radio-round',
-	]);
+export function DeliveryAddressType({
+	value = 'home',
+	fieldId = 'deliveryAddressTypeField',
+	inputName = 'deliveryAddressType',
+	options = ['home', 'company', 'pobox'],
+}) {
 
 	return (
 		<div
-			id="deliveryAddressTypeField"
+			id={fieldId}
 			className="o-forms-field ncf__delivery-address-type"
 			role="group"
 			aria-label="Delivery Address Type"
@@ -31,24 +25,24 @@ export function DeliveryAddressType({ value = 'home' }) {
 				<span className="o-forms-title__main">Address type</span>
 			</span>
 
-			<div className={className}>
-				{addressTypes.map((type) => {
-					const inputProps = {
-						type: 'radio',
-						id: type.id,
-						name: 'deliveryAddressType',
-						value: type.id,
-						className: 'ncf__delivery-address-type__input',
-						defaultChecked: type.id === value,
-					};
+			<div className='o-forms-input o-forms-input--inline o-forms-input--radio-round'>
+				{options.map(option => {
+					const type = addressTypes.find(item => item.id === option);
 
-					return (
-							<label htmlFor={inputProps.id} aria-label={type.label}>
-								<input {...inputProps} />
-								<span className="o-forms-input__label" aria-hidden="true">
-									{type.label}
-								</span>
-							</label>
+					return (!type) ? null : (
+						<label htmlFor={type.id} aria-label={type.label}>
+							<input
+								type="radio"
+								id={type.id}
+								name={inputName}
+								value={type.id}
+								className="ncf__delivery-address-type__input"
+								defaultChecked={type.id === value}
+							/>
+							<span className="o-forms-input__label" aria-hidden="true">
+								{type.label}
+							</span>
+						</label>
 					);
 				})}
 			</div>
@@ -57,5 +51,10 @@ export function DeliveryAddressType({ value = 'home' }) {
 }
 
 DeliveryAddressType.propTypes = {
+	fieldId: PropTypes.string,
+	inputName: PropTypes.string,
 	value: PropTypes.oneOf(['home', 'company', 'pobox']),
+	options: PropTypes.arrayOf(
+		PropTypes.oneOf(['home', 'company', 'pobox']),
+	),
 };

--- a/components/delivery-address-type.jsx
+++ b/components/delivery-address-type.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export function DeliveryAddressType({ value = 'home' }) {
+	const divClassName = classNames([
+		'o-forms-field',
+		'ncf__delivery-address-type',,
+	]);
+
+	const addressTypes = [
+		{ id: 'home',	label: 'Home Address'	},
+		{ id: 'company',	label: 'Company Address'	},
+		{ id: 'pobox',	label: 'P.O. Box'	},
+	];
+
+	const className = classNames([
+		'o-forms-input',
+		'o-forms-input--inline',
+		'o-forms-input--radio-round',
+	]);
+
+	return (
+		<div
+			id="deliveryAddressTypeField"
+			className="o-forms-field ncf__delivery-address-type"
+			role="group"
+			aria-label="Delivery Address Type"
+		>
+			<span className="o-forms-title">
+				<span className="o-forms-title__main">Address type</span>
+			</span>
+
+			<div className={className}>
+				{addressTypes.map((type) => {
+					const inputProps = {
+						type: 'radio',
+						id: type.id,
+						name: 'deliveryAddressType',
+						value: type.id,
+						className: 'ncf__delivery-address-type__input',
+						defaultChecked: type.id === value,
+					};
+
+					return (
+							<label htmlFor={inputProps.id} aria-label={type.label}>
+								<input {...inputProps} />
+								<span className="o-forms-input__label" aria-hidden="true">
+									{type.label}
+								</span>
+							</label>
+					);
+				})}
+			</div>
+		</div>
+	);
+}
+
+DeliveryAddressType.propTypes = {
+	value: PropTypes.oneOf(['home', 'company', 'pobox']),
+};

--- a/components/delivery-address-type.spec.js
+++ b/components/delivery-address-type.spec.js
@@ -10,20 +10,12 @@ describe('DeliveryAddressType', () => {
 		expect(DeliveryAddressType).toRenderCorrectly(props);
 	});
 
-	it('renders with home value selected', () => {
-		const props = { value: 'home' };
-
-		expect(DeliveryAddressType).toRenderCorrectly(props);
-	});
-
-	it('renders with company value selected', () => {
-		const props = { value: 'company' };
-
-		expect(DeliveryAddressType).toRenderCorrectly(props);
-	});
-
-	it('renders with pobox value selected', () => {
-		const props = { value: 'pobox' };
+	it('renders with all props', () => {
+		const props = {
+			fieldId: 'customField',
+			imputName: 'customName',
+			value: 'company',
+		};
 
 		expect(DeliveryAddressType).toRenderCorrectly(props);
 	});

--- a/components/delivery-address-type.spec.js
+++ b/components/delivery-address-type.spec.js
@@ -1,0 +1,30 @@
+import { DeliveryAddressType } from './index';
+import { expectToRenderCorrectly } from '../test-jest/helpers/expect-to-render-correctly';
+
+expect.extend(expectToRenderCorrectly);
+
+describe('DeliveryAddressType', () => {
+	it('renders with default props', () => {
+		const props = {};
+
+		expect(DeliveryAddressType).toRenderCorrectly(props);
+	});
+
+	it('renders with home value selected', () => {
+		const props = { value: 'home' };
+
+		expect(DeliveryAddressType).toRenderCorrectly(props);
+	});
+
+	it('renders with company value selected', () => {
+		const props = { value: 'company' };
+
+		expect(DeliveryAddressType).toRenderCorrectly(props);
+	});
+
+	it('renders with pobox value selected', () => {
+		const props = { value: 'pobox' };
+
+		expect(DeliveryAddressType).toRenderCorrectly(props);
+	});
+});

--- a/components/delivery-address-type.stories.js
+++ b/components/delivery-address-type.stories.js
@@ -7,3 +7,9 @@ export default {
 };
 
 export const Basic = (args) => <DeliveryAddressType {...args} />;
+
+export const HomeAndCompanyTypes = (args) => <DeliveryAddressType {...args} />;
+HomeAndCompanyTypes.args = {
+	value: 'home',
+	options: ['home', 'company'],
+};

--- a/components/delivery-address-type.stories.js
+++ b/components/delivery-address-type.stories.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { DeliveryAddressType } from './delivery-address-type';
+
+export default {
+	title: 'Delivery Address Type',
+	component: DeliveryAddressType,
+};
+
+export const Basic = (args) => <DeliveryAddressType {...args} />;

--- a/components/delivery-po-box.jsx
+++ b/components/delivery-po-box.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export function DeliveryPOBox({
+	hasError = false,
+	value = '',
+	isDisabled = false,
+}) {
+	const inputWrapperClassName = classNames([
+		'o-forms-input',
+		'o-forms-input--text',
+		{ 'o-forms-input--invalid': hasError },
+	]);
+
+	return (
+		<label
+			id="deliveryPOBoxField"
+			className="o-forms-field ncf__validation-error"
+			data-validate="required"
+			htmlFor="deliveryPOBox"
+		>
+			<span className="o-forms-title">
+				<span className="o-forms-title__main">P.O. Box</span>
+				<span className="o-forms-title__prompt">
+					A P.O. Box address is only deliverable by US Mail, and is subject to a delay of up to 3 business days.
+					For delivery on the publication date, we recommend you enter a residential or business address.
+				</span>
+			</span>
+			<span className={inputWrapperClassName}>
+				<input
+					type="text"
+					id="deliveryPOBox"
+					name="deliveryPOBox"
+					data-trackable="field-deliveryPOBox"
+					placeholder="e.g. PO Box 1033"
+					maxLength={50}
+					aria-required="true"
+					required
+					disabled={isDisabled}
+					defaultValue={value}
+				/>
+				<span className="o-forms-input__error">
+					Please enter a valid P.O. Box address
+				</span>
+			</span>
+		</label>
+	);
+}
+
+DeliveryPOBox.propTypes = {
+	hasError: PropTypes.bool,
+	value: PropTypes.string,
+	isDisabled: PropTypes.bool,
+	maxlength: PropTypes.number,
+};

--- a/components/delivery-po-box.jsx
+++ b/components/delivery-po-box.jsx
@@ -2,10 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+const message = {
+	USA: 'A P.O. Box address is only deliverable by US Mail, and is subject to a delay of up to 3 business days. For delivery on the publication date, we recommend you enter a residential or business address.',
+	CAN: 'A P.O. Box address is only deliverable by Canada Post, and is subject to a delay of up to 3 business days. For delivery on the publication day, we recommend you enter a residential or business address.',
+};
+
 export function DeliveryPOBox({
+	fieldId = 'deliveryPOBoxField',
+	inputId = 'deliveryPOBox',
 	hasError = false,
 	value = '',
 	isDisabled = false,
+	maxlength = 50,
+	country = '',
 }) {
 	const inputWrapperClassName = classNames([
 		'o-forms-input',
@@ -15,26 +24,25 @@ export function DeliveryPOBox({
 
 	return (
 		<label
-			id="deliveryPOBoxField"
+			id={fieldId}
 			className="o-forms-field ncf__validation-error"
 			data-validate="required"
-			htmlFor="deliveryPOBox"
+			htmlFor={inputId}
 		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">P.O. Box</span>
 				<span className="o-forms-title__prompt">
-					A P.O. Box address is only deliverable by US Mail, and is subject to a delay of up to 3 business days.
-					For delivery on the publication date, we recommend you enter a residential or business address.
+					{message[country]}
 				</span>
 			</span>
 			<span className={inputWrapperClassName}>
 				<input
 					type="text"
-					id="deliveryPOBox"
-					name="deliveryPOBox"
+					id={inputId}
+					name={inputId}
 					data-trackable="field-deliveryPOBox"
 					placeholder="e.g. PO Box 1033"
-					maxLength={50}
+					maxLength={maxlength}
 					aria-required="true"
 					required
 					disabled={isDisabled}
@@ -49,8 +57,11 @@ export function DeliveryPOBox({
 }
 
 DeliveryPOBox.propTypes = {
-	hasError: PropTypes.bool,
+	fieldId: PropTypes.string,
+	inputId: PropTypes.string,
 	value: PropTypes.string,
+	hasError: PropTypes.bool,
 	isDisabled: PropTypes.bool,
 	maxlength: PropTypes.number,
+	country: PropTypes.string,
 };

--- a/components/delivery-po-box.spec.js
+++ b/components/delivery-po-box.spec.js
@@ -10,20 +10,16 @@ describe('DeliveryPOBox', () => {
 		expect(DeliveryPOBox).toRenderCorrectly(props);
 	});
 
-	it('renders with an error', () => {
-		const props = { hasError: true };
-
-		expect(DeliveryPOBox).toRenderCorrectly(props);
-	});
-
-	it('renders with a custom value', () => {
-		const props = { value: 'PO Box 1054' };
-
-		expect(DeliveryPOBox).toRenderCorrectly(props);
-	});
-
-	it('renders with a disabled input element', () => {
-		const props = { isDisabled: true };
+	it('renders with a custom props values', () => {
+		const props = {
+			value: 'PO Box 1054',
+			fieldId: 'customFieldId',
+			inputId: 'customInputId',
+			maxlength: 30,
+			hasError: true,
+			isDisabled: true,
+			country: 'USA',
+		};
 
 		expect(DeliveryPOBox).toRenderCorrectly(props);
 	});

--- a/components/delivery-po-box.spec.js
+++ b/components/delivery-po-box.spec.js
@@ -1,0 +1,30 @@
+import { DeliveryPOBox } from './index';
+import { expectToRenderCorrectly } from '../test-jest/helpers/expect-to-render-correctly';
+
+expect.extend(expectToRenderCorrectly);
+
+describe('DeliveryPOBox', () => {
+	it('renders with default props', () => {
+		const props = {};
+
+		expect(DeliveryPOBox).toRenderCorrectly(props);
+	});
+
+	it('renders with an error', () => {
+		const props = { hasError: true };
+
+		expect(DeliveryPOBox).toRenderCorrectly(props);
+	});
+
+	it('renders with a custom value', () => {
+		const props = { value: 'PO Box 1054' };
+
+		expect(DeliveryPOBox).toRenderCorrectly(props);
+	});
+
+	it('renders with a disabled input element', () => {
+		const props = { isDisabled: true };
+
+		expect(DeliveryPOBox).toRenderCorrectly(props);
+	});
+});

--- a/components/delivery-po-box.stories.js
+++ b/components/delivery-po-box.stories.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { DeliveryPOBox } from './delivery-po-box';
+
+export default {
+	title: 'Delivery P.O. Box',
+	component: DeliveryPOBox,
+};
+
+export const Basic = (args) => <DeliveryPOBox {...args} />;

--- a/components/delivery-po-box.stories.js
+++ b/components/delivery-po-box.stories.js
@@ -4,6 +4,20 @@ import { DeliveryPOBox } from './delivery-po-box';
 export default {
 	title: 'Delivery P.O. Box',
 	component: DeliveryPOBox,
+	argTypes: {
+		hasError: { control: 'boolean' },
+		isDisabled: { control: 'boolean' },
+	}
 };
 
 export const Basic = (args) => <DeliveryPOBox {...args} />;
+
+export const USAPOBox = (args) => <DeliveryPOBox {...args} />;
+USAPOBox.args = {
+	country: 'USA',
+};
+
+export const CanadaPOBox = (args) => <DeliveryPOBox {...args} />;
+CanadaPOBox.args = {
+	country: 'CAN',
+};

--- a/components/index.jsx
+++ b/components/index.jsx
@@ -12,6 +12,7 @@ export { Country } from './country';
 export { CustomerCare } from './customer-care';
 export { Debug } from './debug';
 export { DecisionMaker } from './decision-maker';
+export { DeliveryAddressType } from './delivery-address-type';
 export { DeliveryAddress } from './delivery-address';
 export { DeliveryCity } from './delivery-city';
 export { DeliveryCounty } from './delivery-county';

--- a/components/index.jsx
+++ b/components/index.jsx
@@ -21,6 +21,7 @@ export { DeliveryOption } from './delivery-option';
 export { DeliveryPostcode } from './delivery-postcode';
 export { DeliverySecurityInstructions } from './delivery-security-instructions';
 export { DeliveryStartDate } from './delivery-start-date';
+export { DeliveryPOBox } from './delivery-po-box';
 export { Email } from './email';
 export { ErrorPage } from './error-page';
 export { Fieldset } from './fieldset';


### PR DESCRIPTION
### Description
As part of US Print Offer Delivery implementation, two new components are added to comply with [Requirements](https://docs.google.com/document/d/1UF3-kRDVATzUuOePEtulcT1lXoZtfdKCztkUgdGtFm0/edit#heading=h.6e0cccq3jiaw) and [Design Document](https://ftnext.invisionapp.com/share/V5Y6GTC4FEJ#/screens/427782519)

These new components will be used by `next-subscribe`.

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-751

### Screenshots

Address type component at `Storybook`
<img width="577" alt="Screenshot 2021-02-24 at 14 49 37" src="https://user-images.githubusercontent.com/13876273/109010791-85708e80-76b0-11eb-843d-50c0d828ca86.png">

P.O. Box field component at `Storybook`
![Screenshot 2021-03-02 at 10 06 00](https://user-images.githubusercontent.com/13876273/109624879-fabfe180-7b3e-11eb-85a6-3155e598eb71.png)
![Screenshot 2021-03-01 at 10 49 00](https://user-images.githubusercontent.com/13876273/109487799-ffc05a80-7a84-11eb-9adb-babb6a08fbaf.png)


### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [x] **Stories** updated to use this change
- [x] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
