### PR TITLE
Fix .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,9 +163,6 @@ workflows:
       - test:
           requires:
             - build
-      - provision:
-          requires:
-            - build
 
   nightly:
     triggers:


### PR DESCRIPTION
Our CircleCi builds are failing. As pointed out by @meel-io in #567, [CircleCi couldn't find our `provision` as a valid step](https://github.com/Financial-Times/n-conversion-forms/pull/567/files#r678181477). We shouldn't need the provision step for this config.