### PR TITLE
Add introText property to PackageChange

### DIFF
--- a/components/__snapshots__/package-change.spec.js.snap
+++ b/components/__snapshots__/package-change.spec.js.snap
@@ -3,12 +3,14 @@
 exports[`PackageChange annual render with defaults 1`] = `
 <div class="ncf__package-change">
   <div class="ncf__package-change__package">
-    <p class="ncf__package-change__content">
-      You have chosen
-      <span class="ncf__strong">
-        Trial
-      </span>
-    </p>
+    <div class="ncf__package-change__content">
+      <p>
+        You have chosen
+        <span class="ncf__strong">
+          Trial
+        </span>
+      </p>
+    </div>
     <div class="ncf__package-change__actions">
       <a href="https://www.ft.com"
          class="ncf__button ncf__button--mono ncf__button--baseline"
@@ -24,12 +26,14 @@ exports[`PackageChange annual render with defaults 1`] = `
 exports[`PackageChange annual render with discount 1`] = `
 <div class="ncf__package-change">
   <div class="ncf__package-change__package">
-    <p class="ncf__package-change__content">
-      You have chosen
-      <span class="ncf__strong">
-        Trial
-      </span>
-    </p>
+    <div class="ncf__package-change__content">
+      <p>
+        You have chosen
+        <span class="ncf__strong">
+          Trial
+        </span>
+      </p>
+    </div>
     <div class="ncf__package-change__actions">
       <a href="https://www.ft.com"
          class="ncf__button ncf__button--mono ncf__button--baseline"
@@ -45,12 +49,14 @@ exports[`PackageChange annual render with discount 1`] = `
 exports[`PackageChange annual render with trialPrice 1`] = `
 <div class="ncf__package-change">
   <div class="ncf__package-change__package">
-    <p class="ncf__package-change__content">
-      You have chosen
-      <span class="ncf__strong">
-        Trial
-      </span>
-    </p>
+    <div class="ncf__package-change__content">
+      <p>
+        You have chosen
+        <span class="ncf__strong">
+          Trial
+        </span>
+      </p>
+    </div>
     <div class="ncf__package-change__actions">
       <a href="https://www.ft.com"
          class="ncf__button ncf__button--mono ncf__button--baseline"
@@ -66,12 +72,14 @@ exports[`PackageChange annual render with trialPrice 1`] = `
 exports[`PackageChange render with defaults 1`] = `
 <div class="ncf__package-change">
   <div class="ncf__package-change__package">
-    <p class="ncf__package-change__content">
-      You have chosen
-      <span class="ncf__strong">
-        Trial
-      </span>
-    </p>
+    <div class="ncf__package-change__content">
+      <p>
+        You have chosen
+        <span class="ncf__strong">
+          Trial
+        </span>
+      </p>
+    </div>
     <div class="ncf__package-change__actions">
       <a href="https://www.ft.com"
          class="ncf__button ncf__button--mono ncf__button--baseline"
@@ -87,12 +95,17 @@ exports[`PackageChange render with defaults 1`] = `
 exports[`PackageChange renders with subtext 1`] = `
 <div class="ncf__package-change">
   <div class="ncf__package-change__package">
-    <p class="ncf__package-change__content">
-      You have chosen
-      <span class="ncf__strong">
-        Trial
-      </span>
-    </p>
+    <div class="ncf__package-change__content">
+      <p>
+        You have chosen
+        <span class="ncf__strong">
+          Trial
+        </span>
+      </p>
+      <p class="ncf__package-change__content__subtext">
+        Personalised email briefings and alerts
+      </p>
+    </div>
     <div class="ncf__package-change__actions">
       <a href="https://www.ft.com"
          class="ncf__button ncf__button--mono ncf__button--baseline"
@@ -102,8 +115,5 @@ exports[`PackageChange renders with subtext 1`] = `
       </a>
     </div>
   </div>
-  <p class="ncf__package-change__subtext">
-    Personalised email briefings and alerts
-  </p>
 </div>
 `;

--- a/components/__snapshots__/package-change.spec.js.snap
+++ b/components/__snapshots__/package-change.spec.js.snap
@@ -92,7 +92,7 @@ exports[`PackageChange render with defaults 1`] = `
 </div>
 `;
 
-exports[`PackageChange renders with introtext 1`] = `
+exports[`PackageChange renders with description 1`] = `
 <div class="ncf__package-change">
   <div class="ncf__package-change__package">
     <div class="ncf__package-change__content">
@@ -102,7 +102,7 @@ exports[`PackageChange renders with introtext 1`] = `
           Trial
         </span>
       </p>
