### PR TITLE
fix payment icons path for paypal and direct debit

### DIFF
--- a/styles/payment-type.scss
+++ b/styles/payment-type.scss
@@ -40,12 +40,12 @@
 			// #2
 			[type='radio'] + .o-forms-input__label {
 				@include buttonImageOverriding();
-				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2Fassets%2Fthird-party%2Fpp-logo-100px.png?width=300&source=next&fit=scale-down);
+				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fthird-party%2Fpp-logo-100px.png?width=300&source=next&fit=scale-down);
 			}
 
 			[type='radio']:checked + .o-forms-input__label {
 				@include buttonImageOverriding();
-				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2Fassets%2Fthird-party%2Fpp-logo-white.png?width=300&source=next&fit=scale-down);
+				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fthird-party%2Fpp-logo-white.png?width=300&source=next&fit=scale-down);
 			}
 		}
 
@@ -53,12 +53,12 @@
 			// #2
 			[type='radio'] + .o-forms-input__label {
 				@include buttonImageOverriding();
-				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2Fassets%2Fthird-party%2Fdirect_debit.png?width=300&source=next&fit=scale-down);
+				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fthird-party%2Fdirect_debit.png?width=300&source=next&fit=scale-down);
 			}
 
 			[type='radio']:checked + .o-forms-input__label {
 				@include buttonImageOverriding();
-				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2Fassets%2Fthird-party%2Fdirect_debit-white.png?width=300&source=next&fit=scale-down);
+				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fthird-party%2Fdirect_debit-white.png?width=300&source=next&fit=scale-down);
 			}
 		}
 	}


### PR DESCRIPTION
### Description
Icons for payment buttons, started to dissapear randomly, the path for them was checked via https://www.ft.com/__origami/service/image/v2/docs/url-builder and we conclude that needed to be modified as follow:

https://www.ft.com/assets/third-party/****** --> https://www.ft.com/__assets/creatives/third-party/******

### Screenshots
![image](https://user-images.githubusercontent.com/48696369/117150802-dc6ca100-ad8e-11eb-8325-8a4a6c3e777b.png) 

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
