### PR TITLE
ACQ-866: Adding a GoogleSignIn button component with styles.

### DIFF
--- a/components/__snapshots__/google-sign-in.spec.js.snap
+++ b/components/__snapshots__/google-sign-in.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GoogleSignIn renders with default props 1`] = `
+<link href="https://fonts.googleapis.com/css?family=Roboto"
+      rel="stylesheet"
+>
+<a class="google_button"
+   href="https://www.ft.com"
+>
+  Sign in with Google
+</a>
+`;

--- a/components/google-sign-in.jsx
+++ b/components/google-sign-in.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export function GoogleSignIn({ signInRedirectUrl }) {
+
+	return (
+		<>
+			<link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet"></link>
+			<a className="google_button" href={signInRedirectUrl}>Sign in with Google</a>
+		</>
+	);
+}
+
+GoogleSignIn.propTypes = {
+	signInRedirectUrl: PropTypes.string.isRequired,
+};

--- a/components/google-sign-in.spec.js
+++ b/components/google-sign-in.spec.js
@@ -1,0 +1,14 @@
+import { GoogleSignIn } from './index';
+import { expectToRenderCorrectly } from '../test-jest/helpers/expect-to-render-correctly';
+
+expect.extend(expectToRenderCorrectly);
+
+describe('GoogleSignIn', () => {
+	it('renders with default props', () => {
+		const props = {
+			signInRedirectUrl: 'https://www.ft.com',
+		};
+
+		expect(GoogleSignIn).toRenderCorrectly(props);
+	});
+});

--- a/components/google-sign-in.stories.js
+++ b/components/google-sign-in.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { GoogleSignIn } from './google-sign-in';
+
+export default {
+	title: 'Google Sign In',
+	component: GoogleSignIn,
+};
+
+export const Basic = (args) => <GoogleSignIn {...args} />;
+Basic.args = {
+	signInRedirectUrl: 'https://social-login-svc-eu-test.memb.ft.com/login/google',
+};

--- a/components/index.jsx
+++ b/components/index.jsx
@@ -52,3 +52,4 @@ export { TrialBanner } from './trial-banner';
 export { EducationJobTitle } from './education-job-title';
 export { GraduationDate } from './graduation-date';
 export { LiteSubConfirmation } from './lite-sub-confirmation';
+export { GoogleSignIn } from './google-sign-in';

--- a/main.scss
+++ b/main.scss
@@ -22,6 +22,7 @@
 @import './styles/error';
 @import './styles/graduation-date';
 @import './styles/lite-subs-confirmation';
+@import './styles/google-sign-in';
 
 @include oTypography();
 @include oFonts();
@@ -421,6 +422,8 @@
 		@include oNormaliseVisuallyHidden;
 	}
 }
+
+@include ncfGoogleSignIn();
 
 .ncf__password-field .ncf__password-field--show-password {
 	margin-top: 7px;

--- a/styles/google-sign-in.scss
+++ b/styles/google-sign-in.scss
@@ -1,0 +1,28 @@
+@mixin ncfGoogleSignIn() {
+	.google_button {
+		background-color: #4285f4;
+		color: #ffffff;
+		display: inline-block;
+		width: 100%;
+		text-align: center;
+		font-size: 14px;
+		font-family: Roboto;
+		text-decoration: none;
+		padding-top: 5px;
+		padding-bottom: 5px;
+		font-weight: 500;
+		letter-spacing: 0.21px;
+		border-radius: 5px;
+
+		@include oGridRespondTo($from: S) {
+			font-size: 16px;
+			width: 240px;
+			padding-top: 10px;
+			padding-bottom: 10px;
+		}
+
+		&:hover {
+			color: #ffffff;
+		}
+	}
+}


### PR DESCRIPTION
### Description
Adding a GoogleSignIn button for the Google extender meter functionality.

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-866

Designs: https://www.figma.com/proto/DMlyoknFg5Gg4zt66qcy3Z/google-integration?node-id=7%3A353&viewport=359%2C345%2C0.45831066370010376&scaling=scale-down

### Storybook Screenshots

| Mobile | Web |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/13876273/112352929-81de2080-8ccb-11eb-8d24-1d2029c067bb.png) | ![image](https://user-images.githubusercontent.com/13876273/112353030-9f12ef00-8ccb-11eb-8d7a-35d55cf860d2.png) |

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
