### PR TITLE
skip ci for gh-pages deploy

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -26,3 +26,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
+          commit_message: [ci skip] {GITHUB_SHA}

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -26,4 +26,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
-          commit_message: [ci skip] {GITHUB_SHA}
+          commit_message: '[ci skip] {GITHUB_SHA}'

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -26,4 +26,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
-          commit_message: '[ci skip] {GITHUB_SHA}'
+          commit_message: '[ci skip] ${GITHUB_SHA}'


### PR DESCRIPTION
### Description
I don't how to test this other than trying it directly. 
It should prevent all these failed runs:
https://app.circleci.com/pipelines/github/Financial-Times/n-conversion-forms?branch=gh-pages&filter=all

Based on adding `[ci skip]` to the commit message: https://discuss.circleci.com/t/gh-pages-not-being-ignored/26062/2
That is generated on this action: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-set-custom-commit-message


### Ticket
No ticket
