### PR TITLE
ACQ-752: fix the billing postcode component to allow hide completely

### DIFF
--- a/components/__snapshots__/billing-city.spec.js.snap
+++ b/components/__snapshots__/billing-city.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BillingCity render different styles 1`] = `
 <label id="billingCityField"
-       class="o-forms-field ncf__validation-error"
+       class="o-forms-field ncf__validation-error ncf__hidden"
        data-validate="required"
        for="billingCity"
 >

--- a/components/__snapshots__/debug.spec.js.snap
+++ b/components/__snapshots__/debug.spec.js.snap
@@ -26,7 +26,7 @@ exports[`Debug renders with isTest 1`] = `
 	var SYSTEM_CODE = document.documentElement.getAttribute('data-next-app') || 'n-conversion-forms';
 	var COUNTRY_CODE = window.FT && window.FT.country || 'GBR';
 
-	var billingPostcodeByCountry = {
+	var postcodeByCountry = {
 		GBR: 'EC4M9BT',
 		USA: '10028',
 		CAN: 'K0E 9Z9'
@@ -35,14 +35,14 @@ exports[`Debug renders with isTest 1`] = `
 	var debugData = {
 		billingCity: 'London',
 		billingCountry: COUNTRY_CODE,
-		billingPostcode: billingPostcodeByCountry[COUNTRY_CODE],
+		billingPostcode: postcodeByCountry[COUNTRY_CODE],
 		country: COUNTRY_CODE,
 		deliveryAddressLine1: 'delivery test1',
 		deliveryAddressLine2: 'delivery test2',
 		deliveryAddressLine3: 'delivery test3',
 		deliveryCity: 'delivery city',
 		deliveryCounty: 'delivery county',
-		deliveryPostcode: billingPostcodeByCountry[COUNTRY_CODE],
+		deliveryPostcode: postcodeByCountry[COUNTRY_CODE],
 		email: SYSTEM_CODE + '-' + Date.now() + '@ftqa.org',
 		firstName: 'Test',
 		industry: 'DEF',
@@ -51,7 +51,7 @@ exports[`Debug renders with isTest 1`] = `
 		organisation: 'ft-org',
 		password: 'password123',
 		position: 'AS',
-		postCode: billingPostcodeByCountry[COUNTRY_CODE],
+		postCode: postcodeByCountry[COUNTRY_CODE],
 		primaryTelephone: '0987654321',
 		responsibility: 'ADL',
 		ukVisa: '4111111111111111',
@@ -179,7 +179,7 @@ exports[`Debug renders with showHelpers 1`] = `
 	var SYSTEM_CODE = document.documentElement.getAttribute('data-next-app') || 'n-conversion-forms';
 	var COUNTRY_CODE = window.FT && window.FT.country || 'GBR';
 
-	var billingPostcodeByCountry = {
+	var postcodeByCountry = {
 		GBR: 'EC4M9BT',
 		USA: '10028',
 		CAN: 'K0E 9Z9'
@@ -188,14 +188,14 @@ exports[`Debug renders with showHelpers 1`] = `
 	var debugData = {
 		billingCity: 'London',
 		billingCountry: COUNTRY_CODE,
-		billingPostcode: billingPostcodeByCountry[COUNTRY_CODE],
+		billingPostcode: postcodeByCountry[COUNTRY_CODE],
 		country: COUNTRY_CODE,
 		deliveryAddressLine1: 'delivery test1',
 		deliveryAddressLine2: 'delivery test2',
 		deliveryAddressLine3: 'delivery test3',
 		deliveryCity: 'delivery city',
 		deliveryCounty: 'delivery county',
-		deliveryPostcode: billingPostcodeByCountry[COUNTRY_CODE],
+		deliveryPostcode: postcodeByCountry[COUNTRY_CODE],
 		email: SYSTEM_CODE + '-' + Date.now() + '@ftqa.org',
 		firstName: 'Test',
 		industry: 'DEF',
@@ -204,7 +204,7 @@ exports[`Debug renders with showHelpers 1`] = `
 		organisation: 'ft-org',
 		password: 'password123',
 		position: 'AS',
-		postCode: billingPostcodeByCountry[COUNTRY_CODE],
+		postCode: postcodeByCountry[COUNTRY_CODE],
 		primaryTelephone: '0987654321',
 		responsibility: 'ADL',
 		ukVisa: '4111111111111111',

--- a/components/__snapshots__/debug.spec.js.snap
+++ b/components/__snapshots__/debug.spec.js.snap
@@ -24,18 +24,25 @@ exports[`Debug renders with isTest 1`] = `
 	// This env var gets set in production. We use this when creating email addresses in case any
 	// get into production so Membership know who to come to about deleting them.
 	var SYSTEM_CODE = document.documentElement.getAttribute('data-next-app') || 'n-conversion-forms';
+	var COUNTRY_CODE = window.FT && window.FT.country || 'GBR';
+
+	var billingPostcodeByCountry = {
+		GBR: 'EC4M9BT',
+		USA: '10028',
+		CAN: 'K0E 9Z9'
+	}
 
 	var debugData = {
 		billingCity: 'London',
-		billingCountry: 'GBR',
-		billingPostcode: 'EC4M9BT',
-		country: 'GBR',
+		billingCountry: COUNTRY_CODE,
+		billingPostcode: billingPostcodeByCountry[COUNTRY_CODE],
+		country: COUNTRY_CODE,
 		deliveryAddressLine1: 'delivery test1',
 		deliveryAddressLine2: 'delivery test2',
 		deliveryAddressLine3: 'delivery test3',
 		deliveryCity: 'delivery city',
 		deliveryCounty: 'delivery county',
-		deliveryPostcode: 'EC4M9BT',
+		deliveryPostcode: billingPostcodeByCountry[COUNTRY_CODE],
 		email: SYSTEM_CODE + '-' + Date.now() + '@ftqa.org',
 		firstName: 'Test',
 		industry: 'DEF',
@@ -44,7 +51,7 @@ exports[`Debug renders with isTest 1`] = `
 		organisation: 'ft-org',
 		password: 'password123',
 		position: 'AS',
-		postCode: 'EC4M9BT',
+		postCode: billingPostcodeByCountry[COUNTRY_CODE],
 		primaryTelephone: '0987654321',
 		responsibility: 'ADL',
 		ukVisa: '4111111111111111',
@@ -170,18 +177,25 @@ exports[`Debug renders with showHelpers 1`] = `
 	// This env var gets set in production. We use this when creating email addresses in case any
 	// get into production so Membership know who to come to about deleting them.
 	var SYSTEM_CODE = document.documentElement.getAttribute('data-next-app') || 'n-conversion-forms';
+	var COUNTRY_CODE = window.FT && window.FT.country || 'GBR';
+
+	var billingPostcodeByCountry = {
+		GBR: 'EC4M9BT',
+		USA: '10028',
+		CAN: 'K0E 9Z9'
+	}
 
 	var debugData = {
 		billingCity: 'London',
-		billingCountry: 'GBR',
-		billingPostcode: 'EC4M9BT',
-		country: 'GBR',
+		billingCountry: COUNTRY_CODE,
+		billingPostcode: billingPostcodeByCountry[COUNTRY_CODE],
+		country: COUNTRY_CODE,
 		deliveryAddressLine1: 'delivery test1',
 		deliveryAddressLine2: 'delivery test2',
 		deliveryAddressLine3: 'delivery test3',
 		deliveryCity: 'delivery city',
 		deliveryCounty: 'delivery county',
-		deliveryPostcode: 'EC4M9BT',
+		deliveryPostcode: billingPostcodeByCountry[COUNTRY_CODE],
 		email: SYSTEM_CODE + '-' + Date.now() + '@ftqa.org',
 		firstName: 'Test',
 		industry: 'DEF',
@@ -190,7 +204,7 @@ exports[`Debug renders with showHelpers 1`] = `
 		organisation: 'ft-org',
 		password: 'password123',
 		position: 'AS',
-		postCode: 'EC4M9BT',
+		postCode: billingPostcodeByCountry[COUNTRY_CODE],
 		primaryTelephone: '0987654321',
 		responsibility: 'ADL',
 		ukVisa: '4111111111111111',

--- a/components/billing-city.jsx
+++ b/components/billing-city.jsx
@@ -8,7 +8,7 @@ export function BillingCity ({
 	isDisabled = false,
 	isHidden = false,
 }) {
-	const BillingCityFieldClassNames = classNames([
+	const billingCityFieldClassNames = classNames([
 		'o-forms-field',
 		'ncf__validation-error',
 		{ ncf__hidden: isHidden },
@@ -24,7 +24,7 @@ export function BillingCity ({
 	return (
 		<label
 			id="billingCityField"
-			className={BillingCityFieldClassNames}
+			className={billingCityFieldClassNames}
 			data-validate="required"
 			htmlFor="billingCity"
 		>

--- a/components/billing-city.jsx
+++ b/components/billing-city.jsx
@@ -2,12 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export function BillingCity({
+export function BillingCity ({
 	hasError = false,
 	value = '',
 	isDisabled = false,
 	isHidden = false,
 }) {
+	const BillingCityFieldClassNames = classNames([
+		'o-forms-field',
+		'ncf__validation-error',
+		{ ncf__hidden: isHidden },
+	]);
+
 	const inputWrapperClassName = classNames([
 		'o-forms-input',
 		'o-forms-input--text',
@@ -18,7 +24,7 @@ export function BillingCity({
 	return (
 		<label
 			id="billingCityField"
-			className="o-forms-field ncf__validation-error"
+			className={BillingCityFieldClassNames}
 			data-validate="required"
 			htmlFor="billingCity"
 		>

--- a/components/debug.jsx
+++ b/components/debug.jsx
@@ -49,18 +49,25 @@ export function Debug({ isTest = false, showHelpers = false, links = {} }) {
 	// This env var gets set in production. We use this when creating email addresses in case any
 	// get into production so Membership know who to come to about deleting them.
 	var SYSTEM_CODE = document.documentElement.getAttribute('data-next-app') || 'n-conversion-forms';
+	var COUNTRY_CODE = window.FT && window.FT.country || 'GBR';
+
+	var billingPostcodeByCountry = {
+		GBR: 'EC4M9BT',
+		USA: '10028',
+		CAN: 'K0E 9Z9'
+	}
 
 	var debugData = {
 		billingCity: 'London',
-		billingCountry: 'GBR',
-		billingPostcode: 'EC4M9BT',
-		country: 'GBR',
+		billingCountry: COUNTRY_CODE,
+		billingPostcode: billingPostcodeByCountry[COUNTRY_CODE],
+		country: COUNTRY_CODE,
 		deliveryAddressLine1: 'delivery test1',
 		deliveryAddressLine2: 'delivery test2',
 		deliveryAddressLine3: 'delivery test3',
 		deliveryCity: 'delivery city',
 		deliveryCounty: 'delivery county',
-		deliveryPostcode: 'EC4M9BT',
+		deliveryPostcode: billingPostcodeByCountry[COUNTRY_CODE],
 		email: SYSTEM_CODE + '-' + Date.now() + '@ftqa.org',
 		firstName: 'Test',
 		industry: 'DEF',
@@ -69,7 +76,7 @@ export function Debug({ isTest = false, showHelpers = false, links = {} }) {
 		organisation: 'ft-org',
 		password: 'password123',
 		position: 'AS',
-		postCode: 'EC4M9BT',
+		postCode: billingPostcodeByCountry[COUNTRY_CODE],
 		primaryTelephone: '0987654321',
 		responsibility: 'ADL',
 		ukVisa: '4111111111111111',

--- a/components/debug.jsx
+++ b/components/debug.jsx
@@ -51,7 +51,7 @@ export function Debug({ isTest = false, showHelpers = false, links = {} }) {
 	var SYSTEM_CODE = document.documentElement.getAttribute('data-next-app') || 'n-conversion-forms';
 	var COUNTRY_CODE = window.FT && window.FT.country || 'GBR';
 
-	var billingPostcodeByCountry = {
+	var postcodeByCountry = {
 		GBR: 'EC4M9BT',
 		USA: '10028',
 		CAN: 'K0E 9Z9'
@@ -60,14 +60,14 @@ export function Debug({ isTest = false, showHelpers = false, links = {} }) {
 	var debugData = {
 		billingCity: 'London',
 		billingCountry: COUNTRY_CODE,
-		billingPostcode: billingPostcodeByCountry[COUNTRY_CODE],
+		billingPostcode: postcodeByCountry[COUNTRY_CODE],
 		country: COUNTRY_CODE,
 		deliveryAddressLine1: 'delivery test1',
 		deliveryAddressLine2: 'delivery test2',
 		deliveryAddressLine3: 'delivery test3',
 		deliveryCity: 'delivery city',
 		deliveryCounty: 'delivery county',
-		deliveryPostcode: billingPostcodeByCountry[COUNTRY_CODE],
+		deliveryPostcode: postcodeByCountry[COUNTRY_CODE],
 		email: SYSTEM_CODE + '-' + Date.now() + '@ftqa.org',
 		firstName: 'Test',
 		industry: 'DEF',
@@ -76,7 +76,7 @@ export function Debug({ isTest = false, showHelpers = false, links = {} }) {
 		organisation: 'ft-org',
 		password: 'password123',
 		position: 'AS',
-		postCode: billingPostcodeByCountry[COUNTRY_CODE],
+		postCode: postcodeByCountry[COUNTRY_CODE],
 		primaryTelephone: '0987654321',
 		responsibility: 'ADL',
 		ukVisa: '4111111111111111',


### PR DESCRIPTION
### Description
fix the billing postcode component to allow hide including its title label. Also include a modification on the debug bar to fill the form depending on the country

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-752

### Screenshots
When it need to be shown
![image](https://user-images.githubusercontent.com/48696369/112525185-646a8e80-8d7f-11eb-82b2-2b02d8292c8f.png)
When it need to be hidden
![image](https://user-images.githubusercontent.com/48696369/112525503-b6131900-8d7f-11eb-89e6-f0290e5e0f4f.png)
Before fix
![image](https://user-images.githubusercontent.com/48696369/112526222-77ca2980-8d80-11eb-90bb-c8a750faeb5e.png)


### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [x] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
