### PR TITLE
ACQ-1330 explicitly install npm 7 for github pages deployment

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14.x
+      - run: npm install npm@7.24.2
       - uses: actions/checkout@v2
         with:
           persist-credentials: false


### PR DESCRIPTION
### Description
Due to this part of the error message in the deployment logs ![Screenshot 2021-11-19 at 12 22 13](https://user-images.githubusercontent.com/45561255/142622257-6dc29c6b-eb35-4b42-9338-00dcdea5fefb.png) this PR tries to explicitly install npm 7 in the github pages. Very trial and error.

### Ticket
[ACQ-1330](https://financialtimes.atlassian.net/browse/ACQ-1330)


### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
