### PR TITLE
fix payment term trial display name

### DIFF
--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -161,6 +161,18 @@ export function PaymentTerm ({
 			);
 		};
 
+		const getDisplayName = () => {
+			let displayName = '';
+			if (showTrialCopyInTitle) {
+				const termName = option.displayName ? option.displayName : 'Premium Digital';
+				displayName = `Trial: ${termName} - `;
+			}
+			const termPeriod = nameMap[option.name] ? title : option.title;
+			displayName = `${displayName}${termPeriod} `;
+
+			return displayName;
+		};
+
 		return (
 			<div key={option.value} className={className}>
 				<input {...props} />
@@ -176,8 +188,7 @@ export function PaymentTerm ({
 							{ 'ncf__payment-term__title--large-price': largePrice },
 						])}
 					>
-						{showTrialCopyInTitle ? 'Trial: Premium Digital - ' : ''}
-						{nameMap[option.name] ? title : option.title}{' '}
+						{getDisplayName()}
 						{option.subTitle && (
 							<span className="ncf__regular ncf__payment-term__sub-title">
 								{option.subTitle}

--- a/components/payment-term.spec.js
+++ b/components/payment-term.spec.js
@@ -153,6 +153,48 @@ describe('PaymentTerm', () => {
 		});
 	});
 
+	describe('getDisplayName', () => {
+		const baseOptions = {
+			name: 'monthly',
+			value: 'monthly',
+			price: '£20.00',
+			monthlyPrice: '£1.67',
+		};
+		describe('non-trial terms', () => {
+			const options = [{
+				...baseOptions,
+				isTrial: false,
+			}];
+			it('renders with time period only if trial.option == false', () => {
+				const wrapper = shallow(<PaymentTerm options={options} />);
+				expect(wrapper.find('.ncf__payment-term__label').text()).toMatch(/^Monthly .*$/);
+			});
+		});
+		describe('getDisplayName', () => {
+			const trialOptions = {
+				...baseOptions,
+				isTrial: true,
+			};
+			it('defaults to `Premium digital`', () => {
+				const options = [trialOptions];
+				const wrapper = shallow(<PaymentTerm options={options} />);
+				expect(wrapper.find('.ncf__payment-term__label').text()).toMatch(
+					/^Trial: Premium Digital - Monthly .*$/
+				);
+			});
+			it('renders using displayName if available', () => {
+				const options = [{
+					...trialOptions,
+					displayName: 'someDisplayName',
+				}];
+				const wrapper = shallow(<PaymentTerm options={options} />);
+				expect(wrapper.find('.ncf__payment-term__label').text()).toMatch(
+					/^Trial: someDisplayName - Monthly .*/
+				);
+			});
+		});
+	});
+
 	describe('[data-base-amount]', () => {
 		it('renders option.amount as data-base-amount if isTrial is false', () => {
 			const options = [


### PR DESCRIPTION
### Description
This PR should have no effect on existing code (unless I've messed up).
It will however allow us to set alternative displayName for terms from the consuming apps.

This is needed to address an issue reported month ago and is now becoming urgent.
Longer term, we my need to move some of the naming logic out of the jsx, it's becoming hard to navigate, maybe compute it server side instead?
Or even better, work with data source (salesforce/membership) so that we just get the required data mapped correctly against the offers.

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-1564

### Screenshots

| Before | After |
| ------ | ----- |
|    
![image](https://user-images.githubusercontent.com/6513313/160428538-9782ef43-69f0-49d8-ac75-48bcef7fe8cf.png)
       |    
![image](https://user-images.githubusercontent.com/6513313/160428327-d322e87a-049a-43aa-8d1e-ec3bad1c2eb4.png)
    | 

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
