### PR TITLE
ENT-561 Add B2B Options to Position and Responsibility Fields

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,13 @@ references:
 
   npm_cache_keys: &npm_cache_keys
     keys:
-        - v2-dependency-npm-{{ checksum "package.json" }}-
-        - v2-dependency-npm-{{ checksum "package.json" }}
-        - v2-dependency-npm-
+        - v3-dependency-npm-{{ checksum "package.json" }}-
+        - v3-dependency-npm-{{ checksum "package.json" }}
+        - v3-dependency-npm-
 
   cache_npm_cache: &cache_npm_cache
     save_cache:
-        key: v2-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
+        key: v3-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
         paths:
         - ./node_modules/
 

--- a/components/position.jsx
+++ b/components/position.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { demographics } from 'n-common-static-data';
-const defaultOptions = demographics.positions.positions;
+import { b2b, demographics } from 'n-common-static-data';
+const B2CPositions = demographics.positions.positions;
+const B2BPositions = b2b.demographics.positions.positions;
 
 export function Position ({
 	value,
@@ -11,7 +12,8 @@ export function Position ({
 	fieldId = 'positionField',
 	selectId = 'position',
 	selectName = 'position',
-	options = defaultOptions,
+	isB2B = false,
+	options = isB2B ? B2BPositions : B2CPositions,
 	isRequired = true,
 	fieldLabel = 'What’s your job position?',
 }) {
@@ -70,6 +72,7 @@ Position.propTypes = {
 	fieldId: PropTypes.string,
 	selectId: PropTypes.string,
 	selectName: PropTypes.string,
+	isB2B: PropTypes.bool,
 	options: PropTypes.arrayOf(
 		PropTypes.shape({
 			code: PropTypes.string,

--- a/components/position.spec.js
+++ b/components/position.spec.js
@@ -1,7 +1,7 @@
 import { Position } from './index';
 import { expectToRenderCorrectly } from '../test-jest/helpers/expect-to-render-correctly';
 import { demographics } from 'n-common-static-data';
-const defaultOptions = demographics.positions.positions;
+const B2CPositions = demographics.positions.positions;
 
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
@@ -12,7 +12,7 @@ expect.extend(expectToRenderCorrectly);
 describe('Position', () => {
 	it('render a select with a label', () => {
 		const props = {
-			options: defaultOptions,
+			options: B2CPositions,
 		};
 
 		expect(Position).toRenderCorrectly(props);
@@ -20,7 +20,7 @@ describe('Position', () => {
 
 	it('can render an initial selected value', () => {
 		const props = {
-			options: defaultOptions,
+			options: B2CPositions,
 			value: 'CP',
 		};
 
@@ -29,7 +29,7 @@ describe('Position', () => {
 
 	it('can render a disable select', () => {
 		const props = {
-			options: defaultOptions,
+			options: B2CPositions,
 			isDisabled: true,
 		};
 
@@ -38,7 +38,7 @@ describe('Position', () => {
 
 	it('can render an error message', () => {
 		const props = {
-			options: defaultOptions,
+			options: B2CPositions,
 			hasError: true,
 		};
 
@@ -67,5 +67,15 @@ describe('Position', () => {
 		expect(
 			component.find('.o-forms-title.o-forms-field--optional').length
 		).toEqual(1);
+	});
+
+	it('defaults to B2B options if isB2B is true', () => {
+		const props = { isB2B: true };
+		const component = mount(Position(props));
+
+		// Look for an option which is only present in the default B2B data set and not in the B2C one.
+		const optionValue = component.find('option').at(1).instance().value;
+
+		expect(optionValue).toBe('OW');
 	});
 });

--- a/components/responsibility.jsx
+++ b/components/responsibility.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { demographics } from 'n-common-static-data';
-const defaultOptions = demographics.responsibilities.responsibilities;
+import { b2b, demographics } from 'n-common-static-data';
+const B2CResponsibilities = demographics.responsibilities.responsibilities;
+const B2BResponsibilities = b2b.demographics.responsibilities.responsibilities;
 
 export function Responsibility ({
 	value,
@@ -12,7 +13,8 @@ export function Responsibility ({
 	fieldId = 'responsibilityField',
 	selectId = 'responsibility',
 	selectName = 'responsibility',
-	options = defaultOptions,
+	isB2B = true,
+	options = isB2B ? B2BResponsibilities : B2CResponsibilities,
 	fieldLabel = 'Which best describes your job responsibility?',
 }) {
 	const inputWrapperClassName = classNames([
@@ -72,6 +74,7 @@ Responsibility.propTypes = {
 	fieldId: PropTypes.string,
 	selectId: PropTypes.string,
 	selectName: PropTypes.string,
+	isB2B: PropTypes.bool,
 	options: PropTypes.arrayOf(
 		PropTypes.shape({
 			code: PropTypes.string,

--- a/components/responsibility.spec.js
+++ b/components/responsibility.spec.js
@@ -1,7 +1,7 @@
 import { Responsibility } from './index';
 import { expectToRenderCorrectly } from '../test-jest/helpers/expect-to-render-correctly';
 import { demographics } from 'n-common-static-data';
-const defaultOptions = demographics.responsibilities.responsibilities;
+const B2CResponsibilities = demographics.responsibilities.responsibilities;
 
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
@@ -12,7 +12,7 @@ expect.extend(expectToRenderCorrectly);
 describe('Responsibility', () => {
 	it('render a select with a label', () => {
 		const props = {
-			options: defaultOptions,
+			options: B2CResponsibilities,
 		};
 
 		expect(Responsibility).toRenderCorrectly(props);
@@ -20,7 +20,7 @@ describe('Responsibility', () => {
 
 	it('can render an initial selected value', () => {
 		const props = {
-			options: defaultOptions,
+			options: B2CResponsibilities,
 			value: 'FIN',
 		};
 
@@ -29,7 +29,7 @@ describe('Responsibility', () => {
 
 	it('can render a disable select', () => {
 		const props = {
-			options: defaultOptions,
+			options: B2CResponsibilities,
 			isDisabled: true,
 		};
 
@@ -38,7 +38,7 @@ describe('Responsibility', () => {
 
 	it('can render an error message', () => {
 		const props = {
-			options: defaultOptions,
+			options: B2CResponsibilities,
 			hasError: true,
 		};
 
@@ -73,5 +73,15 @@ describe('Responsibility', () => {
 		expect(
 			component.find('.o-forms-title.o-forms-field--optional').length
 		).toEqual(1);
+	});
+
+	it('defaults to B2B options if isB2B is true', () => {
+		const props = { isB2B: true };
+		const component = mount(Responsibility(props));
+
+		// Look for an option which is only present in the default B2B data set and not in the B2C one.
+		const optionValue = component.find('option').at(1).instance().value;
+
+		expect(optionValue).toBe('ACC');
 	});
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "classnames": "2.3.1",
         "fetchres": "1.7.2",
         "lodash.get": "4.4.2",
-        "n-common-static-data": "financial-times/n-common-static-data#v1.6.1"
+        "n-common-static-data": "github:Financial-Times/n-common-static-data#v1.7.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.10.5",
@@ -25134,9 +25134,11 @@
     },
     "node_modules/n-common-static-data": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/financial-times/n-common-static-data.git#f20f8476d37b1694134c4bc5ba72bfeb75ea2565",
+      "resolved": "git+ssh://git@github.com/Financial-Times/n-common-static-data.git#bc4ac35d786ed747f026a5e131dd1ce80d746d6a",
+      "hasInstallScript": true,
       "engines": {
-        "node": "^6.11.0"
+        "node": "12.x || 14.x || 16.x",
+        "npm": "7.x || 8.x"
       }
     },
     "node_modules/nan": {
@@ -56318,8 +56320,8 @@
       }
     },
     "n-common-static-data": {
-      "version": "git+ssh://git@github.com/financial-times/n-common-static-data.git#f20f8476d37b1694134c4bc5ba72bfeb75ea2565",
-      "from": "n-common-static-data@financial-times/n-common-static-data#v1.6.1"
+      "version": "git+ssh://git@github.com/Financial-Times/n-common-static-data.git#bc4ac35d786ed747f026a5e131dd1ce80d746d6a",
+      "from": "n-common-static-data@github:Financial-Times/n-common-static-data#v1.7.1"
     },
     "nan": {
       "version": "2.15.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "classnames": "2.3.1",
     "fetchres": "1.7.2",
     "lodash.get": "4.4.2",
-    "n-common-static-data": "financial-times/n-common-static-data#v1.7.1"
+    "n-common-static-data": "github:Financial-Times/n-common-static-data#v1.7.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",


### PR DESCRIPTION
### Description
We're working towards making a change to the signup forms users see when they join under a B2B licence to capture information about the position and responsibility they hold within their company in more depth. This will result in more accurate and actionable data; for more detail see [the Access & Identity ticket](https://financialtimes.atlassian.net/browse/AIM-761).

In order to achieve this, we've added new data sets to `n-common-static-data`. The [PR for that work is here](https://github.com/Financial-Times/n-common-static-data/pull/36). This means there are now [two sets of data](https://docs.google.com/spreadsheets/d/1sLMcknLOHiA5DzNcLJD3I_7TkBo0wTIKQn_13RMgEfg/edit#gid=755191669) for the `position` and `responsibility` fields; one for B2C and one for B2B.

This PR updates the fields so that if they are intended to be used in a B2B setting, they default to displaying the correct B2B data instead of the current B2C data. I've implemented this by adding an `isB2B` prop.

### Ticket
[ENT-561](https://financialtimes.atlassian.net/jira/software/projects/ENT/boards/1312?selectedIssue=ENT-561)

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [X] **Documentation** updated or created
- [X] **Tests** written for new or updated for existing functionality
- [X] **Stories** updated to use this change
- [X] **Accessibility** checked for screen readers and contrast
- [X] **Design Review** ran past the designer
- [X] **Product Review** ran past the product owner
