### PR TITLE
ACC-1581 Fix payFasterNextTime reload iframe bug

### DIFF
--- a/components/__snapshots__/payment-type.spec.js.snap
+++ b/components/__snapshots__/payment-type.spec.js.snap
@@ -72,6 +72,8 @@ exports[`PaymentType can initialise with the loader visible 1`] = `
     Please enter a valid payment type
   </div>
 </div>
+<div class="o-forms-field">
+</div>
 `;
 
 exports[`PaymentType render with default props 1`] = `
@@ -146,6 +148,8 @@ exports[`PaymentType render with default props 1`] = `
     Please enter a valid payment type
   </div>
 </div>
+<div class="o-forms-field">
+</div>
 `;
 
 exports[`PaymentType render with enableApplepay 1`] = `
@@ -219,6 +223,8 @@ exports[`PaymentType render with enableApplepay 1`] = `
   <div class="o-forms-input__error">
     Please enter a valid payment type
   </div>
+</div>
+<div class="o-forms-field">
 </div>
 `;
 
@@ -313,6 +319,8 @@ exports[`PaymentType render with enableCreditcard 1`] = `
     <script src="https://static.zuora.com/Resources/libs/hosted/1.3.1/zuora-min.js">
     </script>
   </div>
+</div>
+<div class="o-forms-field">
 </div>
 `;
 
@@ -447,6 +455,8 @@ exports[`PaymentType render with enableDirectdebit 1`] = `
     </script>
   </div>
 </div>
+<div class="o-forms-field">
+</div>
 `;
 
 exports[`PaymentType render with enablePaypal 1`] = `
@@ -521,6 +531,8 @@ exports[`PaymentType render with enablePaypal 1`] = `
     Please enter a valid payment type
   </div>
 </div>
+<div class="o-forms-field">
+</div>
 `;
 
 exports[`PaymentType render with isSingleTerm 1`] = `
@@ -594,6 +606,8 @@ exports[`PaymentType render with isSingleTerm 1`] = `
   <div class="o-forms-input__error">
     Please enter a valid payment type
   </div>
+</div>
+<div class="o-forms-field">
   <label class="o-forms-input o-forms-input--checkbox o-forms-input--suffix ncf__payment-type-pay-faster-next-time-checkbox"
          for="payFasterNextTime"
   >
@@ -680,6 +694,8 @@ exports[`PaymentType render with isSingleTermChecked 1`] = `
   <div class="o-forms-input__error">
     Please enter a valid payment type
   </div>
+</div>
+<div class="o-forms-field">
   <label class="o-forms-input o-forms-input--checkbox o-forms-input--suffix ncf__payment-type-pay-faster-next-time-checkbox"
          for="payFasterNextTime"
   >
@@ -768,5 +784,7 @@ exports[`PaymentType render with value 1`] = `
   <div class="o-forms-input__error">
     Please enter a valid payment type
   </div>
+</div>
+<div class="o-forms-field">
 </div>
 `;

--- a/components/payment-type.jsx
+++ b/components/payment-type.jsx
@@ -247,7 +247,8 @@ export function PaymentType ({
 				{createDirectDebitPanel()}
 
 				{createZuoraPanel()}
-
+			</div>
+			<div className="o-forms-field">
 				{isSingleTerm && (
 					<>
 						<label


### PR DESCRIPTION
### Description
The input checkbox for `payFasterNextTime` was causing the iframe to reload everytime it was clicked one. The input needs to go outside of the main div in order for this not to happen.

### Ticket
[JIRA](https://financialtimes.atlassian.net/jira/software/c/projects/ACC/boards/1461?modal=detail&selectedIssue=ACC-1581)

### Screenshots
Before:
https://user-images.githubusercontent.com/10453619/164730814-f9e6a8af-3b18-452a-9669-280e403bfb6c.mov

After:
https://user-images.githubusercontent.com/10453619/164729647-882db70a-20c2-4abe-bbce-4520f10b0421.mov




