### PR TITLE
ACQ-1330 attempt to fix gh-deploy failure by using node 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ references:
   container_config_node12: &container_config_node12
     working_directory: ~/project/build
     docker:
-      - image: cimg/node:12.22-browsers
+      - image: cimg/node:14.18-browsers
 
   container_config_lambda_node12: &container_config_lambda_node12
     working_directory: ~/project/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ references:
 version: 2.1
 
 orbs:
-  node: circleci/node@4.6.0
+  node: circleci/node@4.7.0
 
 jobs:
 

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
       - uses: actions/checkout@v2
         with:
           persist-credentials: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "snyk": "1.230.7"
       },
       "engines": {
-        "node": "12.x",
+        "node": "12.x || 14.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -6177,23 +6177,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@storybook/addon-essentials/node_modules/tar": {
-      "version": "6.1.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-      "dev": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@storybook/addon-essentials/node_modules/term-size": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -9200,23 +9183,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@storybook/react/node_modules/tar": {
-      "version": "6.1.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-      "dev": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@storybook/react/node_modules/term-size": {
@@ -25239,6 +25205,18 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/node-gyp/node_modules/tar": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "deprecated": "This version of tar is no longer supported, and will not receive security updates. Please upgrade asap.",
+      "dev": true,
+      "dependencies": {
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -31779,7 +31757,6 @@
     },
     "node_modules/snyk/node_modules/lru-cache": {
       "version": "4.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -31798,7 +31775,6 @@
         "https-proxy-agent-snyk-fork",
         "pac-proxy-agent"
       ],
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31817,7 +31793,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/agent-base": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31829,7 +31804,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/ast-types": {
       "version": "0.13.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -31838,7 +31812,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/bytes": {
       "version": "3.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -31847,7 +31820,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/co": {
       "version": "4.6.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -31857,19 +31829,16 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/core-util-is": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/data-uri-to-buffer": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/debug": {
       "version": "3.2.6",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31878,13 +31847,11 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/deep-is": {
       "version": "0.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/degenerator": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31895,7 +31862,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/depd": {
       "version": "1.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -31904,13 +31870,11 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/es6-promise": {
       "version": "4.2.8",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/es6-promisify": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -31919,7 +31883,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/escodegen": {
       "version": "1.12.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -31941,7 +31904,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/esprima": {
       "version": "3.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "bin": {
@@ -31954,7 +31916,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/estraverse": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -31963,7 +31924,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/esutils": {
       "version": "2.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -31972,25 +31932,21 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/extend": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/file-uri-to-path": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/ftp": {
       "version": "0.3.10",
-      "dev": true,
       "inBundle": true,
       "dependencies": {
         "readable-stream": "1.1.x",
@@ -32002,7 +31958,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/ftp/node_modules/readable-stream": {
       "version": "1.1.14",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32014,7 +31969,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/get-uri": {
       "version": "2.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32028,7 +31982,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/get-uri/node_modules/debug": {
       "version": "4.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32037,7 +31990,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/http-errors": {
       "version": "1.7.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32053,7 +32005,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/http-proxy-agent": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32066,7 +32017,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/http-proxy-agent/node_modules/debug": {
       "version": "3.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32075,13 +32025,11 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/http-proxy-agent/node_modules/ms": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/https-proxy-agent-snyk-fork": {
       "version": "2.2.2-fixed-mitm-vuln",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32094,7 +32042,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32106,25 +32053,21 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/ip": {
       "version": "1.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/isarray": {
       "version": "0.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/levn": {
       "version": "0.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32137,13 +32080,11 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/netmask": {
       "version": "1.0.6",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -32152,7 +32093,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/optionator": {
       "version": "0.8.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32169,7 +32109,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/pac-proxy-agent": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32185,7 +32124,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/pac-resolver": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32198,7 +32136,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/prelude-ls": {
       "version": "1.1.2",
-      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -32206,7 +32143,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/raw-body": {
       "version": "2.4.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32221,7 +32157,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/readable-stream": {
       "version": "3.4.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32235,7 +32170,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/readable-stream/node_modules/string_decoder": {
       "version": "1.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32244,25 +32178,21 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/safe-buffer": {
       "version": "5.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/setprototypeof": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/smart-buffer": {
       "version": "4.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -32272,7 +32202,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/socks": {
       "version": "2.3.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32286,7 +32215,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/socks-proxy-agent": {
       "version": "4.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32299,7 +32227,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/socks-proxy-agent/node_modules/agent-base": {
       "version": "4.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32311,17 +32238,14 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/statuses": {
       "version": "1.5.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -32330,19 +32254,16 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/string_decoder": {
       "version": "0.10.31",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/thunkify": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/toidentifier": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -32351,7 +32272,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/type-check": {
       "version": "0.3.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -32363,7 +32283,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/unpipe": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -32372,19 +32291,16 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/wordwrap": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/xregexp": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -32393,13 +32309,11 @@
     },
     "node_modules/snyk/node_modules/proxy-from-env": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/pseudomap": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -32455,7 +32369,6 @@
     },
     "node_modules/snyk/node_modules/yallist": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -33780,16 +33693,48 @@
       }
     },
     "node_modules/tar": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
-      "deprecated": "This version of tar is no longer supported, and will not receive security updates. Please upgrade asap.",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "dependencies": {
-        "block-stream": "*",
-        "fstream": "^1.0.12",
-        "inherits": "2"
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/telejson": {
       "version": "5.3.3",
@@ -41103,20 +41048,6 @@
           "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
           "dev": true
         },
-        "tar": {
-          "version": "6.1.11",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-          "dev": true,
-          "requires": {
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "minipass": "^3.0.0",
-            "minizlib": "^2.1.1",
-            "mkdirp": "^1.0.3",
-            "yallist": "^4.0.0"
-          }
-        },
         "term-size": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -43430,20 +43361,6 @@
           "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
           "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
           "dev": true
-        },
-        "tar": {
-          "version": "6.1.11",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-          "dev": true,
-          "requires": {
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "minipass": "^3.0.0",
-            "minizlib": "^2.1.1",
-            "mkdirp": "^1.0.3",
-            "yallist": "^4.0.0"
-          }
         },
         "term-size": {
           "version": "2.2.1",
@@ -56245,6 +56162,17 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
+        },
+        "tar": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+          "dev": true,
+          "requires": {
+            "block-stream": "*",
+            "fstream": "^1.0.12",
+            "inherits": "2"
+          }
         }
       }
     },
@@ -60984,7 +60912,6 @@
         "lru-cache": {
           "version": "4.1.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
@@ -60997,7 +60924,6 @@
         "proxy-agent": {
           "version": "3.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "agent-base": "^4.2.0",
             "debug": "^3.1.0",
@@ -61012,53 +60938,44 @@
             "agent-base": {
               "version": "4.3.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "es6-promisify": "^5.0.0"
               }
             },
             "ast-types": {
               "version": "0.13.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "bytes": {
               "version": "3.1.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "co": {
               "version": "4.6.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "data-uri-to-buffer": {
               "version": "2.0.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "debug": {
               "version": "3.2.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "ms": "^2.1.1"
               }
             },
             "deep-is": {
               "version": "0.1.3",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "degenerator": {
               "version": "1.0.4",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "ast-types": "0.x.x",
                 "escodegen": "1.x.x",
@@ -61067,18 +60984,15 @@
             },
             "depd": {
               "version": "1.1.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "es6-promise": {
               "version": "4.2.8",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "es6-promisify": {
               "version": "5.0.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "es6-promise": "^4.0.3"
               }
@@ -61086,7 +61000,6 @@
             "escodegen": {
               "version": "1.12.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "esprima": "^3.1.3",
                 "estraverse": "^4.2.0",
@@ -61097,38 +61010,31 @@
             },
             "esprima": {
               "version": "3.1.3",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "estraverse": {
               "version": "4.3.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "esutils": {
               "version": "2.0.3",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "extend": {
               "version": "3.0.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "fast-levenshtein": {
               "version": "2.0.6",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "file-uri-to-path": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "ftp": {
               "version": "0.3.10",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "readable-stream": "1.1.x",
                 "xregexp": "2.0.0"
@@ -61137,7 +61043,6 @@
                 "readable-stream": {
                   "version": "1.1.14",
                   "bundled": true,
-                  "dev": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
                     "inherits": "~2.0.1",
@@ -61150,7 +61055,6 @@
             "get-uri": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "data-uri-to-buffer": "2",
                 "debug": "4",
@@ -61163,7 +61067,6 @@
                 "debug": {
                   "version": "4.1.1",
                   "bundled": true,
-                  "dev": true,
                   "requires": {
                     "ms": "^2.1.1"
                   }
@@ -61173,7 +61076,6 @@
             "http-errors": {
               "version": "1.7.3",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "depd": "~1.1.2",
                 "inherits": "2.0.4",
@@ -61185,7 +61087,6 @@
             "http-proxy-agent": {
               "version": "2.1.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "agent-base": "4",
                 "debug": "3.1.0"
@@ -61194,22 +61095,19 @@
                 "debug": {
                   "version": "3.1.0",
                   "bundled": true,
-                  "dev": true,
                   "requires": {
                     "ms": "2.0.0"
                   }
                 },
                 "ms": {
                   "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true
+                  "bundled": true
                 }
               }
             },
             "https-proxy-agent-snyk-fork": {
               "version": "2.2.2-fixed-mitm-vuln",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "agent-base": "^4.3.0",
                 "debug": "^3.1.0"
@@ -61218,30 +61116,25 @@
             "iconv-lite": {
               "version": "0.4.24",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
               }
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "ip": {
               "version": "1.1.5",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "isarray": {
               "version": "0.0.1",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "levn": {
               "version": "0.3.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2"
@@ -61249,18 +61142,15 @@
             },
             "ms": {
               "version": "2.1.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "netmask": {
               "version": "1.0.6",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "optionator": {
               "version": "0.8.2",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "deep-is": "~0.1.3",
                 "fast-levenshtein": "~2.0.4",
@@ -61273,7 +61163,6 @@
             "pac-proxy-agent": {
               "version": "3.0.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "agent-base": "^4.2.0",
                 "debug": "^3.1.0",
@@ -61288,7 +61177,6 @@
             "pac-resolver": {
               "version": "3.0.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "co": "^4.6.0",
                 "degenerator": "^1.0.4",
@@ -61299,13 +61187,11 @@
             },
             "prelude-ls": {
               "version": "1.1.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "raw-body": {
               "version": "2.4.1",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "bytes": "3.1.0",
                 "http-errors": "1.7.3",
@@ -61316,7 +61202,6 @@
             "readable-stream": {
               "version": "3.4.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -61326,7 +61211,6 @@
                 "string_decoder": {
                   "version": "1.3.0",
                   "bundled": true,
-                  "dev": true,
                   "requires": {
                     "safe-buffer": "~5.2.0"
                   }
@@ -61335,28 +61219,23 @@
             },
             "safe-buffer": {
               "version": "5.2.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "setprototypeof": {
               "version": "1.1.1",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "smart-buffer": {
               "version": "4.0.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "socks": {
               "version": "2.3.2",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "ip": "^1.1.5",
                 "smart-buffer": "4.0.2"
@@ -61365,7 +61244,6 @@
             "socks-proxy-agent": {
               "version": "4.0.2",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "agent-base": "~4.2.1",
                 "socks": "~2.3.2"
@@ -61374,7 +61252,6 @@
                 "agent-base": {
                   "version": "4.2.1",
                   "bundled": true,
-                  "dev": true,
                   "requires": {
                     "es6-promisify": "^5.0.0"
                   }
@@ -61383,69 +61260,56 @@
             },
             "source-map": {
               "version": "0.6.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "statuses": {
               "version": "1.5.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "string_decoder": {
               "version": "0.10.31",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "thunkify": {
               "version": "2.1.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "toidentifier": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "type-check": {
               "version": "0.3.2",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "prelude-ls": "~1.1.2"
               }
             },
             "unpipe": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "wordwrap": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "xregexp": {
               "version": "2.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "proxy-from-env": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "string-width": {
           "version": "3.1.0",
@@ -61486,8 +61350,7 @@
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         }
       }
     },
@@ -63102,14 +62965,37 @@
       "peer": true
     },
     "tar": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.12",
-        "inherits": "2"
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "telejson": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "snyk": "1.230.7"
   },
   "engines": {
-    "node": "12.x",
+    "node": "12.x || 14.x",
     "npm": "7.x || 8.x"
   },
   "lint-staged": {


### PR DESCRIPTION
### Description
When merging #590 deployment to github pages failed because the npm version used in gh-pages-deploy.yml defaulted to 6.x. This PR attempts to fix that by using node 14.


### Ticket
[ACQ-1330](https://financialtimes.atlassian.net/browse/ACQ-1330)


### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
