### PR TITLE
Acq 751 add change delivery postcode link

### DIFF
--- a/components/__snapshots__/delivery-postcode.spec.js.snap
+++ b/components/__snapshots__/delivery-postcode.spec.js.snap
@@ -259,3 +259,47 @@ exports[`Delivery Postcode render different styles 1`] = `
   </span>
 </label>
 `;
+
+exports[`Delivery Postcode render with link to change the value 1`] = `
+<label id="deliveryPostcodeField"
+       class="o-forms-field"
+       data-validate="required"
+       for="deliveryPostcode"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Delivery
+      <span data-reference="postcode">
+        Zip Code
+      </span>
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="text"
+           id="deliveryPostcode"
+           name="deliveryPostcode"
+           placeholder="Enter your Zip Code"
+           autocomplete="postal-code"
+           data-trackable="delivery-postcode"
+           aria-required="true"
+           required
+           pattern="whatever"
+           value
+    >
+    <span class="o-forms-input__error">
+      Please enter a valid
+      <span data-reference="postcode">
+        Zip Code
+      </span>
+      .
+    </span>
+    <a href="http://local.ft.com"
+       style="font-size:12px"
+       class="change-postcode-url"
+       data-trackable="change-progress"
+    >
+      Change Zip Code
+    </a>
+  </span>
+</label>
+`;

--- a/components/delivery-postcode.jsx
+++ b/components/delivery-postcode.jsx
@@ -15,6 +15,7 @@ export function DeliveryPostcode({
 	isHidden = false,
 	pattern,
 	additionalFieldInformation,
+	changePostcodeUrl = '',
 }) {
 	const postcodeReference = postcodeLabel[country.toUpperCase()] || 'postcode';
 
@@ -72,6 +73,16 @@ export function DeliveryPostcode({
 						{additionalFieldInformation}
 					</p>
 				) : null}
+				{changePostcodeUrl ? (
+					<a
+						href={changePostcodeUrl}
+						style={{fontSize: '12px'}}
+						className="change-postcode-url"
+						data-trackable="change-progress"
+					>
+						{`Change ${postcodeReference}`}
+					</a>
+				) : null}
 			</span>
 		</label>
 	);
@@ -85,4 +96,5 @@ DeliveryPostcode.propTypes = {
 	hasError: PropTypes.bool,
 	isHidden: PropTypes.bool,
 	additionalFieldInformation: PropTypes.node,
+	changePostcodeUrl: PropTypes.string,
 };

--- a/components/delivery-postcode.jsx
+++ b/components/delivery-postcode.jsx
@@ -7,7 +7,7 @@ const postcodeLabel = {
 	CAN: 'postal code',
 };
 
-export function DeliveryPostcode({
+export function DeliveryPostcode ({
 	value = '',
 	country = '',
 	isDisabled = false,

--- a/components/delivery-postcode.spec.js
+++ b/components/delivery-postcode.spec.js
@@ -72,4 +72,15 @@ describe('Delivery Postcode', () => {
 
 		expect(DeliveryPostcode).toRenderCorrectly(props);
 	});
+
+	it('render with link to change the value', () => {
+		const props = {
+			country: 'USA',
+			postcodeReference: 'Zip Code',
+			pattern: 'whatever',
+			changePostcodeUrl: 'http://local.ft.com',
+		};
+
+		expect(DeliveryPostcode).toRenderCorrectly(props);
+	});
 });

--- a/components/delivery-postcode.stories.js
+++ b/components/delivery-postcode.stories.js
@@ -19,3 +19,9 @@ export const Basic = (args) => <DeliveryPostcode {...args} />;
 Basic.args = {
 	additionalFieldInformation: 'Some extra information.',
 };
+
+export const WithLinkToChangeValue = (args) => <DeliveryPostcode {...args} />;
+WithLinkToChangeValue.args = {
+	country: 'USA',
+	changePostcodeUrl: 'http://local.ft.com',
+};

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -173,7 +173,7 @@ class Validation {
 
 			setTimeout(() => {
 				delete this.debounceCustomValidation;
-			}, 500);
+			}, 1500);
 		}
 
 		return !document.querySelector('.ncf__custom-validation-error');


### PR DESCRIPTION
### Description
Adding an url to allow modify postcode by redirecting to first step of subscription. Additionally a fine tune was made on validation component to prevent bouncing.

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-751

### Screenshots
![image](https://user-images.githubusercontent.com/48696369/111509540-95b5df80-872b-11eb-8c62-d85e73b5cbb5.png)


### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [x] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [x] **Design Review** ran past the designer
- [x] **Product Review** ran past the product owner
