### PR TITLE
ACC-1803: update delivery instructions for emea and apac

### DIFF
--- a/components/__snapshots__/delivery-instructions.spec.js.snap
+++ b/components/__snapshots__/delivery-instructions.spec.js.snap
@@ -72,7 +72,7 @@ exports[`DeliveryInstructions renders with a custom value 1`] = `
       For newspaper delivery, we can only deliver to the ground floor, so if you live in an apartment, we’ll leave the newspaper at reception or by the entrance. We deliver in the early hours of the morning so our drivers won’t be able to contact you or ring your doorbell.
     </span>
     <span class="o-forms-title__prompt">
-      Special characters including punctuation cannot be used in the Delivery instructions.
+      Special characters including punctuation cannot be used in the delivery instructions.
     </span>
   </span>
   <span class="o-forms-input o-forms-input--textarea">
@@ -101,7 +101,7 @@ exports[`DeliveryInstructions renders with a disabled input element 1`] = `
       For newspaper delivery, we can only deliver to the ground floor, so if you live in an apartment, we’ll leave the newspaper at reception or by the entrance. We deliver in the early hours of the morning so our drivers won’t be able to contact you or ring your doorbell.
     </span>
     <span class="o-forms-title__prompt">
-      Special characters including punctuation cannot be used in the Delivery instructions.
+      Special characters including punctuation cannot be used in the delivery instructions.
     </span>
   </span>
   <span class="o-forms-input o-forms-input--textarea">
@@ -130,7 +130,7 @@ exports[`DeliveryInstructions renders with an error 1`] = `
       For newspaper delivery, we can only deliver to the ground floor, so if you live in an apartment, we’ll leave the newspaper at reception or by the entrance. We deliver in the early hours of the morning so our drivers won’t be able to contact you or ring your doorbell.
     </span>
     <span class="o-forms-title__prompt">
-      Special characters including punctuation cannot be used in the Delivery instructions.
+      Special characters including punctuation cannot be used in the delivery instructions.
     </span>
   </span>
   <span class="o-forms-input o-forms-input--textarea o-forms-input--invalid">
@@ -158,7 +158,7 @@ exports[`DeliveryInstructions renders with default props 1`] = `
       For newspaper delivery, we can only deliver to the ground floor, so if you live in an apartment, we’ll leave the newspaper at reception or by the entrance. We deliver in the early hours of the morning so our drivers won’t be able to contact you or ring your doorbell.
     </span>
     <span class="o-forms-title__prompt">
-      Special characters including punctuation cannot be used in the Delivery instructions.
+      Special characters including punctuation cannot be used in the delivery instructions.
     </span>
   </span>
   <span class="o-forms-input o-forms-input--textarea">
@@ -186,7 +186,7 @@ exports[`DeliveryInstructions renders with maxlength 1`] = `
       For newspaper delivery, we can only deliver to the ground floor, so if you live in an apartment, we’ll leave the newspaper at reception or by the entrance. We deliver in the early hours of the morning so our drivers won’t be able to contact you or ring your doorbell.
     </span>
     <span class="o-forms-title__prompt">
-      Special characters including punctuation cannot be used in the Delivery instructions.
+      Special characters including punctuation cannot be used in the delivery instructions.
     </span>
   </span>
   <span class="o-forms-input o-forms-input--textarea">
@@ -215,7 +215,7 @@ exports[`DeliveryInstructions renders with rows 1`] = `
       For newspaper delivery, we can only deliver to the ground floor, so if you live in an apartment, we’ll leave the newspaper at reception or by the entrance. We deliver in the early hours of the morning so our drivers won’t be able to contact you or ring your doorbell.
     </span>
     <span class="o-forms-title__prompt">
-      Special characters including punctuation cannot be used in the Delivery instructions.
+      Special characters including punctuation cannot be used in the delivery instructions.
     </span>
   </span>
   <span class="o-forms-input o-forms-input--textarea">

