### PR TITLE
ACQ-873 change of distributor from EDG to News UK 

### DIFF
--- a/components/__snapshots__/delivery-instructions.spec.js.snap
+++ b/components/__snapshots__/delivery-instructions.spec.js.snap
@@ -70,7 +70,7 @@ exports[`DeliveryInstructions renders with a custom value 1`] = `
       For newspaper delivery, we can only deliver to the ground floor, so if you live in an apartment, we’ll leave the newspaper at reception or by the entrance. We deliver in the early hours of the morning so our drivers won’t be able to contact you or ring your doorbell.
     </span>
     <span class="o-forms-title__prompt">
-      If your property requires security codes that will help our drivers deliver your newspaper safely, please do not add them here as they may be printed on your newspaper label. If you do add them here you do so at your own risk as these will appear on your label.
+      Special characters including punctuation cannot be used in the Delivery instructions.
     </span>
   </span>
   <span class="o-forms-input o-forms-input--textarea">
@@ -99,7 +99,7 @@ exports[`DeliveryInstructions renders with a disabled input element 1`] = `
       For newspaper delivery, we can only deliver to the ground floor, so if you live in an apartment, we’ll leave the newspaper at reception or by the entrance. We deliver in the early hours of the morning so our drivers won’t be able to contact you or ring your doorbell.
     </span>
     <span class="o-forms-title__prompt">
-      If your property requires security codes that will help our drivers deliver your newspaper safely, please do not add them here as they may be printed on your newspaper label. If you do add them here you do so at your own risk as these will appear on your label.
+      Special characters including punctuation cannot be used in the Delivery instructions.
     </span>
   </span>
   <span class="o-forms-input o-forms-input--textarea">
@@ -128,7 +128,7 @@ exports[`DeliveryInstructions renders with an error 1`] = `
       For newspaper delivery, we can only deliver to the ground floor, so if you live in an apartment, we’ll leave the newspaper at reception or by the entrance. We deliver in the early hours of the morning so our drivers won’t be able to contact you or ring your doorbell.
     </span>
     <span class="o-forms-title__prompt">
-      If your property requires security codes that will help our drivers deliver your newspaper safely, please do not add them here as they may be printed on your newspaper label. If you do add them here you do so at your own risk as these will appear on your label.
+      Special characters including punctuation cannot be used in the Delivery instructions.
     </span>
   </span>
   <span class="o-forms-input o-forms-input--textarea o-forms-input--invalid">
@@ -156,7 +156,7 @@ exports[`DeliveryInstructions renders with default props 1`] = `
       For newspaper delivery, we can only deliver to the ground floor, so if you live in an apartment, we’ll leave the newspaper at reception or by the entrance. We deliver in the early hours of the morning so our drivers won’t be able to contact you or ring your doorbell.
     </span>
     <span class="o-forms-title__prompt">
-      If your property requires security codes that will help our drivers deliver your newspaper safely, please do not add them here as they may be printed on your newspaper label. If you do add them here you do so at your own risk as these will appear on your label.
+      Special characters including punctuation cannot be used in the Delivery instructions.
     </span>
   </span>
   <span class="o-forms-input o-forms-input--textarea">
@@ -184,7 +184,7 @@ exports[`DeliveryInstructions renders with maxlength 1`] = `
       For newspaper delivery, we can only deliver to the ground floor, so if you live in an apartment, we’ll leave the newspaper at reception or by the entrance. We deliver in the early hours of the morning so our drivers won’t be able to contact you or ring your doorbell.
     </span>
     <span class="o-forms-title__prompt">
-      If your property requires security codes that will help our drivers deliver your newspaper safely, please do not add them here as they may be printed on your newspaper label. If you do add them here you do so at your own risk as these will appear on your label.
+      Special characters including punctuation cannot be used in the Delivery instructions.
     </span>
   </span>
   <span class="o-forms-input o-forms-input--textarea">
@@ -213,7 +213,7 @@ exports[`DeliveryInstructions renders with rows 1`] = `
       For newspaper delivery, we can only deliver to the ground floor, so if you live in an apartment, we’ll leave the newspaper at reception or by the entrance. We deliver in the early hours of the morning so our drivers won’t be able to contact you or ring your doorbell.
     </span>
     <span class="o-forms-title__prompt">
