### PR TITLE
ENT-561 Correct isB2B Responsibility Component Default

### DIFF
--- a/components/responsibility.jsx
+++ b/components/responsibility.jsx
@@ -13,7 +13,7 @@ export function Responsibility ({
 	fieldId = 'responsibilityField',
 	selectId = 'responsibility',
 	selectName = 'responsibility',
-	isB2B = true,
+	isB2B = false,
 	options = isB2B ? B2BResponsibilities : B2CResponsibilities,
 	fieldLabel = 'Which best describes your job responsibility?',
 }) {


### PR DESCRIPTION
### Description
Currently the `isB2B` prop defaults to `false` on the `Responsibility` component and `true` on the `Position` field, which isn't great for consistency. This PR changes the prop to default to `false` on both components.

### Ticket
[ENT-561](https://financialtimes.atlassian.net/jira/software/projects/ENT/boards/1312?selectedIssue=ENT-561)

### Reminder

- [X] **Documentation** updated or created
- [X] **Tests** written for new or updated for existing functionality
- [X] **Stories** updated to use this change
- [X] **Accessibility** checked for screen readers and contrast
- [X] **Design Review** ran past the designer
- [X] **Product Review** ran past the product owner
