### PR TITLE
UG-541 — Show Light Subscription Offer name

### DIFF
--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -79,7 +79,7 @@ exports[`AcceptTerms renders appropriately if a signup 1`] = `
       <span class="terms-signup">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
-           href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+           href="https://help.ft.com/legal-privacy/terms-and-conditions/"
            target="_blank"
            rel="noopener noreferrer"
         >
@@ -153,7 +153,7 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 1`]
       <span class="terms-signup">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
-           href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+           href="https://help.ft.com/legal-privacy/terms-and-conditions/"
            target="_blank"
            rel="noopener noreferrer"
         >
@@ -415,7 +415,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
       <span class="terms-signup">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
-           href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+           href="https://help.ft.com/legal-privacy/terms-and-conditions/"
            target="_blank"
            rel="noopener noreferrer"
         >
@@ -489,7 +489,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
       <span class="terms-signup">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
-           href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+           href="https://help.ft.com/legal-privacy/terms-and-conditions/"
            target="_top"
            rel="noopener noreferrer"
         >
@@ -563,7 +563,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
       <span class="terms-signup">
         Find out more about our cancellation policy in our
         <a class="ncf__link--external"
-           href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+           href="https://help.ft.com/legal-privacy/terms-and-conditions/"
            target="_blank"
            rel="noopener noreferrer"
         >

