### PR TITLE
ACC-1000: Add new term to AcceptTerms and tweak styles of PaymentTerm

### DIFF
--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -1266,6 +1266,66 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
 </div>
 `;
 
+exports[`AcceptTerms renders appropriately if is transition with transition type other than immediate and is single term 1`] = `
+<div id="acceptTermsField"
+     class="o-forms-field o-layout-typography ncf__validation-error"
+     data-validate="required,checked"
+>
+  <ul class="o-typography-list ncf__accept-terms-list">
+    <li>
+      <span class="terms-default">
+        I confirm I am 16 years or older and have read and agree to the
+        <a class="ncf__link--external"
+           href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+           target="_blank"
+           rel="noopener noreferrer"
+           data-trackable="terms-and-conditions"
+        >
+          Terms &amp; Conditions
+        </a>
+        .
+      </span>
+    </li>
+    <li>
+      <span class="terms-transition terms-transition--other">
+        By placing my order, I acknowledge that my subscription will start and the chosen payment method will be charged on the date given above. Any cancellation notice received after that date will take effect at the end of my subscription term and previously paid amounts are non-refundable.
+      </span>
+    </li>
+    <li>
+      <span class="terms-transition">
+        Find out more about our cancellation policy in our
+        <a class="ncf__link--external"
+           href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+           target="_blank"
+           rel="noopener noreferrer"
+        >
+          Terms &amp; Conditions
+        </a>
+        .
+      </span>
+    </li>
+  </ul>
+  <label class="o-forms-input o-forms-input--checkbox"
+         for="termsAcceptance"
+  >
+    <input type="checkbox"
+           id="termsAcceptance"
+           name="termsAcceptance"
+           value="true"
+           data-trackable="field-terms"
+           aria-required="true"
+           required
+    >
+    <span class="o-forms-input__label">
+      I agree to the above terms &amp; conditions.
+    </span>
+    <p class="o-forms-input__error">
+      Please accept our terms &amp; conditions
+    </p>
+  </label>
+</div>
+`;
+
 exports[`AcceptTerms renders with an error 1`] = `
 <div id="acceptTermsField"
      class="o-forms-field o-layout-typography ncf__validation-error"

