### PR TITLE
Clarify password validation label

### DIFF
--- a/components/__snapshots__/password.spec.js.snap
+++ b/components/__snapshots__/password.spec.js.snap
@@ -12,7 +12,7 @@ exports[`Password can render a disable input 1`] = `
       Password
     </span>
     <span class="o-forms-title__prompt">
-      Use 8 or more characters with a mix of letters, numbers &amp; symbols
+      Use 8 or more characters. You can use letters, numbers or symbols
     </span>
   </label>
   <div class="o-forms-input o-forms-input--password o-forms-input--checkbox o-forms-input--suffix">
@@ -58,7 +58,7 @@ exports[`Password can render a pattern attribute 1`] = `
       Password
     </span>
     <span class="o-forms-title__prompt">
-      Use 8 or more characters with a mix of letters, numbers &amp; symbols
+      Use 8 or more characters. You can use letters, numbers or symbols
     </span>
   </label>
   <div class="o-forms-input o-forms-input--password o-forms-input--checkbox o-forms-input--suffix">
@@ -104,7 +104,7 @@ exports[`Password can render as an Error 1`] = `
       Password
     </span>
     <span class="o-forms-title__prompt">
-      Use 8 or more characters with a mix of letters, numbers &amp; symbols
+      Use 8 or more characters. You can use letters, numbers or symbols
     </span>
   </label>
   <div class="o-forms-input o-forms-input--password o-forms-input--checkbox o-forms-input--suffix o-forms-input--invalid">
@@ -149,7 +149,7 @@ exports[`Password can render as an Unknown user 1`] = `
       Password
     </span>
     <span class="o-forms-title__prompt">
-      Use 8 or more characters with a mix of letters, numbers &amp; symbols
+      Use 8 or more characters. You can use letters, numbers or symbols
     </span>
   </label>
   <div class="o-forms-input o-forms-input--password o-forms-input--checkbox o-forms-input--suffix">
@@ -194,7 +194,7 @@ exports[`Password render a password input with a label where input ID and Name a
       Password
     </span>
     <span class="o-forms-title__prompt">
-      Use 8 or more characters with a mix of letters, numbers &amp; symbols
+      Use 8 or more characters. You can use letters, numbers or symbols
     </span>
   </label>
   <div class="o-forms-input o-forms-input--password o-forms-input--checkbox o-forms-input--suffix">

--- a/components/password.jsx
+++ b/components/password.jsx
@@ -12,7 +12,7 @@ export function Password ({
 	inputName,
 	label = 'Password',
 	placeholder = 'Enter a password',
-	description = 'Use 8 or more characters with a mix of letters, numbers & symbols',
+	description = 'Use 8 or more characters. You can use letters, numbers or symbols',
 	showDescription = true,
 	hasShowPassword = true,
 }) {


### PR DESCRIPTION
### Description
Changes the password label to “Use 8 or more characters. You can use letters, numbers or symbols”

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-1418
### Screenshots

| Before | After |
| ------ | ----- |
|    ![before](https://user-images.githubusercontent.com/1725956/155523578-c59fa626-85bf-43fc-ab6e-f7833279f14e.png)    |   ![after](https://user-images.githubusercontent.com/1725956/155523667-d48ad83e-b947-45ef-8c8e-ae999b4ae029.png)     |

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
