### PR TITLE
Fix missing eslint dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1466,9 +1466,9 @@
       }
     },
     "@financial-times/eslint-config-next": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/eslint-config-next/-/eslint-config-next-2.0.1.tgz",
-      "integrity": "sha512-2mTv/wvYgsETRsizdLMfSDf7qkU/xIBPn0P+2MIB3oh38kwpDoPknYvVN10I0Kj2cgawQsqLXzNQPuKJzpDRzw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/eslint-config-next/-/eslint-config-next-3.0.0.tgz",
+      "integrity": "sha512-cOwrhMrXlCd/TiD42EQdx0s8VXiELYpSJn+mI6TZrZ0YdaRw9ykcszRRQe/HA5zN8Srr/8izJzVT1yJ0RkN1vg==",
       "dev": true,
       "requires": {
         "eslint": ">=5.0.0",
@@ -1508,6 +1508,16 @@
         "yargs": "^16.0.0"
       },
       "dependencies": {
+        "@financial-times/eslint-config-next": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@financial-times/eslint-config-next/-/eslint-config-next-2.0.1.tgz",
+          "integrity": "sha512-2mTv/wvYgsETRsizdLMfSDf7qkU/xIBPn0P+2MIB3oh38kwpDoPknYvVN10I0Kj2cgawQsqLXzNQPuKJzpDRzw==",
+          "dev": true,
+          "requires": {
+            "eslint": ">=5.0.0",
+            "eslint-plugin-no-only-tests": ">=2.0.0"
+          }
+        },
         "eslint": {
           "version": "5.16.0",
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
@@ -10365,9 +10375,9 @@
       }
     },
     "eslint-plugin-no-only-tests": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.4.0.tgz",
-      "integrity": "sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
+      "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
       "dev": true
     },
     "eslint-plugin-react": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-react": "^7.10.4",
     "@financial-times/dotcom-build-bower-resolve": "2.6.2",
+    "@financial-times/eslint-config-next": "^3.0.0",
     "@financial-times/n-gage": "^8.2.0",
     "@storybook/addon-a11y": "^6.0.10",
     "@storybook/addon-essentials": "^6.0.10",


### PR DESCRIPTION
Add @financial-times/eslint-config-next as a devDependency.

Relates to #585.
