### PR TITLE
ACQ-1143 Provides an option to remove the links in the progress indicator

### DIFF
--- a/components/__snapshots__/progress-indicator.spec.js.snap
+++ b/components/__snapshots__/progress-indicator.spec.js.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ProgressIndicator renders completed items with disabled links 1`] = `
+<div class="ncf__stepped-progress o-stepped-progress"
+     data-o-component="o-stepped-progress"
+>
+  <ol class="o-stepped-progress__steps">
+    <li>
+      <span class="o-stepped-progress__step o-stepped-progress__step--complete">
+        <span class="o-stepped-progress__label">
+          Item name
+          <span class="o-stepped-progress__status">
+            (completed)
+          </span>
+        </span>
+      </span>
+    </li>
+  </ol>
+</div>
+`;
+
 exports[`ProgressIndicator renders items that are complete 1`] = `
 <div class="ncf__stepped-progress o-stepped-progress"
      data-o-component="o-stepped-progress"

--- a/components/progress-indicator.jsx
+++ b/components/progress-indicator.jsx
@@ -2,9 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export function ProgressIndicator({ items = [] }) {
+export function ProgressIndicator({ items = [], disableLinks = false }) {
 	function getElementsForComplete(item) {
-		return (
+		return disableLinks? (
+			<span className="o-stepped-progress__step o-stepped-progress__step--complete">
+				<span className="o-stepped-progress__label">
+					{item.name}
+					<span className="o-stepped-progress__status">(completed)</span>
+				</span>
+			</span>
+		) : (
 			<a
 				href={item.url}
 				className="o-stepped-progress__step o-stepped-progress__step--complete"
@@ -66,4 +73,5 @@ ProgressIndicator.propTypes = {
 			url: PropTypes.string,
 		})
 	),
+	disableLinks: PropTypes.bool,
 };

--- a/components/progress-indicator.spec.js
+++ b/components/progress-indicator.spec.js
@@ -61,4 +61,20 @@ describe('ProgressIndicator', () => {
 
 		expect(ProgressIndicator).toRenderCorrectly(props);
 	});
+
+	it('renders completed items with disabled links', () => {
+		const props = {
+			items: [
+				{
+					url: 'https://foo.com',
+					name: 'Item name',
+					isComplete: true,
+					isCurrent: false,
+				},
+			],
+			disableLinks: true,
+		};
+
+		expect(ProgressIndicator).toRenderCorrectly(props);
+	});
 });

--- a/components/progress-indicator.stories.js
+++ b/components/progress-indicator.stories.js
@@ -29,3 +29,28 @@ Basic.args = {
 		},
 	],
 };
+
+export const WithLinksDisabled = (args) => <ProgressIndicator {...args} />;
+WithLinksDisabled.args = {
+	items: [
+		{
+			isComplete: true,
+			isCurrent: false,
+			name: 'Get Business',
+			url: 'https://ft.com',
+		},
+		{
+			isComplete: true,
+			isCurrent: true,
+			name: '????',
+			url: 'https://google.com',
+		},
+		{
+			isComplete: false,
+			isCurrent: false,
+			name: 'Profit',
+			url: 'https://ft.com',
+		},
+	],
+	disableLinks: true,
+};


### PR DESCRIPTION
### Description
Provides an option to remove the links on completed items in the progress indicator.

### Ticket
[ACQ-1143](https://financialtimes.atlassian.net/browse/ACQ-1143)

### Related PR 
https://github.com/Financial-Times/next-subscribe/pull/1861

### Screenshots

| Before | After |
| ------ | ----- |
|![Screenshot 2021-09-01 at 17 33 34](https://user-images.githubusercontent.com/45561255/131709307-d756965d-2e93-4117-8733-368f31144aff.png)|![Screenshot 2021-09-01 at 17 33 49](https://user-images.githubusercontent.com/45561255/131709349-11ccbb0b-3592-4edf-ab6c-a61ecc5d5059.png)|

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [X] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