-      <p class="ncf__package-change__content__introtext">
+      <p class="ncf__package-change__content__description">
         Personalised email briefings and alerts
       </p>
     </div>

--- a/components/__snapshots__/package-change.spec.js.snap
+++ b/components/__snapshots__/package-change.spec.js.snap
@@ -83,3 +83,27 @@ exports[`PackageChange render with defaults 1`] = `
   </div>
 </div>
 `;
+
+exports[`PackageChange renders with subtext 1`] = `
+<div class="ncf__package-change">
+  <div class="ncf__package-change__package">
+    <p class="ncf__package-change__content">
+      You have chosen
+      <span class="ncf__strong">
+        Trial
+      </span>
+    </p>
+    <div class="ncf__package-change__actions">
+      <a href="https://www.ft.com"
+         class="ncf__button ncf__button--mono ncf__button--baseline"
+         data-trackable="change"
+      >
+        Change
+      </a>
+    </div>
+  </div>
+  <div class="ncf__package-change__subtext">
+    Personalised email briefings and alerts
+  </div>
+</div>
+`;

--- a/components/__snapshots__/package-change.spec.js.snap
+++ b/components/__snapshots__/package-change.spec.js.snap
@@ -102,8 +102,8 @@ exports[`PackageChange renders with subtext 1`] = `
       </a>
     </div>
   </div>
-  <div class="ncf__package-change__subtext">
+  <p class="ncf__package-change__subtext">
     Personalised email briefings and alerts
-  </div>
+  </p>
 </div>
 `;

--- a/components/__snapshots__/package-change.spec.js.snap
+++ b/components/__snapshots__/package-change.spec.js.snap
@@ -92,7 +92,7 @@ exports[`PackageChange render with defaults 1`] = `
 </div>
 `;
 
-exports[`PackageChange renders with subtext 1`] = `
+exports[`PackageChange renders with introtext 1`] = `
 <div class="ncf__package-change">
   <div class="ncf__package-change__package">
     <div class="ncf__package-change__content">
