### PR TITLE
ACQ-1010. Remove ft-next-webhooks from the repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,3 @@ workflows:
           requires:
             - build
           context: next-nightly-build
-
-notify:
-  webhooks:
-    - url: https://ft-next-webhooks.herokuapp.com/circleci2-workflow


### PR DESCRIPTION
### Description
Remove ft-next-webhooks from the repo and check and remove the Deploy hook add-on from the Heroku app. More information in the ticket

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-1010