-      If your property requires security codes that will help our drivers deliver your newspaper safely, please do not add them here as they may be printed on your newspaper label. If you do add them here you do so at your own risk as these will appear on your label.
+      Special characters including punctuation cannot be used in the Delivery instructions.
     </span>
   </span>
   <span class="o-forms-input o-forms-input--textarea">

--- a/components/delivery-instructions.jsx
+++ b/components/delivery-instructions.jsx
@@ -24,7 +24,6 @@ export function DeliveryInstructions ({
 	rows = null,
 	isDisabled = false,
 	placeholder = '',
-	hasSignupSecurityNote = false,
 	value = '',
 	country,
 }) {
@@ -34,8 +33,9 @@ export function DeliveryInstructions ({
 		{ 'o-forms-input--invalid': hasError },
 	]);
 
-	const maxLengthText = maxlength ? `(Max. ${maxlength} characters)` : '';
-	const defaultPlaceholder = `Enter instructions ${maxLengthText}:\u000a- Door colour, letterbox location\u000a- Placement i.e. letterbox delivery\u000a- Special handling i.e. place in plastic bag`;
+	const maxLengthText = maxlength && country !== 'GBR'? ` (Max. ${maxlength} characters)` : '';
+	const extraInstruction = country === 'GBR' ? '' : '\u000a- Special handling i.e. place in plastic bag';
+	const defaultPlaceholder = `Enter instructions${maxLengthText}:\u000a- Door colour, letterbox location\u000a- Placement i.e. letterbox delivery${extraInstruction}` ;
 
 	const textAreaProps = {
 		id: inputId,
@@ -47,17 +47,8 @@ export function DeliveryInstructions ({
 		disabled: isDisabled,
 		defaultValue: value,
 	};
-
-	const signupSecurityNote = hasSignupSecurityNote && (
-		<>
-			Either add them to the Security Notes section at{' '}
-			<a href="https://ft.com/myaccount">ft.com/myaccount</a> after purchase, or
-			contact <a href="https://help.ft.com/contact/">FT Customer Care</a>.{' '}
-		</>
-	);
-
-	const securityMessage = <span className="o-forms-title__prompt">
-		If your property requires security codes that will help our drivers deliver your newspaper safely, please do not add them here as they may be printed on your newspaper label. {signupSecurityNote}If you do add them here you do so at your own risk as these will appear on your label.
+	const deliveryInstructionsMessage = <span className="o-forms-title__prompt">
+		Special characters including punctuation cannot be used in the Delivery instructions.
 	</span>;
 
 	return (
@@ -70,7 +61,7 @@ export function DeliveryInstructions ({
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">Delivery instructions</span>
 				{spanMessageByCountry[country]}
-				{country === 'GBR' && securityMessage}
+				{country === 'GBR' && deliveryInstructionsMessage}
 			</span>
 
 			<span className={textAreaWrapperClassNames}>
@@ -85,7 +76,6 @@ DeliveryInstructions.propTypes = {
 	maxlength: PropTypes.number,
 	rows: PropTypes.number,
 	isDisabled: PropTypes.bool,
-	hasSignupSecurityNote: PropTypes.bool,
 	value: PropTypes.string,
 	country: PropTypes.oneOf(['GBR', 'USA', 'CAN']).isRequired,
 };

--- a/components/delivery-instructions.stories.js
+++ b/components/delivery-instructions.stories.js
@@ -5,7 +5,6 @@ export default {
 	title: 'Delivery Instructions',
 	component: DeliveryInstructions,
 	argTypes: {
-		hasSignupSecurityNote: { control: 'boolean' },
 		hasError: { control: 'boolean' },
 		isDisabled: { control: 'boolean' },
 	},


### PR DESCRIPTION
### Description
Changes related to change of distributor for print subscription


### Ticket
[ACQ-873](https://financialtimes.atlassian.net/browse/ACQ-873)
The change can be seen via next-subscribe locally https://local.ft.com:5050/buy/offer/testprint/details But n-conversion-forms should be built and linked in next-subscribe first


### Screenshots
<img width="659" alt="Screenshot 2021-03-18 at 15 43 36" src="https://user-images.githubusercontent.com/14136353/111654739-eea37780-8800-11eb-9a0d-bd3015a321b3.png">



### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