--- a/components/__snapshots__/payment-term.spec.js.snap
+++ b/components/__snapshots__/payment-term.spec.js.snap
@@ -18,9 +18,9 @@ exports[`PaymentTerm When using custom options renders when not using an option 
         <span class="ncf__payment-term__discount">
           Best offer - 33% off RRP
         </span>
-        <span class="ncf__payment-term__title">
+        <span class="ncf__payment-term__title ncf__payment-term__title--large-price">
           Annual
-          <span class="ncf__regular">
+          <span class="ncf__regular ncf__payment-term__sub-title">
             (Renews annually unless cancelled)
           </span>
         </span>
@@ -48,7 +48,7 @@ exports[`PaymentTerm When using custom options renders when not using an option 
         <span class="ncf__payment-term__discount">
           Save 10% off RRP
         </span>
-        <span class="ncf__payment-term__title">
+        <span class="ncf__payment-term__title ncf__payment-term__title--large-price">
           12 Month Subscription
         </span>
         <div>

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -19,6 +19,7 @@ export function AcceptTerms({
 	transitionType = null,
 	isPrintProduct = false,
 	specialTerms = null,
+	isSingleTerm = false,
 }) {
 	const divProps = {
 		id: 'acceptTermsField',
@@ -132,22 +133,24 @@ export function AcceptTerms({
 
 	const transitionTerms = isTransition && (
 		<>
-			<li>
-				<span className="terms-transition">
-					I give consent for my chosen payment method to be charged
-					automatically at the end of each subscription term until I cancel it
-					by contacting{' '}
-					<a
-						className="ncf__link--external"
-						href="https://help.ft.com/help/contact-us/"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						customer care through chat, phone or email
-					</a>
-					.
-				</span>
-			</li>
+			{!isSingleTerm && (
+				<li>
+					<span className="terms-transition">
+						I give consent for my chosen payment method to be charged
+						automatically at the end of each subscription term until I cancel it
+						by contacting{' '}
+						<a
+							className="ncf__link--external"
+							href="https://help.ft.com/help/contact-us/"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							customer care through chat, phone or email
+						</a>
+						.
+					</span>
+				</li>
+			)}
 			{transitionType === 'immediate' ? (
 				<li>
 					<span className="terms-transition terms-transition--immediate">
@@ -160,6 +163,9 @@ export function AcceptTerms({
 				<li>
 					<span className="terms-transition terms-transition--other">
 						By placing my order, I acknowledge that my subscription will start
+						{isSingleTerm
+							? ' and the chosen payment method will be charged '
+							: ' '}
 						on the date given above. Any cancellation notice received after that
 						date will take effect at the end of my subscription term and
 						previously paid amounts are non-refundable.
@@ -326,4 +332,5 @@ AcceptTerms.propTypes = {
 	transitionType: PropTypes.string,
 	isPrintProduct: PropTypes.bool,
 	specialTerms: PropTypes.string,
+	isSingleTerm: PropTypes.bool,
 };

--- a/components/accept-terms.spec.js
+++ b/components/accept-terms.spec.js
@@ -145,6 +145,16 @@ describe('AcceptTerms', () => {
 		expect(AcceptTerms).toRenderCorrectly(props);
 	});
 
+	it('renders appropriately if is transition with transition type other than immediate and is single term', () => {
+		const props = {
+			isTransition: true,
+			transitionType: 'foobar',
+			isSingleTerm: true,
+		};
+
+		expect(AcceptTerms).toRenderCorrectly(props);
+	});
+
 	it('renders appropriately if is B2C Partnership', () => {
 		const props = { isB2cPartnership: true };
 

--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -170,11 +170,18 @@ export function PaymentTerm({
 				>
 					{createDiscount()}
 
-					<span className="ncf__payment-term__title">
+					<span
+						className={classNames([
+							'ncf__payment-term__title',
+							{ 'ncf__payment-term__title--large-price': largePrice },
+						])}
+					>
 						{showTrialCopyInTitle ? 'Trial: Premium Digital - ' : ''}
 						{nameMap[option.name] ? title : option.title}{' '}
 						{option.subTitle && (
-							<span className="ncf__regular">{option.subTitle}</span>
+							<span className="ncf__regular ncf__payment-term__sub-title">
+								{option.subTitle}
+							</span>
 						)}
 					</span>
 

--- a/styles/payment-term.scss
+++ b/styles/payment-term.scss
@@ -7,7 +7,7 @@
 		@include oGridRespondTo(L) {
 			&__options-grid {
 				display: flex;
-				align-items: baseline;
+				align-items: flex-end;
 
 				> * {
 					flex: 1;
@@ -76,6 +76,14 @@
 			@include oTypographySans($scale: -1, $include-font-family: false);
 			margin-bottom: 0;
 			margin-top: oSpacingByName('s1');
+		}
+
+		&__title--large-price {
+			@include oTypographySans($scale: 0, $include-font-family: false);
+		}
+
+		&__sub-title {
+			@include oTypographySans($scale: -1, $include-font-family: false);
 		}
 	}
 }


### PR DESCRIPTION
### Description

Add a new term to AcceptTerms for single term subscriptions in transition. Update styles to PaymentTerm as when options are in a row, they were ever so slightly misaligned (`baseline` can be misleading).

### Ticket

https://financialtimes.atlassian.net/browse/ACC-1000

### Screenshots

![image](https://user-images.githubusercontent.com/893208/129167151-fd1532d4-417c-4e3b-8dfe-0fa38957ccba.png)

![image](https://user-images.githubusercontent.com/893208/129167741-c6525efc-5446-49a3-a94d-f9cdd20f5db6.png)

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