--- a/components/delivery-instructions.jsx
+++ b/components/delivery-instructions.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { identifyFTShippingZone } from '../helpers/supportedCountries';
+
 
 const spanMessageByCountry = {
 	GBR: (
@@ -31,6 +33,57 @@ const spanMessageByCountry = {
 			form, or contact &nbsp;
 			<a href="https://help.ft.com/contact/">FT Customer Care</a>.
 		</span>
+	),
+	CEMEA_V1: (
+		<>
+			<span className="o-forms-title__prompt">
+				Newspaper delivery is restricted to ground floor addresses.
+				If you live in an apartment the newspaper will be left at reception or by the entrance.
+				Delivery is made in the early hours making it sometimes difficult to identify the right
+				delivery location or gaining access where letter boxes are inside a building.
+			</span>
+			<span className="o-forms-title__prompt">
+				Special characters including punctuation cannot be used in the delivery instructions.
+			</span>
+			<span className="o-forms-title__prompt">
+				If you prefer delivery to a mailbox, please either select the “PO Box” delivery option from the top of this form, or contact&nbsp;
+				<a href="https://help.ft.com/contact/">FT Customer Care</a>.
+			</span>
+		</>
+	),
+	CEMEA_V2: (
+		<>
+			<span className="o-forms-title__prompt">
+				Newspaper delivery is restricted to ground floor addresses.
+				If you live in an apartment the newspaper will be left at reception or by the entrance.
+				Delivery is made in the early hours making it sometimes difficult to identify the right
+				delivery location or gaining access where letter boxes are inside a building.
+			</span>
+			<span className="o-forms-title__prompt">
+				Special characters including punctuation cannot be used in the delivery instructions.
+			</span>
+			<span className="o-forms-title__prompt">
+				If you prefer delivery to a mailbox, please either select the “PO Box” delivery option from the top of this form, or contact&nbsp;
+				<a href="https://help.ft.com/contact/">FT Customer Care</a>.
+			</span>
+		</>
+	),
+	APAC: (
+		<>
+			<span className="o-forms-title__prompt">
+				Newspaper delivery is restricted to ground floor addresses.
+				If you live in an apartment the newspaper will be left at reception or by the entrance.
+				Delivery is made in the early hours making it sometimes difficult to identify the right
+				delivery location or gaining access where letter boxes are inside a building.
+			</span>
+			<span className="o-forms-title__prompt">
+				Special characters including punctuation cannot be used in the delivery instructions.
+			</span>
+			<span className="o-forms-title__prompt">
+				If you prefer delivery to a mailbox, please either select the “PO Box” delivery option from the top of this form, or contact&nbsp;
+				<a href="https://help.ft.com/contact/">FT Customer Care</a>.
+			</span>
+		</>
 	),
 };
 
@@ -79,11 +132,10 @@ export function DeliveryInstructions ({
 	};
 	const deliveryInstructionsMessage = (
 		<span className="o-forms-title__prompt">
-			Special characters including punctuation cannot be used in the Delivery
-			instructions.
+			Special characters including punctuation cannot be used in the delivery instructions.
 		</span>
 	);
-
+	const FTShippingZone = identifyFTShippingZone(country);
 	return (
 		<label
 			id={fieldId}
@@ -93,7 +145,7 @@ export function DeliveryInstructions ({
 		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main">Delivery instructions</span>
-				{spanMessageByCountry[country]}
+				{spanMessageByCountry[FTShippingZone]}
 				{country === 'GBR' && deliveryInstructionsMessage}
 			</span>
 


### PR DESCRIPTION
### Description
We need to update the copy on the delivery instructions for CEMEA and APAC. [These are the instructions for CEMEA](https://docs.google.com/document/d/15m79euirAZQ3Y837x-XyqCaalh6VcHlT/edit), We don’t have instructions for APAC, so we’ll use this one for now

### Ticket
[TICKET](https://financialtimes.atlassian.net/browse/ACC-1803)
