### PR TITLE
NOPS-823 Fix location of Emmanuel Macron image

### DIFF
--- a/components/__snapshots__/trial-banner.spec.js.snap
+++ b/components/__snapshots__/trial-banner.spec.js.snap
@@ -6,7 +6,7 @@ exports[`TrialBanner renders with default props 1`] = `
 >
   <p class="ncf__trial-banner-content">
     Your free FT.com trial
-    <img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2Fassets%2Fb2b%2Fmacron-desktop-banner.png?source=conversion&amp;height=40"
+    <img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fb2b%2Fmacron-desktop-banner.png?source=conversion&amp;height=40"
          alt="Emmanuel Macron"
          class="ncf__trial-banner-img"
     >

--- a/components/trial-banner.jsx
+++ b/components/trial-banner.jsx
@@ -15,7 +15,7 @@ export function TrialBanner({ trialDuration = '' }) {
 			<p className="ncf__trial-banner-content">
 				Your free {durationMessage}FT.com trial
 				<img
-					src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2Fassets%2Fb2b%2Fmacron-desktop-banner.png?source=conversion&height=40"
+					src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fb2b%2Fmacron-desktop-banner.png?source=conversion&height=40"
 					alt="Emmanuel Macron"
 					className="ncf__trial-banner-img"
 				/>


### PR DESCRIPTION
### Description
this url was incorrect: https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2Fassets%2Fb2b%2Fmacron-desktop-banner.png?source=conversion&height=40
and has been updated per @ekocian advice.

### Ticket
Spotted when doing: 
https://financialtimes.atlassian.net/browse/NOPS-823

### Screenshots

| Before | After |
| ------ | ----- |
|![image](https://user-images.githubusercontent.com/25018001/118121210-09e9c800-b3e9-11eb-9c5d-34de1bf19e30.png)|      ![image](https://user-images.githubusercontent.com/25018001/118121675-ba57cc00-b3e9-11eb-8ee9-e1cd9a9e52fb.png)|

(from storybook)