### PR TITLE
ACQ-963. Change URL leading to account settings

### DIFF
--- a/components/__snapshots__/confirmation.spec.js.snap
+++ b/components/__snapshots__/confirmation.spec.js.snap
@@ -27,7 +27,7 @@ exports[`Confirmation renders appropriately if is B2C Partnership 1`] = `
     <p class="ncf__paragraph">
       Go to your
       <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
+         href="https://www.ft.com/myaccount/personal-details"
          target="_blank"
          rel="noopener"
          data-trackable="yourAccount"
@@ -84,7 +84,7 @@ exports[`Confirmation renders appropriately if is trial 1`] = `
     <p class="ncf__paragraph">
       Go to your
       <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
+         href="https://www.ft.com/myaccount/personal-details"
          target="_blank"
          rel="noopener"
          data-trackable="yourAccount"
@@ -139,7 +139,7 @@ exports[`Confirmation renders appropriately if nextActionBottom is not supplied 
     <p class="ncf__paragraph">
       Go to your
       <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
+         href="https://www.ft.com/myaccount/personal-details"
          target="_blank"
          rel="noopener"
          data-trackable="yourAccount"
@@ -194,7 +194,7 @@ exports[`Confirmation renders appropriately if nextActionBottom is supplied 1`] 
     <p class="ncf__paragraph">
       Go to your
       <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
+         href="https://www.ft.com/myaccount/personal-details"
          target="_blank"
          rel="noopener"
          data-trackable="yourAccount"
@@ -250,7 +250,7 @@ exports[`Confirmation renders appropriately if nextActionTop is not supplied 1`]
     <p class="ncf__paragraph">
       Go to your
       <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
+         href="https://www.ft.com/myaccount/personal-details"
          target="_blank"
          rel="noopener"
          data-trackable="yourAccount"
@@ -306,7 +306,7 @@ exports[`Confirmation renders appropriately if nextActionTop is supplied 1`] = `
     <p class="ncf__paragraph">
       Go to your
       <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
+         href="https://www.ft.com/myaccount/personal-details"
          target="_blank"
          rel="noopener"
          data-trackable="yourAccount"
@@ -375,7 +375,7 @@ exports[`Confirmation renders with complete details 1`] = `
     <p class="ncf__paragraph">
       Go to your
       <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
+         href="https://www.ft.com/myaccount/personal-details"
          target="_blank"
          rel="noopener"
          data-trackable="yourAccount"
@@ -430,7 +430,7 @@ exports[`Confirmation renders with custom email 1`] = `
     <p class="ncf__paragraph">
       Go to your
       <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
+         href="https://www.ft.com/myaccount/personal-details"
          target="_blank"
          rel="noopener"
          data-trackable="yourAccount"
@@ -485,7 +485,7 @@ exports[`Confirmation renders with default props 1`] = `
     <p class="ncf__paragraph">
       Go to your
       <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
+         href="https://www.ft.com/myaccount/personal-details"
          target="_blank"
          rel="noopener"
          data-trackable="yourAccount"
@@ -551,7 +551,7 @@ exports[`Confirmation renders with details missing a description 1`] = `
     <p class="ncf__paragraph">
       Go to your
       <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
+         href="https://www.ft.com/myaccount/personal-details"
          target="_blank"
          rel="noopener"
          data-trackable="yourAccount"
@@ -619,7 +619,7 @@ exports[`Confirmation renders with direct debit mandate URL 1`] = `
     <p class="ncf__paragraph">
       Go to your
       <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
+         href="https://www.ft.com/myaccount/personal-details"
          target="_blank"
          rel="noopener"
          data-trackable="yourAccount"

--- a/components/__snapshots__/registration-confirmation.spec.js.snap
+++ b/components/__snapshots__/registration-confirmation.spec.js.snap
@@ -21,7 +21,7 @@ exports[`RegistrationConfirmation renders with a custom email 1`] = `
     <p class="ncf__paragraph">
       Go to your
       <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
+         href="https://www.ft.com/myaccount/personal-details"
          target="_blank"
          rel="noopener"
          data-trackable="yourAccount"
@@ -68,7 +68,7 @@ exports[`RegistrationConfirmation renders with default props 1`] = `
     <p class="ncf__paragraph">
       Go to your
       <a class="ncf__link ncf__link--external"
-         href="https://myaccount.ft.com/details/core/view"
+         href="https://www.ft.com/myaccount/personal-details"
          target="_blank"
          rel="noopener"
          data-trackable="yourAccount"

--- a/components/confirmation.jsx
+++ b/components/confirmation.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const EMAIL_DEFAULT_TEXT = 'your email';
 
-export function Confirmation({
+export function Confirmation ({
 	// isTrial prop is needed for the floodlight pixel tracking.
 	isTrial = false,
 	isB2cPartnership = false,
@@ -90,7 +90,7 @@ export function Confirmation({
 					Go to your{' '}
 					<a
 						className="ncf__link ncf__link--external"
-						href="https://myaccount.ft.com/details/core/view"
+						href="https://www.ft.com/myaccount/personal-details"
 						target="_blank"
 						rel="noopener"
 						data-trackable="yourAccount"

--- a/components/lite-sub-confirmation.jsx
+++ b/components/lite-sub-confirmation.jsx
@@ -83,7 +83,7 @@ export function LiteSubConfirmation ({
 			<div className="ncf__headed-paragraph">
 				<h3 className="ncf__header">Something not right?</h3>
 				<p className="ncf__paragraph">
-					Go to your <a className="ncf__link ncf__link--external" href="https://myaccount.ft.com/details/core/view" target="_blank" rel="noopener" data-trackable="yourAccount">account settings</a> to view or edit your account. If you need to get in touch call us on <a href="tel:+18556852372" className="ncf__link ncf__link--external">+1 855 685 2372</a>. Or contact us for additional support.
+					Go to your <a className="ncf__link ncf__link--external" href="https://www.ft.com/myaccount/personal-details" target="_blank" rel="noopener" data-trackable="yourAccount">account settings</a> to view or edit your account. If you need to get in touch call us on <a href="tel:+18556852372" className="ncf__link ncf__link--external">+1 855 685 2372</a>. Or contact us for additional support.
 				</p>
 			</div>
 		</div>

--- a/components/registration-confirmation.jsx
+++ b/components/registration-confirmation.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const EMAIL_DEFAULT_TEXT = 'your email';
 
-export function RegistrationConfirmation({ email = EMAIL_DEFAULT_TEXT }) {
+export function RegistrationConfirmation ({ email = EMAIL_DEFAULT_TEXT }) {
 	return (
 		<div className="ncf ncf__wrapper">
 			<div className="ncf__center">
@@ -25,7 +25,7 @@ export function RegistrationConfirmation({ email = EMAIL_DEFAULT_TEXT }) {
 					Go to your{' '}
 					<a
 						className="ncf__link ncf__link--external"
-						href="https://myaccount.ft.com/details/core/view"
+						href="https://www.ft.com/myaccount/personal-details"
 						target="_blank"
 						rel="noopener"
 						data-trackable="yourAccount"


### PR DESCRIPTION
### Description
It was reported that a user didn't manage to reach their account settings after successfully buying an offer.
We changed the URL leading to account settings to https://www.ft.com/myaccount/personal-details

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-963

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
