### PR TITLE
ACC-998: Implement single term subscription into PaymentTerm component

### DIFF
--- a/components/__snapshots__/payment-term.spec.js.snap
+++ b/components/__snapshots__/payment-term.spec.js.snap
@@ -4,30 +4,32 @@ exports[`PaymentTerm annual option render option 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round">
-    <input type="radio"
-           id="annual"
-           name="paymentTerm"
-           value="annual"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-    >
-    <label for="annual"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__title">
-        Annual
-      </span>
-      <div class="ncf__payment-term__description">
-        Single
-        <span class="ncf__payment-term__price ncf__strong">
-          £20.00
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round">
+      <input type="radio"
+             id="annual"
+             name="paymentTerm"
+             value="annual"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+      >
+      <label for="annual"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__title">
+          Annual
         </span>
-        payment
-        <p class="ncf__payment-term__renews-text">
-          Renews annually unless cancelled
-        </p>
-      </div>
-    </label>
+        <div class="ncf__payment-term__description">
+          Single
+          <span class="ncf__payment-term__price ncf__strong">
+            £20.00
+          </span>
+          payment
+          <p class="ncf__payment-term__renews-text">
+            Renews annually unless cancelled
+          </p>
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -53,33 +55,35 @@ exports[`PaymentTerm annual option render option with discount 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round ncf__payment-term__item--discount">
-    <input type="radio"
-           id="annual"
-           name="paymentTerm"
-           value="annual"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-    >
-    <label for="annual"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__discount">
-        Save 25% off off RRP
-      </span>
-      <span class="ncf__payment-term__title">
-        Annual
-      </span>
-      <div class="ncf__payment-term__description">
-        Single
-        <span class="ncf__payment-term__price ncf__strong">
-          £20.00
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round ncf__payment-term__item--discount">
+      <input type="radio"
+             id="annual"
+             name="paymentTerm"
+             value="annual"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+      >
+      <label for="annual"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__discount">
+          Save 25% off off RRP
         </span>
-        payment
-        <p class="ncf__payment-term__renews-text">
-          Renews annually unless cancelled
-        </p>
-      </div>
-    </label>
+        <span class="ncf__payment-term__title">
+          Annual
+        </span>
+        <div class="ncf__payment-term__description">
+          Single
+          <span class="ncf__payment-term__price ncf__strong">
+            £20.00
+          </span>
+          payment
+          <p class="ncf__payment-term__renews-text">
+            Renews annually unless cancelled
+          </p>
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -105,31 +109,33 @@ exports[`PaymentTerm annual option render option with isTrial 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round">
-    <input type="radio"
-           id="annual"
-           name="paymentTerm"
-           value="annual"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-    >
-    <label for="annual"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__title">
-        Trial: Premium Digital - Annual
-      </span>
-      <div class="ncf__payment-term__description">
-        4 weeks for
-        <span class="ncf__payment-term__trial-price">
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round">
+      <input type="radio"
+             id="annual"
+             name="paymentTerm"
+             value="annual"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+      >
+      <label for="annual"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__title">
+          Trial: Premium Digital - Annual
         </span>
-        <br>
-        Unless you cancel during your trial you will be billed
-        <span class="ncf__payment-term__price">
-          £20.00
-        </span>
-        per year after the trial period.
-      </div>
-    </label>
+        <div class="ncf__payment-term__description">
+          4 weeks for
+          <span class="ncf__payment-term__trial-price">
+          </span>
+          <br>
+          Unless you cancel during your trial you will be billed
+          <span class="ncf__payment-term__price">
+            £20.00
+          </span>
+          per year after the trial period.
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -155,37 +161,39 @@ exports[`PaymentTerm annual option render option with monthlyPrice 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round">
-    <input type="radio"
-           id="annual"
-           name="paymentTerm"
-           value="annual"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-    >
-    <label for="annual"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__title">
-        Annual
-      </span>
-      <div class="ncf__payment-term__description">
-        Single
-        <span class="ncf__payment-term__price ncf__strong">
-          £20.00
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round">
+      <input type="radio"
+             id="annual"
+             name="paymentTerm"
+             value="annual"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+      >
+      <label for="annual"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__title">
+          Annual
         </span>
-        payment
-        <span class="ncf__payment-term__equivalent-price">
-          That’s equivalent to
-          <span class="ncf__payment-term__monthly-price">
-            £1.67
+        <div class="ncf__payment-term__description">
+          Single
+          <span class="ncf__payment-term__price ncf__strong">
+            £20.00
           </span>
-          per month
-        </span>
-        <p class="ncf__payment-term__renews-text">
-          Renews annually unless cancelled
-        </p>
-      </div>
-    </label>
+          payment
+          <span class="ncf__payment-term__equivalent-price">
+            That’s equivalent to
+            <span class="ncf__payment-term__monthly-price">
+              £1.67
+            </span>
+            per month
+          </span>
+          <p class="ncf__payment-term__renews-text">
+            Renews annually unless cancelled
+          </p>
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -211,31 +219,33 @@ exports[`PaymentTerm annual option render option with selected 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round">
-    <input type="radio"
-           id="annual"
-           name="paymentTerm"
-           value="annual"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-           checked
-    >
-    <label for="annual"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__title">
-        Annual
-      </span>
-      <div class="ncf__payment-term__description">
-        Single
-        <span class="ncf__payment-term__price ncf__strong">
-          £20.00
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round">
+      <input type="radio"
+             id="annual"
+             name="paymentTerm"
+             value="annual"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+             checked
+      >
+      <label for="annual"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__title">
+          Annual
         </span>
-        payment
-        <p class="ncf__payment-term__renews-text">
-          Renews annually unless cancelled
-        </p>
-      </div>
-    </label>
+        <div class="ncf__payment-term__description">
+          Single
+          <span class="ncf__payment-term__price ncf__strong">
+            £20.00
+          </span>
+          payment
+          <p class="ncf__payment-term__renews-text">
+            Renews annually unless cancelled
+          </p>
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -261,32 +271,34 @@ exports[`PaymentTerm annual option render option with trial 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round">
-    <input type="radio"
-           id="annual"
-           name="paymentTerm"
-           value="annual"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-    >
-    <label for="annual"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__title">
-        Trial: Premium Digital - Annual
-      </span>
-      <div class="ncf__payment-term__description">
-        6 weeks for
-        <span class="ncf__payment-term__trial-price">
-          £1.00
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round">
+      <input type="radio"
+             id="annual"
+             name="paymentTerm"
+             value="annual"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+      >
+      <label for="annual"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__title">
+          Trial: Premium Digital - Annual
         </span>
-        <br>
-        Unless you cancel during your trial you will be billed
-        <span class="ncf__payment-term__price">
-          £20.00
-        </span>
-        per year after the trial period.
-      </div>
-    </label>
+        <div class="ncf__payment-term__description">
+          6 weeks for
+          <span class="ncf__payment-term__trial-price">
+            £1.00
+          </span>
+          <br>
+          Unless you cancel during your trial you will be billed
+          <span class="ncf__payment-term__price">
+            £20.00
+          </span>
+          per year after the trial period.
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -312,29 +324,31 @@ exports[`PaymentTerm monthly option render option 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round">
-    <input type="radio"
-           id="monthly"
-           name="paymentTerm"
-           value="monthly"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-    >
-    <label for="monthly"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__title">
-        Monthly
-      </span>
-      <div class="ncf__payment-term__description">
-        <span class="ncf__payment-term__price">
-          £20.00
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round">
+      <input type="radio"
+             id="monthly"
+             name="paymentTerm"
+             value="monthly"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+      >
+      <label for="monthly"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__title">
+          Monthly
         </span>
-        per month
-        <p class="ncf__payment-term__renews-text">
-          Renews monthly unless cancelled
-        </p>
-      </div>
-    </label>
+        <div class="ncf__payment-term__description">
+          <span class="ncf__payment-term__price">
+            £20.00
+          </span>
+          per month
+          <p class="ncf__payment-term__renews-text">
+            Renews monthly unless cancelled
+          </p>
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -360,32 +374,34 @@ exports[`PaymentTerm monthly option render option with discount 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round ncf__payment-term__item--discount">
-    <input type="radio"
-           id="monthly"
-           name="paymentTerm"
-           value="monthly"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-    >
-    <label for="monthly"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__discount">
-        Save 25% off off RRP
-      </span>
-      <span class="ncf__payment-term__title">
-        Monthly
-      </span>
-      <div class="ncf__payment-term__description">
-        <span class="ncf__payment-term__price">
-          £20.00
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round ncf__payment-term__item--discount">
+      <input type="radio"
+             id="monthly"
+             name="paymentTerm"
+             value="monthly"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+      >
+      <label for="monthly"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__discount">
+          Save 25% off off RRP
         </span>
-        per month
-        <p class="ncf__payment-term__renews-text">
-          Renews monthly unless cancelled
-        </p>
-      </div>
-    </label>
+        <span class="ncf__payment-term__title">
+          Monthly
+        </span>
+        <div class="ncf__payment-term__description">
+          <span class="ncf__payment-term__price">
+            £20.00
+          </span>
+          per month
+          <p class="ncf__payment-term__renews-text">
+            Renews monthly unless cancelled
+          </p>
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -411,31 +427,33 @@ exports[`PaymentTerm monthly option render option with isTrial 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round">
-    <input type="radio"
-           id="monthly"
-           name="paymentTerm"
-           value="monthly"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-    >
-    <label for="monthly"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__title">
-        Trial: Premium Digital - Monthly
-      </span>
-      <div class="ncf__payment-term__description">
-        4 weeks for
-        <span class="ncf__payment-term__trial-price">
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round">
+      <input type="radio"
+             id="monthly"
+             name="paymentTerm"
+             value="monthly"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+      >
+      <label for="monthly"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__title">
+          Trial: Premium Digital - Monthly
         </span>
-        <br>
-        Unless you cancel during your trial you will be billed
-        <span class="ncf__payment-term__price">
-          £20.00
-        </span>
-        per month after the trial period.
-      </div>
-    </label>
+        <div class="ncf__payment-term__description">
+          4 weeks for
+          <span class="ncf__payment-term__trial-price">
+          </span>
+          <br>
+          Unless you cancel during your trial you will be billed
+          <span class="ncf__payment-term__price">
+            £20.00
+          </span>
+          per month after the trial period.
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -461,29 +479,31 @@ exports[`PaymentTerm monthly option render option with monthlyPrice 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round">
-    <input type="radio"
-           id="monthly"
-           name="paymentTerm"
-           value="monthly"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-    >
-    <label for="monthly"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__title">
-        Monthly
-      </span>
-      <div class="ncf__payment-term__description">
-        <span class="ncf__payment-term__price">
-          £20.00
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round">
+      <input type="radio"
+             id="monthly"
+             name="paymentTerm"
+             value="monthly"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+      >
+      <label for="monthly"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__title">
+          Monthly
         </span>
-        per month
-        <p class="ncf__payment-term__renews-text">
-          Renews monthly unless cancelled
-        </p>
-      </div>
-    </label>
+        <div class="ncf__payment-term__description">
+          <span class="ncf__payment-term__price">
+            £20.00
+          </span>
+          per month
+          <p class="ncf__payment-term__renews-text">
+            Renews monthly unless cancelled
+          </p>
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -509,30 +529,32 @@ exports[`PaymentTerm monthly option render option with selected 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round">
-    <input type="radio"
-           id="monthly"
-           name="paymentTerm"
-           value="monthly"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-           checked
-    >
-    <label for="monthly"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__title">
-        Monthly
-      </span>
-      <div class="ncf__payment-term__description">
-        <span class="ncf__payment-term__price">
-          £20.00
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round">
+      <input type="radio"
+             id="monthly"
+             name="paymentTerm"
+             value="monthly"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+             checked
+      >
+      <label for="monthly"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__title">
+          Monthly
         </span>
-        per month
-        <p class="ncf__payment-term__renews-text">
-          Renews monthly unless cancelled
-        </p>
-      </div>
-    </label>
+        <div class="ncf__payment-term__description">
+          <span class="ncf__payment-term__price">
+            £20.00
+          </span>
+          per month
+          <p class="ncf__payment-term__renews-text">
+            Renews monthly unless cancelled
+          </p>
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -558,32 +580,34 @@ exports[`PaymentTerm monthly option render option with trial 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round">
-    <input type="radio"
-           id="monthly"
-           name="paymentTerm"
-           value="monthly"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-    >
-    <label for="monthly"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__title">
-        Trial: Premium Digital - Monthly
-      </span>
-      <div class="ncf__payment-term__description">
-        6 weeks for
-        <span class="ncf__payment-term__trial-price">
-          £1.00
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round">
+      <input type="radio"
+             id="monthly"
+             name="paymentTerm"
+             value="monthly"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+      >
+      <label for="monthly"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__title">
+          Trial: Premium Digital - Monthly
         </span>
-        <br>
-        Unless you cancel during your trial you will be billed
-        <span class="ncf__payment-term__price">
-          £20.00
-        </span>
-        per month after the trial period.
-      </div>
-    </label>
+        <div class="ncf__payment-term__description">
+          6 weeks for
+          <span class="ncf__payment-term__trial-price">
+            £1.00
+          </span>
+          <br>
+          Unless you cancel during your trial you will be billed
+          <span class="ncf__payment-term__price">
+            £20.00
+          </span>
+          per month after the trial period.
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -609,29 +633,31 @@ exports[`PaymentTerm quarterly option render option 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round">
-    <input type="radio"
-           id="quarterly"
-           name="paymentTerm"
-           value="quarterly"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-    >
-    <label for="quarterly"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__title">
-        Quarterly
-      </span>
-      <div class="ncf__payment-term__description">
-        <span class="ncf__payment-term__price">
-          £20.00
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round">
+      <input type="radio"
+             id="quarterly"
+             name="paymentTerm"
+             value="quarterly"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+      >
+      <label for="quarterly"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__title">
+          Quarterly
         </span>
-        per quarter
-        <p class="ncf__payment-term__renews-text">
-          Renews quarterly unless cancelled
-        </p>
-      </div>
-    </label>
+        <div class="ncf__payment-term__description">
+          <span class="ncf__payment-term__price">
+            £20.00
+          </span>
+          per quarter
+          <p class="ncf__payment-term__renews-text">
+            Renews quarterly unless cancelled
+          </p>
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -657,32 +683,34 @@ exports[`PaymentTerm quarterly option render option with discount 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round ncf__payment-term__item--discount">
-    <input type="radio"
-           id="quarterly"
-           name="paymentTerm"
-           value="quarterly"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-    >
-    <label for="quarterly"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__discount">
-        Save 25% off off RRP
-      </span>
-      <span class="ncf__payment-term__title">
-        Quarterly
-      </span>
-      <div class="ncf__payment-term__description">
-        <span class="ncf__payment-term__price">
-          £20.00
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round ncf__payment-term__item--discount">
+      <input type="radio"
+             id="quarterly"
+             name="paymentTerm"
+             value="quarterly"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+      >
+      <label for="quarterly"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__discount">
+          Save 25% off off RRP
         </span>
-        per quarter
-        <p class="ncf__payment-term__renews-text">
-          Renews quarterly unless cancelled
-        </p>
-      </div>
-    </label>
+        <span class="ncf__payment-term__title">
+          Quarterly
+        </span>
+        <div class="ncf__payment-term__description">
+          <span class="ncf__payment-term__price">
+            £20.00
+          </span>
+          per quarter
+          <p class="ncf__payment-term__renews-text">
+            Renews quarterly unless cancelled
+          </p>
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -708,31 +736,33 @@ exports[`PaymentTerm quarterly option render option with isTrial 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round">
-    <input type="radio"
-           id="quarterly"
-           name="paymentTerm"
-           value="quarterly"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-    >
-    <label for="quarterly"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__title">
-        Trial: Premium Digital - Quarterly
-      </span>
-      <div class="ncf__payment-term__description">
-        4 weeks for
-        <span class="ncf__payment-term__trial-price">
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round">
+      <input type="radio"
+             id="quarterly"
+             name="paymentTerm"
+             value="quarterly"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+      >
+      <label for="quarterly"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__title">
+          Trial: Premium Digital - Quarterly
         </span>
-        <br>
-        Unless you cancel during your trial you will be billed
-        <span class="ncf__payment-term__price">
-          £20.00
-        </span>
-        per quarter after the trial period.
-      </div>
-    </label>
+        <div class="ncf__payment-term__description">
+          4 weeks for
+          <span class="ncf__payment-term__trial-price">
+          </span>
+          <br>
+          Unless you cancel during your trial you will be billed
+          <span class="ncf__payment-term__price">
+            £20.00
+          </span>
+          per quarter after the trial period.
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -758,29 +788,31 @@ exports[`PaymentTerm quarterly option render option with monthlyPrice 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round">
-    <input type="radio"
-           id="quarterly"
-           name="paymentTerm"
-           value="quarterly"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-    >
-    <label for="quarterly"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__title">
-        Quarterly
-      </span>
-      <div class="ncf__payment-term__description">
-        <span class="ncf__payment-term__price">
-          £20.00
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round">
+      <input type="radio"
+             id="quarterly"
+             name="paymentTerm"
+             value="quarterly"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+      >
+      <label for="quarterly"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__title">
+          Quarterly
         </span>
-        per quarter
-        <p class="ncf__payment-term__renews-text">
-          Renews quarterly unless cancelled
-        </p>
-      </div>
-    </label>
+        <div class="ncf__payment-term__description">
+          <span class="ncf__payment-term__price">
+            £20.00
+          </span>
+          per quarter
+          <p class="ncf__payment-term__renews-text">
+            Renews quarterly unless cancelled
+          </p>
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -806,30 +838,32 @@ exports[`PaymentTerm quarterly option render option with selected 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round">
-    <input type="radio"
-           id="quarterly"
-           name="paymentTerm"
-           value="quarterly"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-           checked
-    >
-    <label for="quarterly"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__title">
-        Quarterly
-      </span>
-      <div class="ncf__payment-term__description">
-        <span class="ncf__payment-term__price">
-          £20.00
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round">
+      <input type="radio"
+             id="quarterly"
+             name="paymentTerm"
+             value="quarterly"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+             checked
+      >
+      <label for="quarterly"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__title">
+          Quarterly
         </span>
-        per quarter
-        <p class="ncf__payment-term__renews-text">
-          Renews quarterly unless cancelled
-        </p>
-      </div>
-    </label>
+        <div class="ncf__payment-term__description">
+          <span class="ncf__payment-term__price">
+            £20.00
+          </span>
+          per quarter
+          <p class="ncf__payment-term__renews-text">
+            Renews quarterly unless cancelled
+          </p>
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -855,32 +889,34 @@ exports[`PaymentTerm quarterly option render option with trial 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
-  <div class="ncf__payment-term__item o-forms-input--radio-round">
-    <input type="radio"
-           id="quarterly"
-           name="paymentTerm"
-           value="quarterly"
-           class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
-    >
-    <label for="quarterly"
-           class="o-forms-input__label ncf__payment-term__label"
-    >
-      <span class="ncf__payment-term__title">
-        Trial: Premium Digital - Quarterly
-      </span>
-      <div class="ncf__payment-term__description">
-        6 weeks for
-        <span class="ncf__payment-term__trial-price">
-          £1.00
+  <div class>
+    <div class="ncf__payment-term__item o-forms-input--radio-round">
+      <input type="radio"
+             id="quarterly"
+             name="paymentTerm"
+             value="quarterly"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+      >
+      <label for="quarterly"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__title">
+          Trial: Premium Digital - Quarterly
         </span>
-        <br>
-        Unless you cancel during your trial you will be billed
-        <span class="ncf__payment-term__price">
-          £20.00
-        </span>
-        per quarter after the trial period.
-      </div>
-    </label>
+        <div class="ncf__payment-term__description">
+          6 weeks for
+          <span class="ncf__payment-term__trial-price">
+            £1.00
+          </span>
+          <br>
+          Unless you cancel during your trial you will be billed
+          <span class="ncf__payment-term__price">
+            £20.00
+          </span>
+          per quarter after the trial period.
+        </div>
+      </label>
+    </div>
   </div>
   <div class="ncf__payment-term__legal">
     <p>
@@ -906,6 +942,8 @@ exports[`PaymentTerm render with defaults 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
+  <div class>
+  </div>
   <div class="ncf__payment-term__legal">
     <p>
       With all subscription types, we will automatically renew your subscription using the payment method provided unless you cancel before your renewal date.
@@ -930,6 +968,8 @@ exports[`PaymentTerm render with isPrintOrBundle 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"
 >
+  <div class>
+  </div>
   <div class="ncf__payment-term__legal">
     <p>
       With all subscription types, we will automatically renew your subscription using the payment method provided unless you cancel before your renewal date.

--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -116,7 +116,8 @@ export function PaymentTerm({
 			return (
 				option.discount && (
 					<span className="ncf__payment-term__discount">
-						{option.bestOffer ? 'Best offer -' : 'Save'} {option.discount} off RRP
+						{option.bestOffer ? 'Best offer -' : 'Save'} {option.discount} off
+						RRP
 					</span>
 				)
 			);
@@ -129,7 +130,8 @@ export function PaymentTerm({
 						{option.trialPrice}
 					</span>
 					<br />
-					{nameMap[option.name] && nameMap[option.name].trialPrice(option.price)}
+					{nameMap[option.name] &&
+						nameMap[option.name].trialPrice(option.price)}
 				</div>
 			) : (
 				<React.Fragment>
@@ -143,7 +145,11 @@ export function PaymentTerm({
 						</div>
 					) : (
 						<div>
-							<span className={largePrice ? 'ncf__payment-term__large-price' : ''}>{option.price}</span>
+							<span
+								className={largePrice ? 'ncf__payment-term__large-price' : ''}
+							>
+								{option.price}
+							</span>
 							{option.chargeOnText && (
 								<p className="ncf__payment-term__charge-on-text">
 									{option.chargeOnText}
@@ -151,7 +157,7 @@ export function PaymentTerm({
 							)}
 						</div>
 					)}
-					</React.Fragment>
+				</React.Fragment>
 			);
 		};
 
@@ -166,8 +172,7 @@ export function PaymentTerm({
 
 					<span className="ncf__payment-term__title">
 						{showTrialCopyInTitle ? 'Trial: Premium Digital - ' : ''}
-						{nameMap[option.name] ? title : option.title}
-						{' '}
+						{nameMap[option.name] ? title : option.title}{' '}
 						{option.subTitle && (
 							<span className="ncf__regular">{option.subTitle}</span>
 						)}
@@ -181,7 +186,7 @@ export function PaymentTerm({
 
 	return (
 		<div id={fieldId} className="o-forms__group ncf__payment-term">
-			<div className={`${optionsInARow ? 'ncf__payment-term__options-grid' : ''}`}>
+			<div className={optionsInARow ? 'ncf__payment-term__options-grid' : ''}>
 				{options.map((option) => createPaymentTerm(option))}
 			</div>
 
@@ -210,8 +215,8 @@ export function PaymentTerm({
 							</p>
 							<p>
 								We will notify you at least 14 days in advance of any changes to
-								the price in your subscription that would apply upon next renewal.
-								Find out more about our cancellation policy in our{' '}
+								the price in your subscription that would apply upon next
+								renewal. Find out more about our cancellation policy in our{' '}
 								<a
 									className="ncf__link--external"
 									href="https://help.ft.com/legal-privacy/terms-and-conditions/"

--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -9,6 +9,9 @@ export function PaymentTerm({
 	options = [],
 	isFixedTermOffer = false,
 	displayName,
+	showLegal = true,
+	largePrice = false,
+	optionsInARow = false,
 }) {
 	const nameMap = {
 		annual: {
@@ -113,7 +116,7 @@ export function PaymentTerm({
 			return (
 				option.discount && (
 					<span className="ncf__payment-term__discount">
-						Save {option.discount} off RRP
+						{option.bestOffer ? 'Best offer -' : 'Save'} {option.discount} off RRP
 					</span>
 				)
 			);
@@ -126,16 +129,29 @@ export function PaymentTerm({
 						{option.trialPrice}
 					</span>
 					<br />
-					{nameMap[option.name].trialPrice(option.price)}
+					{nameMap[option.name] && nameMap[option.name].trialPrice(option.price)}
 				</div>
 			) : (
-				<div className="ncf__payment-term__description">
-					{nameMap[option.name].price(option.price)}
-					{nameMap[option.name].monthlyPrice(option.monthlyPrice)}
-					{nameMap[option.name].renewsText(isFixedTermOffer)}
-					{/* Remove this discount text temporarily in favour of monthly price */}
-					{/* <br />Save up to 25% when you pay annually */}
-				</div>
+				<React.Fragment>
+					{nameMap[option.name] ? (
+						<div className="ncf__payment-term__description">
+							{nameMap[option.name].price(option.price)}
+							{nameMap[option.name].monthlyPrice(option.monthlyPrice)}
+							{nameMap[option.name].renewsText(isFixedTermOffer)}
+							{/* Remove this discount text temporarily in favour of monthly price */}
+							{/* <br />Save up to 25% when you pay annually */}
+						</div>
+					) : (
+						<div>
+							<span className={largePrice ? 'ncf__payment-term__large-price' : ''}>{option.price}</span>
+							{option.chargeOnText && (
+								<p className="ncf__payment-term__charge-on-text">
+									{option.chargeOnText}
+								</p>
+							)}
+						</div>
+					)}
+					</React.Fragment>
 			);
 		};
 
@@ -150,7 +166,11 @@ export function PaymentTerm({
 
 					<span className="ncf__payment-term__title">
 						{showTrialCopyInTitle ? 'Trial: Premium Digital - ' : ''}
-						{title}
+						{nameMap[option.name] ? title : option.title}
+						{' '}
+						{option.subTitle && (
+							<span className="ncf__regular">{option.subTitle}</span>
+						)}
 					</span>
 
 					{createDescription()}
@@ -161,33 +181,14 @@ export function PaymentTerm({
 
 	return (
 		<div id={fieldId} className="o-forms__group ncf__payment-term">
-			{options.map((option) => createPaymentTerm(option))}
+			<div className={`${optionsInARow ? 'ncf__payment-term__options-grid' : ''}`}>
+				{options.map((option) => createPaymentTerm(option))}
+			</div>
 
-			<div className="ncf__payment-term__legal">
-				{isFixedTermOffer ? (
-					<p>
-						Find out more about our cancellation policy in our{' '}
-						<a
-							className="ncf__link--external"
-							href="https://help.ft.com/legal-privacy/terms-and-conditions/"
-							title="FT Legal Terms and Conditions help page"
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							Terms &amp; Conditions
-						</a>
-						.
-					</p>
-				) : (
-					<React.Fragment>
+			{showLegal && (
+				<div className="ncf__payment-term__legal">
+					{isFixedTermOffer ? (
 						<p>
-							With all subscription types, we will automatically renew your
-							subscription using the payment method provided unless you cancel
-							before your renewal date.
-						</p>
-						<p>
-							We will notify you at least 14 days in advance of any changes to
-							the price in your subscription that would apply upon next renewal.
 							Find out more about our cancellation policy in our{' '}
 							<a
 								className="ncf__link--external"
@@ -200,9 +201,32 @@ export function PaymentTerm({
 							</a>
 							.
 						</p>
-					</React.Fragment>
-				)}
-			</div>
+					) : (
+						<React.Fragment>
+							<p>
+								With all subscription types, we will automatically renew your
+								subscription using the payment method provided unless you cancel
+								before your renewal date.
+							</p>
+							<p>
+								We will notify you at least 14 days in advance of any changes to
+								the price in your subscription that would apply upon next renewal.
+								Find out more about our cancellation policy in our{' '}
+								<a
+									className="ncf__link--external"
+									href="https://help.ft.com/legal-privacy/terms-and-conditions/"
+									title="FT Legal Terms and Conditions help page"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									Terms &amp; Conditions
+								</a>
+								.
+							</p>
+						</React.Fragment>
+					)}
+				</div>
+			)}
 		</div>
 	);
 }
@@ -225,8 +249,15 @@ PaymentTerm.propTypes = {
 			trialAmount: PropTypes.number,
 			value: PropTypes.string.isRequired,
 			monthlyPrice: PropTypes.string,
+			title: PropTypes.string,
+			subTitle: PropTypes.string,
+			bestOffer: PropTypes.bool,
+			chargeOnText: PropTypes.string,
 		})
 	),
 	isFixedTermOffer: PropTypes.bool,
 	displayName: PropTypes.string,
+	showLegal: PropTypes.bool,
+	largePrice: PropTypes.bool,
+	optionsInARow: PropTypes.bool,
 };

--- a/components/payment-term.spec.js
+++ b/components/payment-term.spec.js
@@ -124,16 +124,26 @@ describe('PaymentTerm', () => {
 				price: '$5.00',
 				value: 'monthly',
 				monthlyPrice: '$5.00',
-			}
+			},
 		];
-		const wrapper = shallow(<PaymentTerm isFixedTermOffer={true} options={options} displayName='Mix & Match' />);
+		const wrapper = shallow(
+			<PaymentTerm
+				isFixedTermOffer={true}
+				options={options}
+				displayName="Mix & Match"
+			/>
+		);
 
 		it('should not include renewal text', () => {
-			expect(wrapper.find('.ncf__payment-term__renews-text').text()).not.toMatch(/Renews (annually|monthly|quarterly) unless cancelled/);
+			expect(
+				wrapper.find('.ncf__payment-term__renews-text').text()
+			).not.toMatch(/Renews (annually|monthly|quarterly) unless cancelled/);
 		});
 
 		it('should render fixed term renewal text in English', () => {
-			expect(wrapper.find('.ncf__payment-term__renews-text').text()).toMatch(/This subscription is for 3 months, charged monthly. You can cancel at anytime/);
+			expect(wrapper.find('.ncf__payment-term__renews-text').text()).toMatch(
+				/This subscription is for 3 months, charged monthly. You can cancel at anytime/
+			);
 		});
 
 		it('should render offer name on payment term title', () => {
@@ -154,7 +164,7 @@ describe('PaymentTerm', () => {
 					isTrial: false,
 					amount: 100,
 					trialAmount: 1,
-				}
+				},
 			];
 			const wrapper = shallow(<PaymentTerm options={options} />);
 			expect(wrapper.find('input').prop('data-base-amount')).toEqual(100);
@@ -170,11 +180,10 @@ describe('PaymentTerm', () => {
 					isTrial: true,
 					amount: 100,
 					trialAmount: 1,
-				}
+				},
 			];
 			const wrapper = shallow(<PaymentTerm options={options} />);
 			expect(wrapper.find('input').prop('data-base-amount')).toEqual(1);
 		});
-
 	});
 });

--- a/components/payment-term.stories.js
+++ b/components/payment-term.stories.js
@@ -35,17 +35,23 @@ Basic.args = {
 	],
 };
 
-export const FixedTermOffer = (args) => <div className="ncf"><Fieldset><PaymentTerm {...args} /></Fieldset></div>;
+export const FixedTermOffer = (args) => (
+	<div className="ncf">
+		<Fieldset>
+			<PaymentTerm {...args} />
+		</Fieldset>
+	</div>
+);
 FixedTermOffer.args = {
 	options: [
 		{
 			name: 'monthly',
 			price: '$5.00',
-			value: 5.00,
-		}
+			value: 5.0,
+		},
 	],
 	isFixedTermOffer: true,
-	displayName: 'Mix & Match'
+	displayName: 'Mix & Match',
 };
 
 export const RenewOffers = (args) => (
@@ -64,7 +70,7 @@ RenewOffers.args = {
 			title: 'Annual',
 			subTitle: '(Renews annually unless cancelled)',
 			price: '€ 270.00',
-			value: 270.00,
+			value: 270.0,
 			isTrial: false,
 			discount: '33%',
 			bestOffer: true,
@@ -74,7 +80,7 @@ RenewOffers.args = {
 		{
 			title: '12 Month Subscription',
 			price: '€ 300.00',
-			value: 300.00,
+			value: 300.0,
 			isTrial: false,
 			discount: '10%',
 			selected: true,

--- a/components/payment-term.stories.js
+++ b/components/payment-term.stories.js
@@ -47,3 +47,39 @@ FixedTermOffer.args = {
 	isFixedTermOffer: true,
 	displayName: 'Mix & Match'
 };
+
+export const RenewOffers = (args) => (
+	<div className="ncf">
+		<Fieldset>
+			<PaymentTerm {...args} />
+		</Fieldset>
+	</div>
+);
+
+RenewOffers.args = {
+	showLegal: false,
+	largePrice: true,
+	options: [
+		{
+			title: 'Annual',
+			subTitle: '(Renews annually unless cancelled)',
+			price: '€ 270.00',
+			value: 270.00,
+			isTrial: false,
+			discount: '33%',
+			bestOffer: true,
+			selected: false,
+			chargeOnText: 'You will be charged on May 1, 2021',
+		},
+		{
+			title: '12 Month Subscription',
+			price: '€ 300.00',
+			value: 300.00,
+			isTrial: false,
+			discount: '10%',
+			selected: true,
+			chargeOnText: 'You will be charged on May 1, 2021',
+		},
+	],
+	optionsInARow: true,
+};

--- a/main.scss
+++ b/main.scss
@@ -291,6 +291,10 @@
 		font-weight: oFontsWeight('semibold');
 	}
 
+	&__regular {
+		font-weight: oFontsWeight('regular');
+	}
+
 	&__icon {
 		background: oColorsByName('paper');
 		border: 2px solid oColorsByName('black-40');

--- a/styles/_shared.scss
+++ b/styles/_shared.scss
@@ -8,6 +8,7 @@
 			border: 2px solid oColorsByName('teal');
 			text-align: left;
 			width: 100%;
+			position: relative;
 
 			// radio button styling
 			&::before {
@@ -53,7 +54,6 @@
 		+ .o-forms-input__label {
 			background-color: oColorsByName('teal');
 			color: oColorsByName('white');
-			position: relative;
 
 			// radio button styling
 			&::before {

--- a/styles/payment-term.scss
+++ b/styles/payment-term.scss
@@ -11,7 +11,10 @@
 
 				> * {
 					flex: 1;
-					margin-left: oGridGutter(L);
+
+					&:not(:first-child) {
+						margin-left: oGridGutter(L);
+					}
 				}
 			}
 		}

--- a/styles/payment-term.scss
+++ b/styles/payment-term.scss
@@ -4,6 +4,18 @@
 	&__payment-term {
 		@include bigRadioButton($className: '.ncf__payment-term');
 
+		@include oGridRespondTo(L) {
+			&__options-grid {
+				display: flex;
+				align-items: baseline;
+
+				> * {
+					flex: 1;
+					margin-left: oGridGutter(L);
+				}
+			}
+		}
+
 		&__item {
 			position: relative;
 			margin-bottom: oSpacingByName('s3');
@@ -47,9 +59,20 @@
 			font-weight: oFontsWeight('semibold');
 		}
 
+		&__large-price {
+			@include oTypographySans($scale: 5, $include-font-family: false);
+			font-weight: oFontsWeight('semibold');
+		}
+
 		&__renews-text {
 			@include oTypographySans($scale: -2, $include-font-family: false);
 			margin-bottom: 0;
+		}
+
+		&__charge-on-text {
+			@include oTypographySans($scale: -1, $include-font-family: false);
+			margin-bottom: 0;
+			margin-top: oSpacingByName('s1');
 		}
 	}
 }


### PR DESCRIPTION
### Description

As part of [ACC-998](https://financialtimes.atlassian.net/browse/ACC-998), this PR adds some new style options to the `PaymentTerm` component. This includes:

- Larger price size with prop `largePrice`
- Hide legal copy with `showLegal={false}`
- Have options appear in a row for larger screen sizes with `optionsInARow`
- Control the name of the payment term option with `title` and `subTitle` keys
- Prepend "Best offer - " to discount with `bestOffer: true` for each option
- Control the last line text with `chargeOnText` for each option

This PR also fixes a small graphical issue where the radio button and discount would move slightly when an option is selected / not selected.

### Ticket

https://financialtimes.atlassian.net/browse/ACC-998

### Screenshots

Large screen:

![image](https://user-images.githubusercontent.com/893208/127458869-6a0b7118-7b2c-4141-a010-5946e8751798.png)

Small screen:

![image](https://user-images.githubusercontent.com/893208/127458899-4d7f6c30-d804-420e-8960-b6304a7034f1.png)


### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