@@ -102,7 +102,7 @@ exports[`PackageChange renders with subtext 1`] = `
           Trial
         </span>
       </p>
-      <p class="ncf__package-change__content__subtext">
+      <p class="ncf__package-change__content__introtext">
         Personalised email briefings and alerts
       </p>
     </div>

--- a/components/package-change.jsx
+++ b/components/package-change.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export function PackageChange({ changePackageUrl, currentPackage, introText }) {
+export function PackageChange({ changePackageUrl, currentPackage, packageDescription }) {
 	return (
 		<div className="ncf__package-change">
 			<div className="ncf__package-change__package">
@@ -9,7 +9,7 @@ export function PackageChange({ changePackageUrl, currentPackage, introText }) {
 					<p>
 						You have chosen <span className="ncf__strong">{currentPackage}</span>
 					</p>
-					{introText && <p className="ncf__package-change__content__introtext">{introText}</p>}
+					{packageDescription && <p className="ncf__package-change__content__description">{packageDescription}</p>}
 				</div>	
 				<div className="ncf__package-change__actions">
 					<a
@@ -28,5 +28,5 @@ export function PackageChange({ changePackageUrl, currentPackage, introText }) {
 PackageChange.propTypes = {
 	changePackageUrl: PropTypes.string.isRequired,
 	currentPackage: PropTypes.string.isRequired,
-	introText: PropTypes.string,
+	packageDescription: PropTypes.string,
 };

--- a/components/package-change.jsx
+++ b/components/package-change.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export function PackageChange({ changePackageUrl, currentPackage }) {
+export function PackageChange({ changePackageUrl, currentPackage, subText }) {
 	return (
 		<div className="ncf__package-change">
 			<div className="ncf__package-change__package">
@@ -18,6 +18,7 @@ export function PackageChange({ changePackageUrl, currentPackage }) {
 					</a>
 				</div>
 			</div>
+			{subText && <p className="ncf__package-change__subtext">{subText}</p>}
 		</div>
 	);
 }

--- a/components/package-change.jsx
+++ b/components/package-change.jsx
@@ -5,9 +5,12 @@ export function PackageChange({ changePackageUrl, currentPackage, subText }) {
 	return (
 		<div className="ncf__package-change">
 			<div className="ncf__package-change__package">
-				<p className="ncf__package-change__content">
-					You have chosen <span className="ncf__strong">{currentPackage}</span>
-				</p>
+				<div className="ncf__package-change__content">
+					<p>
+						You have chosen <span className="ncf__strong">{currentPackage}</span>
+					</p>
+					{subText && <p className="ncf__package-change__content__subtext">{subText}</p>}
+				</div>	
 				<div className="ncf__package-change__actions">
 					<a
 						href={changePackageUrl}
@@ -18,7 +21,6 @@ export function PackageChange({ changePackageUrl, currentPackage, subText }) {
 					</a>
 				</div>
 			</div>
-			{subText && <p className="ncf__package-change__subtext">{subText}</p>}
 		</div>
 	);
 }
@@ -26,4 +28,5 @@ export function PackageChange({ changePackageUrl, currentPackage, subText }) {
 PackageChange.propTypes = {
 	changePackageUrl: PropTypes.string.isRequired,
 	currentPackage: PropTypes.string.isRequired,
+	subText: PropTypes.string,
 };

--- a/components/package-change.jsx
+++ b/components/package-change.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export function PackageChange({ changePackageUrl, currentPackage, subText }) {
+export function PackageChange({ changePackageUrl, currentPackage, introText }) {
 	return (
 		<div className="ncf__package-change">
 			<div className="ncf__package-change__package">
@@ -9,7 +9,7 @@ export function PackageChange({ changePackageUrl, currentPackage, subText }) {
 					<p>
 						You have chosen <span className="ncf__strong">{currentPackage}</span>
 					</p>
-					{subText && <p className="ncf__package-change__content__subtext">{subText}</p>}
+					{introText && <p className="ncf__package-change__content__introtext">{introText}</p>}
 				</div>	
 				<div className="ncf__package-change__actions">
 					<a
@@ -28,5 +28,5 @@ export function PackageChange({ changePackageUrl, currentPackage, subText }) {
 PackageChange.propTypes = {
 	changePackageUrl: PropTypes.string.isRequired,
 	currentPackage: PropTypes.string.isRequired,
-	subText: PropTypes.string,
+	introText: PropTypes.string,
 };

--- a/components/package-change.spec.js
+++ b/components/package-change.spec.js
@@ -13,11 +13,11 @@ describe('PackageChange', () => {
 		expect(PackageChange).toRenderCorrectly(props);
 	});
 
-	it('renders with introtext', () => {
+	it('renders with description', () => {
 		const props = {
 			changePackageUrl: 'https://www.ft.com',
 			currentPackage: 'Trial',
-			introText: 'Personalised email briefings and alerts',
+			packageDescription: 'Personalised email briefings and alerts',
 		};
 
 		expect(PackageChange).toRenderCorrectly(props);

--- a/components/package-change.spec.js
+++ b/components/package-change.spec.js
@@ -13,6 +13,16 @@ describe('PackageChange', () => {
 		expect(PackageChange).toRenderCorrectly(props);
 	});
 
+	it('renders with subtext', () => {
+		const props = {
+			changePackageUrl: 'https://www.ft.com',
+			currentPackage: 'Trial',
+			subText: 'Personalised email briefings and alerts',
+		};
+
+		expect(PackageChange).toRenderCorrectly(props);
+	});
+
 	['annual'].forEach((term) => {
 		describe(`${term}`, () => {
 			it('render with defaults', () => {

--- a/components/package-change.spec.js
+++ b/components/package-change.spec.js
@@ -13,11 +13,11 @@ describe('PackageChange', () => {
 		expect(PackageChange).toRenderCorrectly(props);
 	});
 
-	it('renders with subtext', () => {
+	it('renders with introtext', () => {
 		const props = {
 			changePackageUrl: 'https://www.ft.com',
 			currentPackage: 'Trial',
-			subText: 'Personalised email briefings and alerts',
+			introText: 'Personalised email briefings and alerts',
 		};
 
 		expect(PackageChange).toRenderCorrectly(props);

--- a/components/package-change.stories.js
+++ b/components/package-change.stories.js
@@ -10,4 +10,5 @@ export const Basic = (args) => <PackageChange {...args} />;
 Basic.args = {
 	currentPackage: 'Premium Digital',
 	changePackageUrl: 'https://ft.com/products',
+	subText: 'Personalised email briefings and alerts',
 };

--- a/components/package-change.stories.js
+++ b/components/package-change.stories.js
@@ -10,5 +10,11 @@ export const Basic = (args) => <PackageChange {...args} />;
 Basic.args = {
 	currentPackage: 'Premium Digital',
 	changePackageUrl: 'https://ft.com/products',
+};
+
+export const WithIntroText = (args) => <PackageChange {...args} />;
+WithIntroText.args = {
+	currentPackage: 'Premium Digital',
+	changePackageUrl: 'https://ft.com/products',
 	introText: 'Personalised email briefings and alerts',
 };

--- a/components/package-change.stories.js
+++ b/components/package-change.stories.js
@@ -12,9 +12,9 @@ Basic.args = {
 	changePackageUrl: 'https://ft.com/products',
 };
 
-export const WithIntroText = (args) => <PackageChange {...args} />;
-WithIntroText.args = {
+export const WithPackageDescription = (args) => <PackageChange {...args} />;
+WithPackageDescription.args = {
 	currentPackage: 'Premium Digital',
 	changePackageUrl: 'https://ft.com/products',
-	introText: 'Personalised email briefings and alerts',
+	packageDescription: 'Personalised email briefings and alerts',
 };

--- a/components/package-change.stories.js
+++ b/components/package-change.stories.js
@@ -10,5 +10,5 @@ export const Basic = (args) => <PackageChange {...args} />;
 Basic.args = {
 	currentPackage: 'Premium Digital',
 	changePackageUrl: 'https://ft.com/products',
-	subText: 'Personalised email briefings and alerts',
+	introText: 'Personalised email briefings and alerts',
 };

--- a/styles/package-change.scss
+++ b/styles/package-change.scss
@@ -20,7 +20,7 @@
 				margin: 0.5em 0;
 			}
 
-			&__introtext {
+			&__description {
 				@include oTypographySans($scale: -1);
 			}
 		}

--- a/styles/package-change.scss
+++ b/styles/package-change.scss
@@ -20,7 +20,7 @@
 				margin: 0.5em 0;
 			}
 
-			&__subtext {
+			&__introtext {
 				@include oTypographySans($scale: -1);
 			}
 		}

--- a/styles/package-change.scss
+++ b/styles/package-change.scss
@@ -13,10 +13,16 @@
 			align-items: center;
 		}
 
-		&__subtext {
-			@include oTypographySans($scale: -1);
-			margin: 0;
-			padding-bottom: 1em;
+		&__content {
+			padding: 0.5em 0;
+
+			p {
+				margin: 0.5em 0;
+			}
+
+			&__subtext {
+				@include oTypographySans($scale: -1);
+			}
 		}
 	}
 }

--- a/styles/package-change.scss
+++ b/styles/package-change.scss
@@ -12,5 +12,11 @@
 			grid-template-columns: 1fr min-content;
 			align-items: center;
 		}
+
+		&__subtext {
+			@include oTypographySans($scale: -1);
+			margin: 0;
+			padding-bottom: 1em;
+		}
 	}
 }


### PR DESCRIPTION
### Description
Added optional prop `introText` to PackageChange. If present, it'll render it as secondary text below the package name.

### Ticket
https://financialtimes.atlassian.net/browse/UG-431

### Screenshots

| Before | After |
| ------ | ----- |
|<img width="649" alt="before" src="https://user-images.githubusercontent.com/7011304/114195893-c95de100-9948-11eb-9978-eb23e9ef1e4f.png">|<img width="676" alt="after" src="https://user-images.githubusercontent.com/7011304/114195978-d8449380-9948-11eb-9cd8-f914224d447f.png">|

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Tests** written for new or updated for existing functionality
- [x] **Stories** updated to use this change
- [x] **Product Review** ran past the product owner
