### PR TITLE
ACQ-995: prevent repeated useless calls to check availability endpoint

### DIFF
--- a/utils/delivery-start-date.js
+++ b/utils/delivery-start-date.js
@@ -6,6 +6,7 @@ const fetchres = require('fetchres');
  * const deliveryStartDate = new DeliveryStartDate(document);
  */
 class DeliveryStartDate {
+
 	/**
 	 * Initalise the DeliveryStartDate utility
 	 * @param {Element} element Usually the window.document
@@ -59,9 +60,11 @@ class DeliveryStartDate {
 	 * @throws If there was an error calling the endpoint to check this.
 	 */
 	async handleDeliveryStartDateChange (url, getData) {
-		if (this.$deliveryStartDate.value) {
+		const isNewValue = (this.previousDeliveryDateValue !== this.$deliveryStartDate.value);
+		this.previousDeliveryDateValue = this.$deliveryStartDate.value;
+
+		if (this.$deliveryStartDate.value && isNewValue) {
 			try {
-				this.$container.classList.remove('o-forms-input--invalid');
 				const result = await fetch(url, {
 					method: 'POST',
 					credentials: 'include',
@@ -78,13 +81,21 @@ class DeliveryStartDate {
 
 				this.$deliveryStartDate.value = result.firstDeliveryDate;
 				this.$deliveryStartDateText.innerHTML = result.firstDeliveryDateString;
+				this.$container.classList.remove('o-forms-input--invalid');
+
+				this.lastDeliveryDateState = true;
 
 				return true;
 			} catch (error) {
 				this.$container.classList.add('o-forms-input--invalid');
+
+				this.lastDeliveryDateState = false;
+
 				return false;
 			}
 		}
+
+		return this.lastDeliveryDateState || false;
 	}
 
 	/**


### PR DESCRIPTION
### Description
Not a proper solution (the method is still called needlessly but doesn't do anything), but until we fix it properly this should prevent the repeated calls and the rateLimiting kicking in.

We need to go thought the whole custom validation thing and figure out how to trigger it ONLY when related field is changed.

We'll keep https://financialtimes.atlassian.net/browse/ACQ-995 open to come up with a proper fix.

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-995
