### PR TITLE
ACC-1108 Add maxlength attribute in CompanyName

### DIFF
--- a/components/__snapshots__/company-name.spec.js.snap
+++ b/components/__snapshots__/company-name.spec.js.snap
@@ -20,6 +20,7 @@ exports[`CompanyName renders with a custom value 1`] = `
            data-trackable="company-name"
            aria-required="true"
            required
+           maxlength="50"
            value="foobar"
     >
     <span class="o-forms-input__error">
@@ -49,6 +50,7 @@ exports[`CompanyName renders with an error 1`] = `
            data-trackable="company-name"
            aria-required="true"
            required
+           maxlength="50"
            value
     >
     <span class="o-forms-input__error">
@@ -78,6 +80,7 @@ exports[`CompanyName renders with default props 1`] = `
            data-trackable="company-name"
            aria-required="true"
            required
+           maxlength="50"
            value
     >
     <span class="o-forms-input__error">
@@ -108,6 +111,7 @@ exports[`CompanyName renders with disabled input 1`] = `
            aria-required="true"
            required
            disabled
+           maxlength="50"
            value
     >
     <span class="o-forms-input__error">
@@ -136,6 +140,7 @@ exports[`CompanyName renders with optional field 1`] = `
            autocomplete="organization"
            data-trackable="company-name"
            aria-required="false"
+           maxlength="50"
            value
     >
     <span class="o-forms-input__error">

--- a/components/company-name.jsx
+++ b/components/company-name.jsx
@@ -13,7 +13,7 @@ export function CompanyName ({
 	placeholder = 'Please enter your company name',
 	isRequired = true,
 	isHidden = false,
-	maxlength = 50,
+	maxlength = '50',
 }) {
 	const divClassNames = classNames([
 		'o-forms-field',
@@ -69,4 +69,5 @@ CompanyName.propTypes = {
 	fieldLabel: PropTypes.string,
 	isRequired: PropTypes.bool,
 	isHidden: PropTypes.bool,
+	maxlength: PropTypes.number,
 };

--- a/components/company-name.jsx
+++ b/components/company-name.jsx
@@ -13,6 +13,7 @@ export function CompanyName ({
 	placeholder = 'Please enter your company name',
 	isRequired = true,
 	isHidden = false,
+	maxlength = 50,
 }) {
 	const divClassNames = classNames([
 		'o-forms-field',
@@ -37,6 +38,7 @@ export function CompanyName ({
 		required: isRequired,
 		disabled: isDisabled,
 		defaultValue: value,
+		maxlength
 	};
 
 	return (

--- a/components/company-name.stories.js
+++ b/components/company-name.stories.js
@@ -11,6 +11,7 @@ export default {
 		isDisabled: { control: 'boolean' },
 		isRequired: { control: 'boolean' },
 		isHidden: { control: 'boolean' },
+		maxlength: { control: 'number'}
 	},
 };
 


### PR DESCRIPTION
### Description
While working on [ticket](https://financialtimes.atlassian.net/jira/software/c/projects/ACC/boards/1461?modal=detail&selectedIssue=ACC-1108) I have noticed that there is no max length attribute for the company name component. Shouldn't this be restricted? `next-subscribe` does not allow more than 50 characters in the `deliveryCompany` field and I believe frontend/backend validation should be consistent

### Ticket
[Related ticket](https://financialtimes.atlassian.net/jira/software/c/projects/ACC/boards/1461?modal=detail&selectedIssue=ACC-1108)

