### PR TITLE
ACC-1714 Fix subtitle position for paymentTerm component

### DIFF
--- a/styles/payment-term.scss
+++ b/styles/payment-term.scss
@@ -84,6 +84,9 @@
 
 		&__sub-title {
 			@include oTypographySans($scale: -1, $include-font-family: false);
+			display: block;
+			margin-top: 2px;
+			margin-bottom: 2px;
 		}
 	}
 }


### PR DESCRIPTION
### Description
Skip a line for the subtitle by changing the CSS of the` __subtitle` subclass in the paymentTerm component.

### Ticket
[JIRA](https://financialtimes.atlassian.net/jira/software/c/projects/ACC/boards/1461?modal=detail&selectedIssue=ACC-1714)

### Screenshots
before: 
![Screenshot 2022-05-31 at 13 48 48 (1)](https://user-images.githubusercontent.com/10453619/171370866-2e7efdca-be90-45c3-a0c5-3064c7bff71c.png)

after:
![Screenshot 2022-06-01 at 10 16 01](https://user-images.githubusercontent.com/10453619/171370881-ec89d423-7787-4e19-bca3-10aec4b3c161.png)

