### PR TITLE
ACQ-1589: add calculation to monthly price introduced in payment-term component

### DIFF
--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -26,11 +26,11 @@ export function PaymentTerm ({
 	 * @param {string} period PxY (yearly) or PxM (montly) where x is the amount of years/months
 	 * @returns {string}
 	 */
-	 function getMontlyPriceFromPeriod (amount, currency, period) {
+	const getMontlyPriceFromPeriod = (amount, currency, period) => {
 		const periodObj = new Period(period);
 		const monthlyPrice = periodObj.calculatePrice('P1M', amount);
 		return new Monthly({ value: monthlyPrice, currency }).getAmount('monthly');
-	}
+	};
 
 	/**
 	 * returns period converted to time if found

--- a/utils/payment-term.js
+++ b/utils/payment-term.js
@@ -1,3 +1,8 @@
+const {
+	Period,
+	Monthly,
+} = require('@financial-times/n-pricing');
+
 /**
  * Utility for the `n-conversion-forms/partial/payment-term.html` partial
  * @example
@@ -75,6 +80,23 @@ class PaymentTerm {
 		return this.$paymentTerm.addEventListener('change', callback);
 	}
 
+	isValidPeriod (period) {
+		try {
+			// Period should throw an error if it is not properly provided
+			// in order to validate it, we just send in case type is string
+			new Period(typeof period === 'string' ? period : '');
+			return true;
+		} catch (e) {
+			return false;
+		}
+	};
+
+	getMontlyPriceFromPeriod (amount, currency, period) {
+		const periodObj = new Period(period);
+		const monthlyPrice = periodObj.calculatePrice('P1M', amount);
+		return new Monthly({ value: monthlyPrice, currency }).getAmount('monthly');
+	}
+
 	/**
 	 * Update the payment term options
 	 * @param {Array} options Array of objects contain terms information
@@ -104,7 +126,9 @@ class PaymentTerm {
 				trialPrice.innerHTML = update.trialPrice;
 			}
 			if (monthlyPrice) {
-				monthlyPrice.innerHTML = update.monthlyPrice;
+				monthlyPrice.innerHTML = this.isValidPeriod(update.value) ?
+					this.getMontlyPriceFromPeriod(update.amount, update.currency, update.value) :
+					update.monthlyPrice;
 			}
 		}
 	}


### PR DESCRIPTION
### Description
Replicate monthly price calculation introduced here https://github.com/Financial-Times/n-conversion-forms/pull/632 for client side, since it was overwriting values calculated by server side.

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-1589

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
