### PR TITLE
Fixed the logic around max characters

### DIFF
--- a/components/delivery-instructions.jsx
+++ b/components/delivery-instructions.jsx
@@ -33,7 +33,7 @@ export function DeliveryInstructions ({
 		{ 'o-forms-input--invalid': hasError },
 	]);
 
-	const maxLengthText = maxlength && country !== 'GBR'? ` (Max. ${maxlength} characters)` : '';
+	const maxLengthText = maxlength && country === 'GBR'? ` (Max. ${maxlength} characters)` : '';
 	const extraInstruction = country === 'GBR' ? '' : '\u000a- Special handling i.e. place in plastic bag';
 	const defaultPlaceholder = `Enter instructions${maxLengthText}:\u000a- Door colour, letterbox location\u000a- Placement i.e. letterbox delivery${extraInstruction}` ;
 


### PR DESCRIPTION
### Description
This is a patch to the UK distributor changes. Changed the line
```
const maxLengthText = maxlength && country !== 'GBR'? ` (Max. ${maxlength} characters)` : '';
```

to `&& country === 'GBR` 

because we need to pass in the country to remove the `plastic bag` part of the message. And if we do that, then the line above would forcibly remove the `max characters` message because the country *was* GBR.