### PR TITLE
ACQ-1007: add possibility to hide title for email component

### DIFF
--- a/components/__snapshots__/email.spec.js.snap
+++ b/components/__snapshots__/email.spec.js.snap
@@ -193,6 +193,30 @@ exports[`Email with confirmation render a email input with given description 1`]
 </label>
 `;
 
+exports[`Email with confirmation render a email input with hiding the title 1`] = `
+<label id="emailField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required,email"
+       for="email"
+>
+  <span class="o-forms-input o-forms-input--text">
+    <input type="email"
+           id="email"
+           name="email"
+           placeholder="Enter your email address"
+           autocomplete="email"
+           data-trackable="field-email"
+           aria-required="true"
+           required
+           value
+    >
+    <span class="o-forms-input__error">
+      This email address is not valid
+    </span>
+  </span>
+</label>
+`;
+
 exports[`Email with confirmation render a email input with read only fields 1`] = `
 <label id="emailField"
        class="o-forms-field ncf__validation-error"

--- a/components/email.jsx
+++ b/components/email.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export function Email({
+export function Email ({
 	dataTrackable = 'field-email',
 	description = 'Please enter an email address',
 	errorText = 'This email address is not valid',
@@ -16,6 +16,7 @@ export function Email({
 	value = '',
 	isEducationalLicence = false,
 	isB2cPartnershipLicence = false,
+	hideTitle = false,
 }) {
 	const labelText =
 		label ||
@@ -35,12 +36,12 @@ export function Email({
 			data-validate="required,email"
 			htmlFor={inputId}
 		>
-			<span className="o-forms-title">
+			{!hideTitle && <span className="o-forms-title">
 				<span className="o-forms-title__main">{labelText}</span>
 				{description && (
 					<span className="o-forms-title__prompt">{description}</span>
 				)}
-			</span>
+			</span>}
 			<span className={inputWrapperClassNames}>
 				<input
 					type="email"
@@ -74,4 +75,5 @@ Email.propTypes = {
 	value: PropTypes.string,
 	isEducationalLicence: PropTypes.bool,
 	isB2cPartnershipLicence: PropTypes.bool,
+	hideTitle: PropTypes.bool
 };

--- a/components/email.jsx
+++ b/components/email.jsx
@@ -16,7 +16,7 @@ export function Email ({
 	value = '',
 	isEducationalLicence = false,
 	isB2cPartnershipLicence = false,
-	hideTitle = false,
+	showTitle = true,
 }) {
 	const labelText =
 		label ||
@@ -36,7 +36,7 @@ export function Email ({
 			data-validate="required,email"
 			htmlFor={inputId}
 		>
-			{!hideTitle && <span className="o-forms-title">
+			{showTitle && <span className="o-forms-title">
 				<span className="o-forms-title__main">{labelText}</span>
 				{description && (
 					<span className="o-forms-title__prompt">{description}</span>
@@ -75,5 +75,5 @@ Email.propTypes = {
 	value: PropTypes.string,
 	isEducationalLicence: PropTypes.bool,
 	isB2cPartnershipLicence: PropTypes.bool,
-	hideTitle: PropTypes.bool
+	showTitle: PropTypes.bool
 };

--- a/components/email.spec.js
+++ b/components/email.spec.js
@@ -79,4 +79,12 @@ describe('Email with confirmation', () => {
 
 		expect(Email).toRenderCorrectly(props);
 	});
+
+	it('render a email input with hiding the title', () => {
+		const props = {
+			hideTitle: true,
+		};
+
+		expect(Email).toRenderCorrectly(props);
+	});
 });

--- a/components/email.spec.js
+++ b/components/email.spec.js
@@ -82,7 +82,7 @@ describe('Email with confirmation', () => {
 
 	it('render a email input with hiding the title', () => {
 		const props = {
-			hideTitle: true,
+			showTitle: false,
 		};
 
 		expect(Email).toRenderCorrectly(props);


### PR DESCRIPTION
### Description
Allow hide title for email component. This is aim to cover a specific requirement in https://financialtimes.atlassian.net/browse/ACQ-972

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-1007 and https://financialtimes.atlassian.net/browse/ACQ-972

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
