### PR TITLE
[ACQ-885] White-label design implementation

### DIFF
--- a/components/industry.jsx
+++ b/components/industry.jsx
@@ -21,13 +21,18 @@ export function Industry({
 		{ 'o-forms-input--invalid': hasError },
 	]);
 
+	const fieldTitleClassName = classNames([
+		'o-forms-title',
+		{ 'o-forms-field--optional': !isRequired }
+	]);
+
 	return (
 		<label
 			id={fieldId}
 			className="o-forms-field ncf__validation-error"
 			htmlFor={selectId}
 		>
-			<span className="o-forms-title">
+			<span className={fieldTitleClassName}>
 				<span className="o-forms-title__main">{fieldLabel}</span>
 			</span>
 			<span className={inpiutWrapperClassName}>

--- a/components/industry.spec.js
+++ b/components/industry.spec.js
@@ -83,4 +83,11 @@ describe('Industry', () => {
 
 		expect(component.find('.o-forms-title__main').text()).toEqual('Industry');
 	});
+
+	it('renders with optional title class, when not required', () => {
+		const props = { isRequired: false };
+		const component = mount(Industry(props));
+
+		expect(component.find('.o-forms-title.o-forms-field--optional').length).toEqual(1);
+	});
 });

--- a/components/job-title.jsx
+++ b/components/job-title.jsx
@@ -9,11 +9,17 @@ export function JobTitle({
 	fieldId = 'jobTitleField',
 	inputId = 'jobTitle',
 	inputName = 'jobTitle',
+	isRequired = true,
 }) {
 	const inputWrapperClassName = classNames([
 		'o-forms-input',
 		'o-forms-input--text',
 		{ 'o-forms-input--invalid': hasError },
+	]);
+
+	const fieldTitleClassName = classNames([
+		'o-forms-title',
+		{ 'o-forms-field--optional': !isRequired }
 	]);
 
 	return (
@@ -23,7 +29,7 @@ export function JobTitle({
 			data-validate="required"
 			htmlFor={inputId}
 		>
-			<span className="o-forms-title">
+			<span className={fieldTitleClassName}>
 				<span className="o-forms-title__main">Job title</span>
 			</span>
 			<span className={inputWrapperClassName}>
@@ -34,8 +40,8 @@ export function JobTitle({
 					placeholder="Enter your job title"
 					autoComplete="organization-title"
 					data-trackable="job-title"
-					aria-required="true"
-					required
+					aria-required={isRequired}
+					required={isRequired}
 					disabled={isDisabled}
 					defaultValue={value}
 				/>

--- a/components/job-title.spec.js
+++ b/components/job-title.spec.js
@@ -58,4 +58,11 @@ describe('JobTitle', () => {
 
 		expect(field.exists()).toBe(true);
 	});
+
+	it('renders with optional title class, when not required', () => {
+		const props = { isRequired: false };
+		const component = mount(JobTitle(props));
+
+		expect(component.find('.o-forms-title.o-forms-field--optional').length).toEqual(1);
+	});
 });

--- a/components/phone.jsx
+++ b/components/phone.jsx
@@ -6,6 +6,7 @@ export function Phone({
 	hasError = false,
 	isB2b = false,
 	isDisabled = false,
+	isRequired = true,
 	value = '',
 	pattern = '',
 	fieldId = 'primaryTelephoneField',
@@ -23,6 +24,11 @@ export function Phone({
 		{ 'o-forms-input--invalid': hasError },
 	]);
 
+	const fieldTitleClassName = classNames([
+		'o-forms-title',
+		{ 'o-forms-field--optional': !isRequired }
+	]);
+
 	return (
 		<label
 			id={fieldId}
@@ -30,7 +36,7 @@ export function Phone({
 			className="o-forms-field ncf__validation-error"
 			data-validate="required,number"
 		>
-			<span className="o-forms-title">
+			<span className={fieldTitleClassName}>
 				<span className="o-forms-title__main">{labelText}</span>
 				<span className="o-forms-title__prompt">
 					5 to 15 characters (numbers only)
@@ -47,8 +53,8 @@ export function Phone({
 					maxLength="15"
 					data-trackable={dataTrackable}
 					aria-describedby={descriptionId}
-					aria-required="true"
-					required
+					aria-required={isRequired}
+					required={isRequired}
 					pattern={pattern}
 					disabled={isDisabled}
 					defaultValue={value}

--- a/components/phone.spec.js
+++ b/components/phone.spec.js
@@ -1,3 +1,4 @@
+import { mount } from 'enzyme';
 import { Phone } from './index';
 import { expectToRenderCorrectly } from '../test-jest/helpers/expect-to-render-correctly';
 
@@ -47,5 +48,12 @@ describe('Phone', () => {
 		};
 
 		expect(Phone).toRenderCorrectly(props);
+	});
+
+	it('renders with optional title class, when not required', () => {
+		const props = { isRequired: false };
+		const component = mount(Phone(props));
+
+		expect(component.find('.o-forms-title.o-forms-field--optional').length).toEqual(1);
 	});
 });

--- a/components/position.jsx
+++ b/components/position.jsx
@@ -21,6 +21,11 @@ export function Position({
 		{ 'o-forms-input--invalid': hasError },
 	]);
 
+	const fieldTitleClassName = classNames([
+		'o-forms-title',
+		{ 'o-forms-field--optional': !isRequired }
+	]);
+
 	return (
 		<label
 			id={fieldId}
@@ -28,7 +33,7 @@ export function Position({
 			data-validate={isRequired ? 'required' : ''}
 			htmlFor={selectId}
 		>
-			<span className="o-forms-title">
+			<span className={fieldTitleClassName}>
 				<span className="o-forms-title__main">{fieldLabel}</span>
 			</span>
 			<span className={inputWrapperClassNames}>

--- a/components/position.spec.js
+++ b/components/position.spec.js
@@ -59,4 +59,11 @@ describe('Position', () => {
 		const select = component.find('select#selectId');
 		expect(select.exists()).toBe(true);
 	});
+
+	it('renders with optional title class, when not required', () => {
+		const props = { isRequired: false };
+		const component = mount(Position(props));
+
+		expect(component.find('.o-forms-title.o-forms-field--optional').length).toEqual(1);
+	});
 });

--- a/components/responsibility.jsx
+++ b/components/responsibility.jsx
@@ -7,16 +7,23 @@ const defaultOptions = demographics.responsibilities.responsibilities;
 export function Responsibility({
 	value,
 	isDisabled = false,
+	isRequired = true,
 	hasError = false,
 	fieldId = 'responsibilityField',
 	selectId = 'responsibility',
 	selectName = 'responsibility',
 	options = defaultOptions,
+	fieldLabel = 'Which best describes your job responsibility?',
 }) {
 	const inputWrapperClassName = classNames([
 		'o-forms-input',
 		'o-forms-input--select',
 		{ 'o-forms-input--invalid': hasError },
+	]);
+
+	const fieldTitleClassName = classNames([
+		'o-forms-title',
+		{ 'o-forms-field--optional': !isRequired }
 	]);
 
 	return (
@@ -26,9 +33,9 @@ export function Responsibility({
 			data-validate="required"
 			htmlFor={selectId}
 		>
-			<span className="o-forms-title">
+			<span className={fieldTitleClassName}>
 				<span className="o-forms-title__main">
-					Which best describes your job responsibility?
+					{fieldLabel}
 				</span>
 			</span>
 
@@ -37,8 +44,8 @@ export function Responsibility({
 					id={selectId}
 					name={selectName}
 					data-trackable="responsibility"
-					aria-required="true"
-					required
+					aria-required={isRequired}
+					required={isRequired}
 					disabled={isDisabled}
 					defaultValue={value}
 				>

--- a/components/responsibility.spec.js
+++ b/components/responsibility.spec.js
@@ -65,4 +65,11 @@ describe('Responsibility', () => {
 
 		expect(field.exists()).toBe(true);
 	});
+
+	it('renders with optional title class, when not required', () => {
+		const props = { isRequired: false };
+		const component = mount(Responsibility(props));
+
+		expect(component.find('.o-forms-title.o-forms-field--optional').length).toEqual(1);
+	});
 });


### PR DESCRIPTION
### Description
Working on a `whilte-label` registration form, required some of the existing registration components to allow for dynamic `required` state property.

Changed components:
* `Industry` component's title now has the `optional` additional class
* `JobTitle` has `isRequired` property and `optional` title class
* `Phone` has `isRequired` property and `optional` title class
* `Positon` has an additional `optional` title class
* `Resposnbility` has `isRequired` and `fieldLabel` and `optional` title class

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-885
