### PR TITLE
ACQ-1077: hiding email title instead of not rendering

### DIFF
--- a/components/__snapshots__/email.spec.js.snap
+++ b/components/__snapshots__/email.spec.js.snap
@@ -199,6 +199,14 @@ exports[`Email with confirmation render a email input with hiding the title 1`] 
        data-validate="required,email"
        for="email"
 >
+  <span class="o-forms-title ncf__hidden">
+    <span class="o-forms-title__main">
+      Email address
+    </span>
+    <span class="o-forms-title__prompt">
+      Please enter an email address
+    </span>
+  </span>
   <span class="o-forms-input o-forms-input--text">
     <input type="email"
            id="email"

--- a/components/email.jsx
+++ b/components/email.jsx
@@ -28,6 +28,10 @@ export function Email ({
 		'o-forms-input--text',
 		{ 'o-forms-input--invalid': hasError },
 	]);
+	const emailTitleClassNames = classNames([
+		'o-forms-title',
+		{ ncf__hidden: !showTitle },
+	]);
 
 	return (
 		<label
@@ -36,12 +40,12 @@ export function Email ({
 			data-validate="required,email"
 			htmlFor={inputId}
 		>
-			{showTitle && <span className="o-forms-title">
+			<span className={emailTitleClassNames}>
 				<span className="o-forms-title__main">{labelText}</span>
 				{description && (
 					<span className="o-forms-title__prompt">{description}</span>
 				)}
-			</span>}
+			</span>
 			<span className={inputWrapperClassNames}>
 				<input
 					type="email"


### PR DESCRIPTION
### Description
 Hiding email title instead of not rendering it helps on building error messages.

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-1077

### Screenshots

![image](https://user-images.githubusercontent.com/13876273/125436938-5445c6f4-b117-4eb3-8af9-07621173ed3c.png)


