### PR TITLE
ACQ-1526: add americanExpress to zuora setAgreement call

### DIFF
--- a/utils/zuora.js
+++ b/utils/zuora.js
@@ -162,7 +162,7 @@ class Zuora {
 	setAgreement () {
 		const mitConsentAgreementSrc = 'External';
 		const mitProfileType = 'Recurring';
-		const agreementSupportedBrands = 'Visa,Mastercard';
+		const agreementSupportedBrands = 'Visa,Mastercard,AmericanExpress';
 		const mitConsentAgreementRef = 'createStoredCredentialProfile';
 
 		return this.Z.setAgreement(


### PR DESCRIPTION
### Description
Context 3DS recurring payment are declined for Amex users.
See: https://knowledgecenter.zuora.com/Billing/Billing_and_Payments/LA_Hosted_Payment_Pages/B_Payment_Pages_2.0/H_Integrate_Payment_Pages_2.0


### Ticket
https://financialtimes.atlassian.net/browse/ACQ-1526
