### PR TITLE
Bump n-common-static-data to v1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "classnames": "2.3.1",
     "fetchres": "1.7.2",
     "lodash.get": "4.4.2",
-    "n-common-static-data": "financial-times/n-common-static-data#v1.6.1"
+    "n-common-static-data": "financial-times/n-common-static-data#v1.7.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",


### PR DESCRIPTION
### Description
Bumps n-common-static-data to v1.7.1 to include latest b2b data. No impact on existing behaviour.

### Ticket
[ENT-561](https://financialtimes.atlassian.net/browse/ENT-561?atlOrigin=eyJpIjoiOTdiNzE5MjMxZmE2NDdiOGI5ODEwZTc5YzYwYjkyMmUiLCJwIjoiaiJ9)
