### PR TITLE
ACQ-878 Add Zuora setAgreement method

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,10 @@ zuora.onAgreementCheckboxChange((checked) => {});
 // @param {boolean} confirmed - whether confirmed or not
 zuora.onDirectDebitConfirmation((confirmed) => {});
 
+// Sets necessary static parameters for creadential user profile
+// Makes a call to Zuora supplying those parameters for agreement validation
+zuora.setAgreement();
+
 // Example implementation on form submission
 try {
 	await this.zuora.submit('directdebit');

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ zuora.onAgreementCheckboxChange((checked) => {});
 // @param {boolean} confirmed - whether confirmed or not
 zuora.onDirectDebitConfirmation((confirmed) => {});
 
-// Sets necessary static parameters for creadential user profile
+// Sets necessary static parameters for credential user profile
 // Makes a call to Zuora supplying those parameters for agreement validation
 zuora.setAgreement();
 

--- a/utils/zuora.js
+++ b/utils/zuora.js
@@ -147,15 +147,14 @@ class Zuora {
 	/**
 	 * Creating a stored credential profile within the created payment method
 	 * Zuora doc: https://knowledgecenter.zuora.com/Billing/Billing_and_Payments/LA_Hosted_Payment_Pages/B_Payment_Pages_2.0/H_Integrate_Payment_Pages_2.0#Add_a_Checkbox_for_Stored_Credential_Consent
-	 *
-	 * @param {String} agreementRef Reference for the customer consent agreement
 	 * @returns {boolean}
 	 */
-	setAgreement (agreementRef) {
+	setAgreement () {
 		const mitConsentAgreementSrc = 'External';
 		const mitProfileType = 'Recurring';
 		const agreementSupportedBrands = 'Visa,Mastercard';
-		const mitConsentAgreementRef = agreementRef;
+		const mitConsentAgreementRef = 'createStoredCredentialProfile';
+
 		return this.Z.setAgreement(mitConsentAgreementSrc, mitProfileType, agreementSupportedBrands, mitConsentAgreementRef);
 	}
 

--- a/utils/zuora.js
+++ b/utils/zuora.js
@@ -146,12 +146,16 @@ class Zuora {
 
 	/**
 	 * Creating a stored credential profile within the created payment method
-	 * @param {String} mitConsentAgreementSrc
-	 * @param {String} mitProfileType
-	 * @param {String} agreementSupportedBrands
-	 * @param {String} mitConsentAgreementRef
+	 * Zuora doc: https://knowledgecenter.zuora.com/Billing/Billing_and_Payments/LA_Hosted_Payment_Pages/B_Payment_Pages_2.0/H_Integrate_Payment_Pages_2.0#Add_a_Checkbox_for_Stored_Credential_Consent
+	 *
+	 * @param {String} agreementRef Reference for the customer consent agreement
+	 * @returns {boolean}
 	 */
-	setAgreement (mitConsentAgreementSrc, mitProfileType, agreementSupportedBrands, mitConsentAgreementRef) {
+	setAgreement (agreementRef) {
+		const mitConsentAgreementSrc = 'External';
+		const mitProfileType = 'Recurring';
+		const agreementSupportedBrands = 'Visa,Mastercard';
+		const mitConsentAgreementRef = agreementRef;
 		return this.Z.setAgreement(mitConsentAgreementSrc, mitProfileType, agreementSupportedBrands, mitConsentAgreementRef);
 	}
 

--- a/utils/zuora.js
+++ b/utils/zuora.js
@@ -145,6 +145,17 @@ class Zuora {
 	}
 
 	/**
+	 * Creating a stored credential profile within the created payment method
+	 * @param {String} mitConsentAgreementSrc
+	 * @param {String} mitProfileType
+	 * @param {String} agreementSupportedBrands
+	 * @param {String} mitConsentAgreementRef
+	 */
+	setAgreement (mitConsentAgreementSrc, mitProfileType, agreementSupportedBrands, mitConsentAgreementRef) {
+		return this.Z.setAgreement(mitConsentAgreementSrc, mitProfileType, agreementSupportedBrands, mitConsentAgreementRef);
+	}
+
+	/**
 	 * Expose ZuoraErrorValidation
 	 */
 	static get ZuoraErrorValidation () {


### PR DESCRIPTION
### Description
This is a part of  [Ticket](https://financialtimes.atlassian.net/browse/ACQ-878)
As we only have access to those zuora related methods that we expose through n-conversion-forms. In n-conversion-forms we standardized access to the methods we use in other projects. I have added setAgreement here as it will need to be used on next-subscribe