### PR TITLE
ACQ-925: Adding isEpaper property to filter (avoid) Trial Premium title.

### DIFF
--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -10,6 +10,7 @@ export function PaymentTerm({
 	fieldId = 'paymentTermField',
 	inputName = 'paymentTerm',
 	isPrintOrBundle = false,
+	isEpaper = false,
 	options = [],
 	isFixedTermOffer = false,
 	subscriptionDuration,
@@ -104,7 +105,7 @@ export function PaymentTerm({
 				'o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input',
 			...(option.selected && { defaultChecked: true }),
 		};
-		const showTrialCopyInTitle = option.isTrial && !isPrintOrBundle;
+		const showTrialCopyInTitle = option.isTrial && !isPrintOrBundle && !isEpaper;
 		const createDiscount = () => {
 			return (
 				option.discount && (
@@ -198,6 +199,7 @@ PaymentTerm.propTypes = {
 	fieldId: PropTypes.string,
 	inputName: PropTypes.string,
 	isPrintOrBundle: PropTypes.bool,
+	isEpaper: PropTypes.bool,
 	options: PropTypes.arrayOf(
 		PropTypes.shape({
 			discount: PropTypes.string,


### PR DESCRIPTION
### Description
This is a quick fix (but not elegant from my point of view) in order to unblock go live today with an “ePaper 3 month intro offer global” offer today.

Complete discussion: https://financialtimes.slack.com/archives/CSVRXFV6F/p1618415641326700

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-925

### Screenshots

| Before | After |
| ------ | ----- |
| ![Screenshot 2021-04-15 at 10 01 07](https://user-images.githubusercontent.com/13876273/114837096-9f3a7200-9dd3-11eb-9b49-b9aa9e13e792.png) | ![Screenshot 2021-04-15 at 10 01 23](https://user-images.githubusercontent.com/13876273/114837116-a792ad00-9dd3-11eb-8d75-c2e5e0dc5b11.png) |

