### PR TITLE
ACC-1037 Added id to "Delivery start date" title span

### DIFF
--- a/components/__snapshots__/delivery-start-date.spec.js.snap
+++ b/components/__snapshots__/delivery-start-date.spec.js.snap
@@ -7,7 +7,9 @@ exports[`DeliveryStartDate renders with a custom date 1`] = `
        for="deliveryStartDate"
 >
   <span class="o-forms-title">
-    <span class="o-forms-title__main">
+    <span class="o-forms-title__main"
+          id="start-date-picker-title-span"
+    >
       Delivery start date
     </span>
     <span class="o-forms-title__prompt">
@@ -46,7 +48,9 @@ exports[`DeliveryStartDate renders with a custom input max value 1`] = `
        for="deliveryStartDate"
 >
   <span class="o-forms-title">
-    <span class="o-forms-title__main">
+    <span class="o-forms-title__main"
+          id="start-date-picker-title-span"
+    >
       Delivery start date
     </span>
     <span class="o-forms-title__prompt">
@@ -85,7 +89,9 @@ exports[`DeliveryStartDate renders with a custom input min value 1`] = `
        for="deliveryStartDate"
 >
   <span class="o-forms-title">
-    <span class="o-forms-title__main">
+    <span class="o-forms-title__main"
+          id="start-date-picker-title-span"
+    >
       Delivery start date
     </span>
     <span class="o-forms-title__prompt">
@@ -124,7 +130,9 @@ exports[`DeliveryStartDate renders with a custom input value 1`] = `
        for="deliveryStartDate"
 >
   <span class="o-forms-title">
-    <span class="o-forms-title__main">
+    <span class="o-forms-title__main"
+          id="start-date-picker-title-span"
+    >
       Delivery start date
     </span>
     <span class="o-forms-title__prompt">
@@ -162,7 +170,9 @@ exports[`DeliveryStartDate renders with a disabled input 1`] = `
        for="deliveryStartDate"
 >
   <span class="o-forms-title">
-    <span class="o-forms-title__main">
+    <span class="o-forms-title__main"
+          id="start-date-picker-title-span"
+    >
       Delivery start date
     </span>
     <span class="o-forms-title__prompt">
@@ -201,7 +211,9 @@ exports[`DeliveryStartDate renders with an error 1`] = `
        for="deliveryStartDate"
 >
   <span class="o-forms-title">
-    <span class="o-forms-title__main">
+    <span class="o-forms-title__main"
+          id="start-date-picker-title-span"
+    >
       Delivery start date
     </span>
     <span class="o-forms-title__prompt">
@@ -239,7 +251,9 @@ exports[`DeliveryStartDate renders with appropriate start description example wh
        for="deliveryStartDate"
 >
   <span class="o-forms-title">
-    <span class="o-forms-title__main">
+    <span class="o-forms-title__main"
+          id="start-date-picker-title-span"
+    >
       Delivery start date
     </span>
     <span class="o-forms-title__prompt">
@@ -277,7 +291,9 @@ exports[`DeliveryStartDate renders with appropriate start message when isAddress
        for="deliveryStartDate"
 >
   <span class="o-forms-title">
-    <span class="o-forms-title__main">
+    <span class="o-forms-title__main"
+          id="start-date-picker-title-span"
+    >
       Delivery start date
     </span>
     <span class="o-forms-title__prompt">
@@ -315,7 +331,9 @@ exports[`DeliveryStartDate renders with country different than default 1`] = `
        for="deliveryStartDate"
 >
   <span class="o-forms-title">
-    <span class="o-forms-title__main">
+    <span class="o-forms-title__main"
+          id="start-date-picker-title-span"
+    >
       Delivery start date
     </span>
     <span class="o-forms-title__prompt">
@@ -350,7 +368,9 @@ exports[`DeliveryStartDate renders with default props 1`] = `
        for="deliveryStartDate"
 >
   <span class="o-forms-title">
-    <span class="o-forms-title__main">
+    <span class="o-forms-title__main"
+          id="start-date-picker-title-span"
+    >
       Delivery start date
     </span>
     <span class="o-forms-title__prompt">

--- a/components/delivery-start-date.jsx
+++ b/components/delivery-start-date.jsx
@@ -54,7 +54,7 @@ export function DeliveryStartDate ({
 			htmlFor={inputProps.id}
 		>
 			<span className="o-forms-title">
-				<span className="o-forms-title__main">Delivery start date</span>
+				<span className="o-forms-title__main" id="start-date-picker-title-span">Delivery start date</span>
 				<span className="o-forms-title__prompt">
 					Earliest available delivery date: {date}
 				</span>

--- a/test/utils/delivery-start-date.spec.js
+++ b/test/utils/delivery-start-date.spec.js
@@ -10,9 +10,10 @@ describe('DeliveryStartDate', () => {
 	let startDateContainer;
 	let startDateFieldStub;
 	let startDateTextStub;
+	let dateTestInput;
 
 	beforeEach(() => {
-		document = { querySelector: sandbox.stub().returns(false) };
+		document = { querySelector: sandbox.stub().returns(false), createElement: sandbox.stub().returns(false) };
 
 		startDateContainer = {
 			classList: { add: sandbox.stub(), remove: sandbox.stub() },
@@ -33,6 +34,12 @@ describe('DeliveryStartDate', () => {
 		document.querySelector
 			.withArgs('.js-start-date-text')
 			.returns(startDateTextStub);
+
+		dateTestInput = {
+			setAttribute: sandbox.stub(),
+		};
+
+		document.createElement.withArgs('input').returns(dateTestInput);
 	});
 
 	afterEach(() => {

--- a/utils/delivery-start-date.js
+++ b/utils/delivery-start-date.js
@@ -27,6 +27,26 @@ class DeliveryStartDate {
 				'Please include the delivery start date partial on the page.'
 			);
 		}
+
+		// We need to see if browser supports date field and offer correct format
+		// to use if datepicker isn't available
+		// from https://stackoverflow.com/questions/10193294/how-can-i-tell-if-a-browser-supports-input-type-date
+
+		this.$deliveryStartDateTitleSpan = element.querySelector('#start-date-picker-title-span');
+
+		const checkDateInput = () => {
+			let input = element.createElement('input');
+			input.setAttribute('type', 'date');
+
+			let notADateValue = 'not-a-date';
+			input.setAttribute('value', notADateValue);
+
+			return input.value !== notADateValue;
+		};
+
+		if (checkDateInput() === false) {
+			this.$deliveryStartDateTitleSpan.innerHTML += ' (YYYY-MM-DD)';
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Description
Not all browsers support `input type=date`. One of those is Safari. It looks like it's in the works - the preview version does have it. But meanwhile users on Safari are left wondering what date format to use.

This PR adds an ID to the Start Date picker *title* so that we can access the title and update it to read "Delivery start date (YYYY-MM-DD)" on browsers that don't support `date` input type. 

This has already been done for Adding Suspension as that uses a custom date picker - see here for implementation details. https://github.com/Financial-Times/next-profile/pull/594. 

This PR also plugs the checking functionality into utils so that the users across all repos benefit from explicit format prompt if needed. 

### Ticket
https://financialtimes.atlassian.net/browse/ACC-1037

### Screenshots
This PR does not implement visible changes. 

