### PR TITLE
UG-565: Remove the newsletter list from the lite-sub confirmation page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,9 +163,6 @@ workflows:
       - test:
           requires:
             - build
-      - provision:
-          requires:
-            - build
 
   nightly:
     triggers:

--- a/components/lite-sub-confirmation.jsx
+++ b/components/lite-sub-confirmation.jsx
@@ -75,7 +75,7 @@ export function LiteSubConfirmation ({
 				We&apos;ve sent confirmation to {email}. Make sure you check your spam folder if you don’t receive it.
 			</p>
 			<p className="ncf__paragraph">
-				Here&apos;s a summary of your {isPremium(productCode) ? 'Premium' : 'Digital'} subscription:
+				Here&apos;s a summary of your {isPremium(productCode) ? 'Premium Digital' : 'Standard Digital'} subscription:
 			</p>
 
 			{ detailElements}

--- a/components/lite-sub-confirmation.jsx
+++ b/components/lite-sub-confirmation.jsx
@@ -67,7 +67,7 @@ export function LiteSubConfirmation ({
 				<li>FirstFT: a daily newsletter with the global stories you need to know</li>
 				<li>Share 10 articles per month with colleagues, family and friends</li>
 			</ul>
-			<p className="ncf__paragraph">However, if you would like to cancel your subscription, please contact our <a href="https://help.ft.com/help/contact-us/">customer care team</a> and they will arrange this for you.</p>
+			<p className="ncf__paragraph">However, if you would like to cancel your subscription, please contact our <a href="https://help.ft.com/contact/">customer care team</a> and they will arrange this for you.</p>
 			<p className="ncf__center">
 				<a href="/" className="ncf__button ncf__button--submit ncf__button--margin ncf__lite-sub-confirmation--lite-sub-cta">Go to FT.com</a>
 			</p>

--- a/components/lite-sub-confirmation.jsx
+++ b/components/lite-sub-confirmation.jsx
@@ -13,9 +13,7 @@ const DetailsMobileView = ({details}) => (
 				(
 					<React.Fragment key={index}>
 						<dt className="ncf__list-title">{detail.title}</dt>
-						<dd className="ncf__list-data">{detail.data}
-							{detail.description && (<span className="ncf__lite-sub__details--description">({detail.description})</span>)}
-						</dd>
+						<dd className="ncf__list-data">{detail.data}</dd>
 					</React.Fragment>
 				)
 			)
@@ -40,9 +38,7 @@ export function LiteSubConfirmation ({
 						(
 							<React.Fragment key={index}>
 								<dt className="ncf__list-title">{detail.title}</dt>
-								<dd className="ncf__list-data">{detail.data}
-									{detail.description && (<div>({detail.description})</div>)}
-								</dd>
+								<dd className="ncf__list-data">{detail.data}</dd>
 							</React.Fragment>
 						)
 					)
@@ -98,6 +94,5 @@ LiteSubConfirmation.propTypes = {
 	details: PropTypes.arrayOf(PropTypes.shape({
 		title: PropTypes.string.isRequired,
 		data: PropTypes.string.isRequired,
-		description: PropTypes.string
 	})),
 };

--- a/components/lite-sub-confirmation.jsx
+++ b/components/lite-sub-confirmation.jsx
@@ -60,8 +60,17 @@ export function LiteSubConfirmation ({
 				<p className="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">You&apos;ve been upgraded to:</p>
 				<h1 className="ncf__header ncf__header--confirmation">{isPremium(productCode) ? 'Premium' : 'Digital'}</h1>
 			</div>
-			<p className="ncf__paragraph">Thank you for choosing to subscribe to {offerName}. We are not quite ready to deliver this type of subscription, so we have upgraded you to a {isPremium(productCode) ? 'Premium' : 'Digital'} 3 month subscription at no additional cost.</p>
-			<p className="ncf__paragraph">For {subscriptionAmount} a month, you can now enjoy {isPremium(productCode) ? 'unlimited' : 'standard digital'} access to FT.com, where you can explore not only the product you had purchased, but everything else the FT has to offer. However, if you would like to cancel your subscription, please contact our <a className="barrier__terms-link ncf__link ncf__link--external" href="https://help.ft.com/contact">customer care team</a> and they will arrange this for you.</p>
+			<p className="ncf__paragraph">Thank you for choosing to subscribe to <strong>{offerName}</strong>. We are not quite ready to deliver this type of subscription, so we have upgraded you to a {isPremium(productCode) ? 'Premium' : 'Digital'} 3 month subscription at no additional cost.</p>
+			<p className="ncf__paragraph">For {subscriptionAmount} a month, here&apos;s what your subscription covers:</p>
+			<ul className="ncf__unordered-list">
+				<li>Access to stories from over 600 journalists in 50+ countries covering markets, politics, business, tech and more</li>
+				<li>FirstFT: a daily newsletter with the global stories you need to know</li>
+				<li>Share 10 articles per month with colleagues, family and friends</li>
+			</ul>
+			<p className="ncf__paragraph">However, if you would like to cancel your subscription, please contact our <a href="https://help.ft.com/help/contact-us/">customer care team</a> and they will arrange this for you.</p>
+			<p className="ncf__center">
+				<a href="/" className="ncf__button ncf__button--submit ncf__button--margin ncf__lite-sub-confirmation--lite-sub-cta">Go to FT.com</a>
+			</p>
 			<p className="ncf__paragraph">
 				We&apos;ve sent confirmation to {email}. Make sure you check your spam folder if you don’t receive it.
 			</p>

--- a/components/lite-sub-confirmation.jsx
+++ b/components/lite-sub-confirmation.jsx
@@ -67,7 +67,7 @@ export function LiteSubConfirmation ({
 				<li>FirstFT: a daily newsletter with the global stories you need to know</li>
 				<li>Share 10 articles per month with colleagues, family and friends</li>
 			</ul>
-			<p className="ncf__paragraph">However, if you would like to cancel your subscription, please contact our <a href="https://help.ft.com/contact/">customer care team</a> and they will arrange this for you.</p>
+			<p className="ncf__paragraph">However, if you would like to cancel your subscription, please contact our <a className="ncf__link ncf__link--external" href="https://help.ft.com/contact/" target="_blank" rel="noopener noreferrer">customer care team</a> and they will arrange this for you.</p>
 			<p className="ncf__center">
 				<a href="/" className="ncf__button ncf__button--submit ncf__button--margin ncf__lite-sub-confirmation--lite-sub-cta">Go to FT.com</a>
 			</p>
@@ -83,7 +83,7 @@ export function LiteSubConfirmation ({
 			<div className="ncf__headed-paragraph">
 				<h3 className="ncf__header">Something not right?</h3>
 				<p className="ncf__paragraph">
-					Go to your <a className="ncf__link ncf__link--external" href="https://www.ft.com/myaccount/personal-details" target="_blank" rel="noopener" data-trackable="yourAccount">account settings</a> to view or edit your account. If you need to get in touch call us on <a href="tel:+18556852372" className="ncf__link ncf__link--external">+1 855 685 2372</a>. Or <a href="https://help.ft.com/contact/">contact us</a> for additional support.
+					Go to your <a className="ncf__link ncf__link--external" href="https://www.ft.com/myaccount/personal-details" target="_blank" rel="noopener noreferrer" data-trackable="yourAccount">account settings</a> to view or edit your account. If you need to get in touch call us on <a href="tel:+18556852372" className="ncf__link ncf__link--external">+1 855 685 2372</a>. Or <a className="ncf__link ncf__link--external" href="https://help.ft.com/contact/" target="_blank" rel="noopener noreferrer">contact us</a> for additional support.
 				</p>
 			</div>
 		</div>

--- a/components/lite-sub-confirmation.jsx
+++ b/components/lite-sub-confirmation.jsx
@@ -58,7 +58,7 @@ export function LiteSubConfirmation ({
 			<div className="ncf__center">
 				<div className="ncf__icon ncf__icon--tick ncf__icon--large"></div>
 				<p className="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">You&apos;ve been upgraded to:</p>
-				<h1 className="ncf__header ncf__header--confirmation">{isPremium(productCode) ? 'Premium' : 'Digital'}</h1>
+				<h1 className="ncf__header ncf__header--confirmation">{isPremium(productCode) ? 'Premium Digital' : 'Standard Digital'}</h1>
 			</div>
 			<p className="ncf__paragraph">Thank you for choosing to subscribe to <strong>{offerName}</strong>. We are not quite ready to deliver this type of subscription, so we have upgraded you to a {isPremium(productCode) ? 'Premium' : 'Digital'} 3 month subscription at no additional cost.</p>
 			<p className="ncf__paragraph">For {subscriptionAmount} a month, here&apos;s what your subscription covers:</p>
@@ -83,7 +83,7 @@ export function LiteSubConfirmation ({
 			<div className="ncf__headed-paragraph">
 				<h3 className="ncf__header">Something not right?</h3>
 				<p className="ncf__paragraph">
-					Go to your <a className="ncf__link ncf__link--external" href="https://www.ft.com/myaccount/personal-details" target="_blank" rel="noopener" data-trackable="yourAccount">account settings</a> to view or edit your account. If you need to get in touch call us on <a href="tel:+18556852372" className="ncf__link ncf__link--external">+1 855 685 2372</a>. Or contact us for additional support.
+					Go to your <a className="ncf__link ncf__link--external" href="https://www.ft.com/myaccount/personal-details" target="_blank" rel="noopener" data-trackable="yourAccount">account settings</a> to view or edit your account. If you need to get in touch call us on <a href="tel:+18556852372" className="ncf__link ncf__link--external">+1 855 685 2372</a>. Or <a href="https://help.ft.com/contact/">contact us</a> for additional support.
 				</p>
 			</div>
 		</div>

--- a/components/lite-sub-confirmation.jsx
+++ b/components/lite-sub-confirmation.jsx
@@ -63,15 +63,6 @@ export function LiteSubConfirmation ({
 			<p className="ncf__paragraph">Thank you for choosing to subscribe to {offerName}. We are not quite ready to deliver this type of subscription, so we have upgraded you to a {isPremium(productCode) ? 'Premium' : 'Digital'} 3 month subscription at no additional cost.</p>
 			<p className="ncf__paragraph">For {subscriptionAmount} a month, you can now enjoy {isPremium(productCode) ? 'unlimited' : 'standard digital'} access to FT.com, where you can explore not only the product you had purchased, but everything else the FT has to offer. However, if you would like to cancel your subscription, please contact our <a className="barrier__terms-link ncf__link ncf__link--external" href="https://help.ft.com/contact">customer care team</a> and they will arrange this for you.</p>
 			<p className="ncf__paragraph">
-				<b>Head to FT.com now to sign up to the newsletter(s)</b> that would have been included with your {offerName} subscription
-				{isPremium(productCode) ? <span>: Moral Money, Due Diligence, #techAsia, Energy Source, Trade Secrets and Scoreboard</span>
-					: <span>: FirstFT Americas</span>
-				}.
-			</p>
-			<p className="ncf__center">
-				<a href="/newsletters/" className="ncf__button ncf__button--submit ncf__button--margin ncf__lite-sub-confirmation--lite-sub-cta">Go to newsletters</a>
-			</p>
-			<p className="ncf__paragraph">
 				We&apos;ve sent confirmation to {email}. Make sure you check your spam folder if you don’t receive it.
 			</p>
 			<p className="ncf__paragraph">

--- a/components/lite-sub-confirmation.stories.js
+++ b/components/lite-sub-confirmation.stories.js
@@ -21,7 +21,6 @@ Basic.args = {
 		},
 		{
 			title: '3 monthly payments',
-			description: 'Total cost of subscription: $15.00',
 			data: '$5.00 per month',
 		},
 		{

--- a/main.scss
+++ b/main.scss
@@ -404,6 +404,12 @@
 		}
 	}
 
+	&__unordered-list {
+		> li {
+			margin-bottom: 10px;
+		}
+	}
+
 	@include ncfMessage();
 	@include ncfPackageChange();
 	@include ncfPaymentTerm();

--- a/main.scss
+++ b/main.scss
@@ -405,8 +405,9 @@
 	}
 
 	&__unordered-list {
+		padding-inline-start: 25px;
 		> li {
-			margin-bottom: 10px;
+			margin-bottom: oSpacingByName('s3');
 		}
 	}
 


### PR DESCRIPTION
### Description
Applied changes to the `LiteSubConfirmation` component, which renders on the Confirmation page after a successful subscription to a LiteSub.

- Removed HTML markup for the newsletter section.
- Added a list of features included with the Digital subscription
- Added button to go to ft.com
- Added instructions to cancel the subscription

### Ticket
https://financialtimes.atlassian.net/browse/UG-565

### Screenshots

| Before | After |
| ------ | ----- |
|<img width="358" alt="UG565-before" src="https://user-images.githubusercontent.com/7011304/126615339-db247431-420a-418b-b6a0-de2fef3efd45.png">|<img width="370" alt="UG565" src="https://user-images.githubusercontent.com/7011304/126996999-684e64dc-1ca1-4727-bb62-cc458af12b44.png">|

### How to test this code?

This code depends on [UG-564.](https://github.com/Financial-Times/n-membership-sdk/pull/477). If it hasn't been released, you'll need to checkout its [branch](https://github.com/Financial-Times/n-membership-sdk/tree/feature/UG-564), build it, and run `npm link` on it.

- Checkout this branch and run make build
- Run `npm link`
- Go to next-subscribe and run `npm link @financial-times/n-conversion-forms` to use your local instance of these components. Run `npm link @financial-times/n-conversion-forms @financial-times/n-membership-sdk` if [UG-564](https://github.com/Financial-Times/n-membership-sdk/pull/477) hasn't been released.
- On [Toggler](https://toggler.ft.com/#liteSubPackageTestAlpha), enable the flags `conversionSandbox`, `conversionSandboxHelpers` and set `liteSubPackageTestAlpha` with the value of the offer you're going to test.
- Log out from the FT.
- Go to offer checkout for the enabled offer ([Mix & Match](https://local.ft.com:5050/buy/subscription/e3c33b15-94fe-4730-e9fe-9397f39c509b) and [10 stories per month](https://local.ft.com:5050/buy/subscription/c7bad403-c742-c6e9-adc6-b2b34772f9fe))
- Finish the checkout journey and you should see a confirmation page showing the details from your subscription. Check that there is no reference to the newsletter list.