--- a/components/__snapshots__/payment-term.spec.js.snap
+++ b/components/__snapshots__/payment-term.spec.js.snap
@@ -36,7 +36,7 @@ exports[`PaymentTerm annual option render option 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -88,7 +88,7 @@ exports[`PaymentTerm annual option render option with discount 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -138,7 +138,7 @@ exports[`PaymentTerm annual option render option with isTrial 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -194,7 +194,7 @@ exports[`PaymentTerm annual option render option with monthlyPrice 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -244,7 +244,7 @@ exports[`PaymentTerm annual option render option with selected 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -295,7 +295,7 @@ exports[`PaymentTerm annual option render option with trial 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -343,7 +343,7 @@ exports[`PaymentTerm monthly option render option 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -394,7 +394,7 @@ exports[`PaymentTerm monthly option render option with discount 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -444,7 +444,7 @@ exports[`PaymentTerm monthly option render option with isTrial 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -492,7 +492,7 @@ exports[`PaymentTerm monthly option render option with monthlyPrice 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -541,7 +541,7 @@ exports[`PaymentTerm monthly option render option with selected 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -592,7 +592,7 @@ exports[`PaymentTerm monthly option render option with trial 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -640,7 +640,7 @@ exports[`PaymentTerm quarterly option render option 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -691,7 +691,7 @@ exports[`PaymentTerm quarterly option render option with discount 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -741,7 +741,7 @@ exports[`PaymentTerm quarterly option render option with isTrial 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -789,7 +789,7 @@ exports[`PaymentTerm quarterly option render option with monthlyPrice 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -838,7 +838,7 @@ exports[`PaymentTerm quarterly option render option with selected 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -889,7 +889,7 @@ exports[`PaymentTerm quarterly option render option with trial 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -913,7 +913,7 @@ exports[`PaymentTerm render with defaults 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"
@@ -937,7 +937,7 @@ exports[`PaymentTerm render with isPrintOrBundle 1`] = `
     <p>
       We will notify you at least 14 days in advance of any changes to the price in your subscription that would apply upon next renewal. Find out more about our cancellation policy in our
       <a class="ncf__link--external"
-         href="https://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/terms-and-conditions/"
          title="FT Legal Terms and Conditions help page"
          target="_blank"
          rel="noopener noreferrer"

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -239,7 +239,7 @@ export function AcceptTerms({
 							Find out more about our cancellation policy in our{' '}
 							<a
 								className="ncf__link--external"
-								href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+								href="https://help.ft.com/legal-privacy/terms-and-conditions/"
 								target={isEmbedded ? '_top' : '_blank'}
 								rel="noopener noreferrer"
 							>

--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-
-const isoDurationToEnglish = {
-	P3M: '3 months',
-};
-
 export function PaymentTerm({
 	fieldId = 'paymentTermField',
 	inputName = 'paymentTerm',
@@ -13,7 +8,7 @@ export function PaymentTerm({
 	isEpaper = false,
 	options = [],
 	isFixedTermOffer = false,
-	subscriptionDuration,
+	displayName,
 }) {
 	const nameMap = {
 		annual: {
@@ -82,11 +77,14 @@ export function PaymentTerm({
 				</React.Fragment>
 			),
 			monthlyPrice: () => {},
-			renewsText: () => (
-				<p className="ncf__payment-term__renews-text">
-					Renews monthly unless cancelled
-				</p>
-			),
+			renewsText: (isFixedTermOffer) => {
+				const textToDisplay = isFixedTermOffer
+					? 'This subscription is charged monthly and can be cancelled at anytime'
+					: 'Renews monthly unless cancelled';
+				return (
+					<p className="ncf__payment-term__renews-text">{textToDisplay}</p>
+				);
+			},
 		},
 	};
 	const createPaymentTerm = (option) => {
@@ -98,14 +96,19 @@ export function PaymentTerm({
 		const props = {
 			type: 'radio',
 			id: option.value,
-      'data-base-amount': option.isTrial ? option.trialAmount : option.amount,
+			'data-base-amount': option.isTrial ? option.trialAmount : option.amount,
 			name: inputName,
 			value: option.value,
 			className:
 				'o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input',
 			...(option.selected && { defaultChecked: true }),
 		};
-		const showTrialCopyInTitle = option.isTrial && !isPrintOrBundle && !isEpaper;
+		const showTrialCopyInTitle =
+			option.isTrial && !isPrintOrBundle && !isEpaper;
+		const defaultTitle = nameMap[option.name].title;
+		const title = isFixedTermOffer
+			? `${displayName} - ${defaultTitle}`
+			: defaultTitle;
 		const createDiscount = () => {
 			return (
 				option.discount && (
@@ -129,10 +132,7 @@ export function PaymentTerm({
 				<div className="ncf__payment-term__description">
 					{nameMap[option.name].price(option.price)}
 					{nameMap[option.name].monthlyPrice(option.monthlyPrice)}
-					{isFixedTermOffer ?
-						<p className="ncf__payment-term__renews-text">This subscription is for {isoDurationToEnglish[subscriptionDuration]} and will not renew</p> :
-						nameMap[option.name].renewsText()
-					}
+					{nameMap[option.name].renewsText(isFixedTermOffer)}
 					{/* Remove this discount text temporarily in favour of monthly price */}
 					{/* <br />Save up to 25% when you pay annually */}
 				</div>
@@ -150,7 +150,7 @@ export function PaymentTerm({
 
 					<span className="ncf__payment-term__title">
 						{showTrialCopyInTitle ? 'Trial: Premium Digital - ' : ''}
-						{nameMap[option.name].title}
+						{title}
 					</span>
 
 					{createDescription()}
@@ -164,32 +164,44 @@ export function PaymentTerm({
 			{options.map((option) => createPaymentTerm(option))}
 
 			<div className="ncf__payment-term__legal">
-				{
-					isFixedTermOffer ?
-						<p>Find out more about our cancellation policy in our <a className="ncf__link--external" href="https://help.ft.com/help/legal-privacy/terms-conditions/" title="FT Legal Terms and Conditions help page" target="_blank" rel="noopener noreferrer">Terms &amp; Conditions</a>.</p> :
-						<React.Fragment>
-							<p>
-								With all subscription types, we will automatically renew your
-								subscription using the payment method provided unless you cancel
-								before your renewal date.
-							</p>
-							<p>
-								We will notify you at least 14 days in advance of any changes to the
-								price in your subscription that would apply upon next renewal. Find
-								out more about our cancellation policy in our{' '}
-								<a
-									className="ncf__link--external"
-									href="https://help.ft.com/help/legal-privacy/terms-conditions/"
-									title="FT Legal Terms and Conditions help page"
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									Terms &amp; Conditions
-								</a>
-								.
-							</p>
-						</React.Fragment>
-				}
+				{isFixedTermOffer ? (
+					<p>
+						Find out more about our cancellation policy in our{' '}
+						<a
+							className="ncf__link--external"
+							href="https://help.ft.com/legal-privacy/terms-and-conditions/"
+							title="FT Legal Terms and Conditions help page"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Terms &amp; Conditions
+						</a>
+						.
+					</p>
+				) : (
+					<React.Fragment>
+						<p>
+							With all subscription types, we will automatically renew your
+							subscription using the payment method provided unless you cancel
+							before your renewal date.
+						</p>
+						<p>
+							We will notify you at least 14 days in advance of any changes to
+							the price in your subscription that would apply upon next renewal.
+							Find out more about our cancellation policy in our{' '}
+							<a
+								className="ncf__link--external"
+								href="https://help.ft.com/legal-privacy/terms-and-conditions/"
+								title="FT Legal Terms and Conditions help page"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								Terms &amp; Conditions
+							</a>
+							.
+						</p>
+					</React.Fragment>
+				)}
 			</div>
 		</div>
 	);
@@ -216,5 +228,5 @@ PaymentTerm.propTypes = {
 		})
 	),
 	isFixedTermOffer: PropTypes.bool,
-	subscriptionDuration: PropTypes.string,
+	displayName: PropTypes.string,
 };

--- a/components/payment-term.spec.js
+++ b/components/payment-term.spec.js
@@ -126,14 +126,20 @@ describe('PaymentTerm', () => {
 				monthlyPrice: '$5.00',
 			}
 		];
-		const wrapper = shallow(<PaymentTerm isFixedTermOffer={true} options={options} subscriptionDuration='P3M' />);
+		const wrapper = shallow(<PaymentTerm isFixedTermOffer={true} options={options} displayName='Mix & Match' />);
 
 		it('should not include renewal text', () => {
 			expect(wrapper.find('.ncf__payment-term__renews-text').text()).not.toMatch(/Renews (annually|monthly|quarterly) unless cancelled/);
 		});
 
-		it('should render the subscriptionDuration in English', () => {
-			expect(wrapper.find('.ncf__payment-term__renews-text').text()).toMatch(/3 months/);
+		it('should render fixed term renewal text in English', () => {
+			expect(wrapper.find('.ncf__payment-term__renews-text').text()).toMatch(/This subscription is charged monthly and can be cancelled at anytime/);
+		});
+
+		it('should render offer name on payment term title', () => {
+			expect(wrapper.find('.ncf__payment-term__title').text()).toMatch(
+				'Mix & Match - Monthly'
+			);
 		});
 	});
 

--- a/components/payment-term.stories.js
+++ b/components/payment-term.stories.js
@@ -35,7 +35,7 @@ Basic.args = {
 	],
 };
 
-export const FixedTermOffer = (args) => <div className="ncf"><Fieldset><PaymentTerm {...args} subscriptionDuration='P3M' /></Fieldset></div>;
+export const FixedTermOffer = (args) => <div className="ncf"><Fieldset><PaymentTerm {...args} /></Fieldset></div>;
 FixedTermOffer.args = {
 	options: [
 		{
@@ -45,4 +45,5 @@ FixedTermOffer.args = {
 		}
 	],
 	isFixedTermOffer: true,
+	displayName: 'Mix & Match'
 };


### PR DESCRIPTION
### Description
Changes the payment-term component to show the Light subscription offer name. See [here](https://financialtimes.atlassian.net/browse/UG-534) for more info.

### Ticket
https://financialtimes.atlassian.net/browse/UG-541

### Screenshots

| Before | After |
| ------ | ----- |
|     
<img width="1550" alt="Screenshot 2021-07-27 at 07 33 15" src="https://user-images.githubusercontent.com/13418091/127106900-09acdfe9-70eb-4751-91cd-054924c56fdb.png">
   |    
<img width="1551" alt="Screenshot 2021-07-27 at 07 35 09" src="https://user-images.githubusercontent.com/13418091/127107120-79422616-186c-4548-8095-1a46f8f0068a.png">
   |

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Tests** written for new or updated for existing functionality
- [x] **Stories** updated to use this change
- [x] **Accessibility** checked for screen readers and contrast
- [x] **Design Review** ran past the designer
- [x] **Product Review** ran past the product owner
