### PR TITLE
ACQ-1529: add npm-publish-token to cirlceci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ workflows:
           requires:
             - build
       - publish:
+          context: npm-publish-token
           filters:
             <<: *filters_version_tag
           requires:


### PR DESCRIPTION
copied from: https://github.com/Financial-Times/n-membership-sdk/pull/536

Ticket:
https://financialtimes.atlassian.net/browse/ACQ-1529