### PR TITLE
Added property to allow hiding of myFT paragraph on b2b confirmation page

### DIFF
--- a/components/licence-confirmation.jsx
+++ b/components/licence-confirmation.jsx
@@ -8,6 +8,7 @@ export function LicenceConfirmation ({
 	isEducationalLicence = false,
 	contentId = '',
 	ctaElement = null,
+	bodyContent = null,
 }) {
 	const readingLinkProps = {
 		href: contentId === '' ? '/' : `/content/${contentId}`,
@@ -32,17 +33,19 @@ export function LicenceConfirmation ({
 					)}
 				</div>
 			</div>
+			{
+				bodyContent ? bodyContent : <>
+					<p className="ncf__paragraph">
+					Go to myFT to personalise your feed &amp; follow topics &amp; articles
+					of interest to you. Set this up now or later.
+					</p>
 
-			<p className="ncf__paragraph">
-				Go to myFT to personalise your feed &amp; follow topics &amp; articles
-				of interest to you. Set this up now or later.
-			</p>
-
-			<p className="ncf__paragraph">
-				Explore the homepage &amp; enjoy your unlimited access &amp; exclusive
-				content.
-			</p>
-
+					<p className="ncf__paragraph">
+						Explore the homepage &amp; enjoy your unlimited access &amp; exclusive
+						content.
+					</p>
+				</>
+			}
 			{ctaElement || (
 				<p className="ncf__paragraph ncf__center">
 					<a className="ncf__button ncf__button--submit" href="/myft">
@@ -65,4 +68,5 @@ LicenceConfirmation.propTypes = {
 	isEducationalLicence: PropTypes.bool,
 	contentId: PropTypes.string,
 	ctaElement: PropTypes.node,
+	bodyContent: PropTypes.element,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10419,6 +10419,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-html": {
       "version": "0.0.7",
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
@@ -32005,9 +32017,12 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.21.3",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -41537,6 +41552,14 @@
       "dev": true,
       "requires": {
         "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "dev": true
+        }
       }
     },
     "ansi-html": {
@@ -43096,6 +43119,7 @@
     },
     "call-me-maybe": {
       "version": "1.0.1",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
       "dev": true
     },
     "caller-callsite": {
@@ -47103,6 +47127,7 @@
     },
     "has-glob": {
       "version": "1.0.0",
+      "integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
       "dev": true,
       "requires": {
         "is-glob": "^3.0.0"
@@ -50017,6 +50042,7 @@
     },
     "junk": {
       "version": "3.1.0",
+      "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
       "dev": true
     },
     "just-extend": {
@@ -50680,6 +50706,7 @@
     },
     "lower-case": {
       "version": "2.0.2",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
       "dev": true,
       "requires": {
         "tslib": "^2.0.3"
@@ -51010,6 +51037,7 @@
     },
     "microevent.ts": {
       "version": "0.1.1",
+      "integrity": "sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==",
       "dev": true
     },
     "micromark": {
@@ -51599,6 +51627,7 @@
     },
     "no-case": {
       "version": "3.0.4",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
       "dev": true,
       "requires": {
         "lower-case": "^2.0.2",
@@ -52389,6 +52418,7 @@
     },
     "p-all": {
       "version": "2.1.0",
+      "integrity": "sha512-HbZxz5FONzz/z2gJfk6bFca0BCiSRF8jU3yCsWOen/vR6lZjfPOu/e7L3uFzTW1i0H8TlC3vqQstEJPQL4/uLA==",
       "dev": true,
       "requires": {
         "p-map": "^2.0.0"
@@ -52408,6 +52438,7 @@
     },
     "p-event": {
       "version": "4.2.0",
+      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
       "dev": true,
       "requires": {
         "p-timeout": "^3.1.0"
@@ -52425,6 +52456,7 @@
     },
     "p-filter": {
       "version": "2.1.0",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
       "dev": true,
       "requires": {
         "p-map": "^2.0.0"
@@ -58284,9 +58316,12 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.21.3",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -58710,6 +58745,7 @@
     },
     "utila": {
       "version": "0.4.0",
+      "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
     "utils-merge": {


### PR DESCRIPTION
### Description

Our aim with this ticket is to direct the user to Workspace once they have completed the sign up form by amending the button's text and link on the Confirmation page.

We amended the button in the LicenseConfirmation.jsx page  and passed in content from the next-subscribe repo so that we  could clearly separate what information will be passed to b2b and US users in the logic for the button (which lives in next-subscribe).

We have passed in a BodyContent prop that contains a react element with text in that will differ depending on whether the user is based in the US or belongs to the b2b cohort.  If neither is true then we show the default text that was already in the LicenseConfirmation component. 

### Ticket
[https://financialtimes.atlassian.net/browse/ELE-79?atlOrigin=eyJpIjoiNzIxOTZjOWNhODUwNGM3MDhjZWUzZmYyYWNiNzM1NmQiLCJwIjoiaiJ9](url)

### Screenshots
Before
<img width="726" alt="Screenshot 2022-07-08 at 14 31 50" src="https://user-images.githubusercontent.com/106242654/178001947-aa14c8d4-4d6f-4aa7-9f34-d210d0ded766.png">

After
![FT-Testing-licence-Financial-Times (1)](https://user-images.githubusercontent.com/106242654/178275556-427c6eed-11bf-438a-ae10-b22fe074ccdc.png)

