### PR TITLE
ACQ-1442: remove useless circleci npm update helper, we use package-lock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,9 +78,6 @@ jobs:
           name: Install project dependencies
           command: make install
       - run:
-          name: shared-helper / npm-update
-          command: .circleci/shared-helpers/helper-npm-update
-      - run:
           name: Run the project build task
           command: make build
       - run:


### PR DESCRIPTION
### Description
remove useless circleci npm update helper, we use package-lock

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-1442
