### PR TITLE
ACC-998: Fix PaymentTerm bug where name is undefined

### DIFF
--- a/components/__snapshots__/payment-term.spec.js.snap
+++ b/components/__snapshots__/payment-term.spec.js.snap
@@ -1,5 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PaymentTerm When using custom options renders when not using an option in nameMap but provides a custom props instead 1`] = `
+<div id="paymentTermField"
+     class="o-forms__group ncf__payment-term"
+>
+  <div class="ncf__payment-term__options-grid">
+    <div class="ncf__payment-term__item o-forms-input--radio-round ncf__payment-term__item--discount">
+      <input type="radio"
+             id="270"
+             name="paymentTerm"
+             value="270"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+      >
+      <label for="270"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__discount">
+          Best offer - 33% off RRP
+        </span>
+        <span class="ncf__payment-term__title">
+          Annual
+          <span class="ncf__regular">
+            (Renews annually unless cancelled)
+          </span>
+        </span>
+        <div>
+          <span class="ncf__payment-term__large-price">
+            € 270.00
+          </span>
+          <p class="ncf__payment-term__charge-on-text">
+            You will be charged on May 1, 2021
+          </p>
+        </div>
+      </label>
+    </div>
+    <div class="ncf__payment-term__item o-forms-input--radio-round ncf__payment-term__item--discount">
+      <input type="radio"
+             id="300"
+             name="paymentTerm"
+             value="300"
+             class="o-forms-input__radio o-forms-input__radio--right ncf__payment-term__input"
+             checked
+      >
+      <label for="300"
+             class="o-forms-input__label ncf__payment-term__label"
+      >
+        <span class="ncf__payment-term__discount">
+          Save 10% off RRP
+        </span>
+        <span class="ncf__payment-term__title">
+          12 Month Subscription
+        </span>
+        <div>
+          <span class="ncf__payment-term__large-price">
+            € 300.00
+          </span>
+          <p class="ncf__payment-term__charge-on-text">
+            You will be charged on May 1, 2021
+          </p>
+        </div>
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`PaymentTerm annual option render option 1`] = `
 <div id="paymentTermField"
      class="o-forms__group ncf__payment-term"

--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -108,7 +108,7 @@ export function PaymentTerm({
 		};
 		const showTrialCopyInTitle =
 			option.isTrial && !isPrintOrBundle && !isEpaper;
-		const defaultTitle = nameMap[option.name].title;
+		const defaultTitle = option.name ? nameMap[option.name].title : '';
 		const title = isFixedTermOffer
 			? `${displayName} - ${defaultTitle}`
 			: defaultTitle;

--- a/components/payment-term.spec.js
+++ b/components/payment-term.spec.js
@@ -186,4 +186,38 @@ describe('PaymentTerm', () => {
 			expect(wrapper.find('input').prop('data-base-amount')).toEqual(1);
 		});
 	});
+
+	describe('When using custom options', () => {
+		it('renders when not using an option in nameMap but provides a custom props instead', () => {
+			const props = {
+				showLegal: false,
+				largePrice: true,
+				options: [
+					{
+						title: 'Annual',
+						subTitle: '(Renews annually unless cancelled)',
+						price: '€ 270.00',
+						value: 270.0,
+						isTrial: false,
+						discount: '33%',
+						bestOffer: true,
+						selected: false,
+						chargeOnText: 'You will be charged on May 1, 2021',
+					},
+					{
+						title: '12 Month Subscription',
+						price: '€ 300.00',
+						value: 300.0,
+						isTrial: false,
+						discount: '10%',
+						selected: true,
+						chargeOnText: 'You will be charged on May 1, 2021',
+					},
+				],
+				optionsInARow: true,
+			};
+
+			expect(PaymentTerm).toRenderCorrectly(props);
+		});
+	});
 });


### PR DESCRIPTION
A small bug sneaked in where if an option does not use the `nameMap`, it will break building a `defaultTitle`.
