### PR TITLE
ACQ-867: Small css fixes and to redirect page in parent window

### DIFF
--- a/components/__snapshots__/google-sign-in.spec.js.snap
+++ b/components/__snapshots__/google-sign-in.spec.js.snap
@@ -4,6 +4,7 @@ exports[`GoogleSignIn renders with default props 1`] = `
 <link href="https://fonts.googleapis.com/css?family=Roboto"
       rel="stylesheet"
 >
+<base target="_parent">
 <a class="google_button"
    href="https://www.ft.com"
 >

--- a/components/google-sign-in.jsx
+++ b/components/google-sign-in.jsx
@@ -6,6 +6,7 @@ export function GoogleSignIn({ signInRedirectUrl }) {
 	return (
 		<>
 			<link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet"></link>
+			<base target="_parent" />
 			<a className="google_button" href={signInRedirectUrl}>Sign in with Google</a>
 		</>
 	);

--- a/styles/google-sign-in.scss
+++ b/styles/google-sign-in.scss
@@ -8,8 +8,8 @@
 		font-size: 14px;
 		font-family: Roboto;
 		text-decoration: none;
-		padding-top: 5px;
-		padding-bottom: 5px;
+		padding-top: 10px;
+		padding-bottom: 10px;
 		font-weight: 500;
 		letter-spacing: 0.21px;
 		border-radius: 5px;


### PR DESCRIPTION
### Description
Testing Google registration flow for ACQ-867 I noticed we need some small fixes on the google widget (sign-in button).
- A small fix on padding spaces
- To redirect page but in parent window, because the button is included in an iframe.

### Ticket
- Original: https://financialtimes.atlassian.net/browse/ACQ-866
- Current implementation: https://financialtimes.atlassian.net/browse/ACQ-867

### Screenshots

![image](https://user-images.githubusercontent.com/13876273/113262968-827d4500-92d1-11eb-8248-c10626232337.png)

| Before | After |
| ------ | ----- |
|  https://user-images.githubusercontent.com/13876273/113262805-506be300-92d1-11eb-9a7f-f941ad7145fe.mov  |  https://user-images.githubusercontent.com/13876273/113262846-5cf03b80-92d1-11eb-84d2-8e6393ad9087.mov  |

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
