### PR TITLE
Add maxLengthText for US and Canada

### DIFF
--- a/components/delivery-instructions.jsx
+++ b/components/delivery-instructions.jsx
@@ -33,9 +33,8 @@ export function DeliveryInstructions ({
 		{ 'o-forms-input--invalid': hasError },
 	]);
 
-	const maxLengthText = maxlength && country === 'GBR'? ` (Max. ${maxlength} characters)` : '';
 	const extraInstruction = country === 'GBR' ? '' : '\u000a- Special handling i.e. place in plastic bag';
-	const defaultPlaceholder = `Enter instructions${maxLengthText}:\u000a- Door colour, letterbox location\u000a- Placement i.e. letterbox delivery${extraInstruction}` ;
+	const defaultPlaceholder = `Enter instructions ${maxlength && `(Max. ${maxlength} characters)`}:\u000a- Door colour, letterbox location\u000a- Placement i.e. letterbox delivery${extraInstruction}` ;
 
 	const textAreaProps = {
 		id: inputId,


### PR DESCRIPTION
We need to add Max. characters for US and Canada delivery instructions. The previous PR has added max. characters instructions for UK, which was correct, but conditional removed it from US and Canada. This is a quick fix related to [PR](https://financialtimes.atlassian.net/browse/ACQ-873)
