### PR TITLE
Change registration confirmation cta label

### DIFF
--- a/components/__snapshots__/registration-confirmation.spec.js.snap
+++ b/components/__snapshots__/registration-confirmation.spec.js.snap
@@ -120,7 +120,7 @@ exports[`RegistrationConfirmation renders with a custom email 1`] = `
      class="ncf__confirmation--finish ncf__button ncf__button--submit"
      data-trackable="register-finish"
   >
-    Finish
+    Start reading
   </a>
 </div>
 `;
@@ -245,7 +245,7 @@ exports[`RegistrationConfirmation renders with default props 1`] = `
      class="ncf__confirmation--finish ncf__button ncf__button--submit"
      data-trackable="register-finish"
   >
-    Finish
+    Start reading
   </a>
 </div>
 `;

--- a/components/registration-confirmation.jsx
+++ b/components/registration-confirmation.jsx
@@ -122,7 +122,7 @@ export function RegistrationConfirmation ({
 				className="ncf__confirmation--finish ncf__button ncf__button--submit"
 				data-trackable="register-finish"
 			>
-				Finish
+				Start reading
 			</a>
 		</div>
 	);


### PR DESCRIPTION
### Description
Change the wording from `Finish` to `Start reading` in the registration confirmation cta.

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-1736

