### PR TITLE
ACC-1807 ACC-1810 Show correct options for delivery-option.jsx component

### DIFF
--- a/components/delivery-address-map.jsx
+++ b/components/delivery-address-map.jsx
@@ -31,7 +31,7 @@ const deliveryAddressMap = {
 			APAC: 'District/County/Province/Ward',
 		},
 		addressLine1Title:{
-			'ARE': 'PO Box',
+			ARE: 'PO Box',
 		},
 		addressLine3Title:  {
 			GBR: 'Address line 3',
@@ -39,6 +39,7 @@ const deliveryAddressMap = {
 			CAN: 'APT/FL/STE',
 			CEMEA_V1: 'Address line 3',
 			CEMEA_V2: 'Address line 3',
+			APAC: 'Address line 3',
 		},
 		addressLine3Prompt: {
 			USA: 'Max. 6 characters. Please enter “Apartment 2C” as “Apt 2C”, “Floor 10 as FL 10”',

--- a/components/delivery-address-type.jsx
+++ b/components/delivery-address-type.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { identifyFTShippingZone } from '../helpers/supportedCountries';
 
 const addressTypes = [
 	{ id: 'home', label: 'Home Address' },
@@ -14,9 +13,7 @@ export function DeliveryAddressType ({
 	inputName = 'deliveryAddressType',
 	options = ['home', 'company', 'pobox'],
 	editMode = false,
-	deliveryCountry
 }) {
-	const FTShippingZone = identifyFTShippingZone(deliveryCountry);
 	return (
 		<div
 			id={fieldId}
@@ -32,7 +29,7 @@ export function DeliveryAddressType ({
 				{options.map((option) => {
 					const type = addressTypes.find((item) => item.id === option);
 
-					return !type ||(FTShippingZone==='APAC' && type.id==='pobox') ? null : (
+					return !type ? null : (
 						<label htmlFor={type.id} aria-label={type.label} key={type.id}>
 							<input
 								type="radio"

--- a/components/delivery-address-type.jsx
+++ b/components/delivery-address-type.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { identifyFTShippingZone } from '../helpers/supportedCountries';
 
 const addressTypes = [
 	{ id: 'home', label: 'Home Address' },
@@ -12,7 +13,10 @@ export function DeliveryAddressType ({
 	fieldId = 'deliveryAddressTypeField',
 	inputName = 'deliveryAddressType',
 	options = ['home', 'company', 'pobox'],
+	editMode = false,
+	deliveryCountry
 }) {
+	const FTShippingZone = identifyFTShippingZone(deliveryCountry);
 	return (
 		<div
 			id={fieldId}
@@ -28,7 +32,7 @@ export function DeliveryAddressType ({
 				{options.map((option) => {
 					const type = addressTypes.find((item) => item.id === option);
 
-					return !type ? null : (
+					return !type ||(FTShippingZone==='APAC' && type.id==='pobox') ? null : (
 						<label htmlFor={type.id} aria-label={type.label} key={type.id}>
 							<input
 								type="radio"
@@ -36,6 +40,7 @@ export function DeliveryAddressType ({
 								name={inputName}
 								value={type.id}
 								className="ncf__delivery-address-type__input"
+								disabled={editMode && (type.id !== value)}
 								defaultChecked={type.id === value}
 							/>
 							<span

--- a/utils/delivery-option-messages.js
+++ b/utils/delivery-option-messages.js
@@ -126,6 +126,7 @@ const deliveryOptionMessages = [
 		distributorType: MAIL,
 		country: [printRegions.cemeaV1, printRegions.cemeaV2, printRegions.apac],
 		title: 'Mail Delivery',
+		customId: 'ML',
 		description:
 			'We can only deliver the newspaper to your location by postal mail which means your delivery will arrive up to 3 business days after the date of publication and will not include the HTSI Magazine. We also fly the newspaper to your location which means delivery is subject to flight delays/cancellations outside the FT\'s control. If you prefer to read the printed content on the day of publication, please proceed to subscribe to the FT ePaper - a digital replica of the print edition.',
 	},

--- a/utils/delivery-option-messages.js
+++ b/utils/delivery-option-messages.js
@@ -124,7 +124,7 @@ const deliveryOptionMessages = [
 			SIX_DAYS_WEEK_DELIVERY_FREQ,
 		],
 		distributorType: MAIL,
-		country: [USA_COUNTRY_CODE, CAN_COUNTRY_CODE],
+		country: [printRegions.cemeaV1, printRegions.cemeaV2, printRegions.apac],
 		title: 'Mail',
 		customId: 'ML',
 		description:
@@ -188,38 +188,38 @@ function includesDeliveryFrequency (productCode = '', item) {
 	});
 }
 
-function mailStrategy (productCode, option, country, item) {
+function mailStrategy (productCode, option, FTShippingZone, item) {
 	return (
 		includesDeliveryFrequency(productCode, item) &&
 		item.distributorType === MAIL &&
-		item.country.includes(country)
+		item.country.includes(FTShippingZone)
 	);
 }
 
-function handDeliveryStrategy (productCode, option, country, item) {
+function handDeliveryStrategy (productCode, option, FTShippingZone, item) {
 	return (
 		includesDeliveryFrequency(productCode, item) &&
 		item.distributorType === HAND_DELIVERY &&
 		item.deliveryOnPublicationDate === option.deliveryOnPublicationDate &&
 		item.flightMarket === option.flightMarket &&
-		item.country.includes(country)
+		item.country.includes(FTShippingZone)
 	);
 }
 
 /**
- * Method to find a specific delivery option based on the delivery frequency, country and option values.
+ * Method to find a specific delivery option based on the delivery frequency, FTShippingZone and option values.
  * There are two different strategies, one for options with mailDelivery = true and other by the opposite.
  * Both cases are represented by system option code 'HD', but differ on the mailDelivery property value.
  * If no message matchs, then undefined is returned.
  */
-function findCustomDeliveryOption (productCode, option, country) {
+function findCustomDeliveryOption (productCode, option, FTShippingZone) {
 	let deliveryOption;
 
 	if (option.value === HAND_DELIVERY) {
 		const filteredMessages = deliveryOptionMessages.filter((item) => {
 			return option.mailDelivery
-				? mailStrategy(productCode, option, country, item)
-				: handDeliveryStrategy(productCode, option, country, item);
+				? mailStrategy(productCode, option, FTShippingZone, item)
+				: handDeliveryStrategy(productCode, option, FTShippingZone, item);
 		});
 
 		if (filteredMessages.length) {
@@ -231,10 +231,10 @@ function findCustomDeliveryOption (productCode, option, country) {
 	return deliveryOption;
 }
 
-function getDeliveryOption (productCode, option, country) {
-	return country === UK_COUNTRY_CODE
+function getDeliveryOption (productCode, option, FTShippingZone) {
+	return FTShippingZone === UK_COUNTRY_CODE
 		? UKDeliveryOptions[option.value]
-		: findCustomDeliveryOption(productCode, option, country);
+		: findCustomDeliveryOption(productCode, option, FTShippingZone);
 }
 
 module.exports = {

--- a/utils/delivery-option-messages.js
+++ b/utils/delivery-option-messages.js
@@ -114,7 +114,7 @@ const deliveryOptionMessages = [
 		deliveryOnPublicationDate: true,
 		flightMarket: false,
 		country: [printRegions.cemeaV1, printRegions.cemeaV2, printRegions.apac],
-		title: 'Hand delivery',
+		title: 'Hand Delivery',
 		description:
 			'Enjoy the delivery of the newspaper to your home or office address. Please note we fly the newspaper to your location which means delivery is subject to flight delays/cancellations outside of the FT’s control. In those circumstances, your newspaper will be delivered the next delivery day. Please also be aware that your FT weekend will be delivered on Sunday.',
 	},
@@ -125,6 +125,17 @@ const deliveryOptionMessages = [
 		],
 		distributorType: MAIL,
 		country: [printRegions.cemeaV1, printRegions.cemeaV2, printRegions.apac],
+		title: 'Mail Delivery',
+		description:
+			'We can only deliver the newspaper to your location by postal mail which means your delivery will arrive up to 3 business days after the date of publication and will not include the HTSI Magazine. We also fly the newspaper to your location which means delivery is subject to flight delays/cancellations outside the FT\'s control. If you prefer to read the printed content on the day of publication, please proceed to subscribe to the FT ePaper - a digital replica of the print edition.',
+	},
+	{
+		deliveryFrequency: [
+			FIVE_DAYS_WEEK_DELIVERY_FREQ,
+			SIX_DAYS_WEEK_DELIVERY_FREQ,
+		],
+		distributorType: MAIL,
+		country: [USA_COUNTRY_CODE, CAN_COUNTRY_CODE],
 		title: 'Mail',
 		customId: 'ML',
 		description:

--- a/utils/delivery-option-messages.js
+++ b/utils/delivery-option-messages.js
@@ -111,8 +111,21 @@ const deliveryOptionMessages = [
 			SIX_DAYS_WEEK_DELIVERY_FREQ,
 		],
 		distributorType: HAND_DELIVERY,
+		deliveryOnPublicationDate: false,
+		flightMarket: true,
+		country: [printRegions.cemeaV1, printRegions.cemeaV2, printRegions.apac],
+		title: 'Hand Delivery',
+		description:
+			'Enjoy the delivery of the newspaper to your home or office address. Please note we fly the newspaper to your location which means delivery is subject to flight delays/cancellations outside of the FT’s control. In those circumstances, your newspaper will be delivered the next delivery day. Please also be aware that your FT weekend will be delivered on Sunday.',
+	},
+	{
+		deliveryFrequency: [
+			FIVE_DAYS_WEEK_DELIVERY_FREQ,
+			SIX_DAYS_WEEK_DELIVERY_FREQ,
+		],
+		distributorType: HAND_DELIVERY,
 		deliveryOnPublicationDate: true,
-		flightMarket: false,
+		flightMarket: true,
 		country: [printRegions.cemeaV1, printRegions.cemeaV2, printRegions.apac],
 		title: 'Hand Delivery',
 		description:

--- a/utils/delivery-option-messages.spec.js
+++ b/utils/delivery-option-messages.spec.js
@@ -133,4 +133,45 @@ describe('Find Custom Delivery Option', () => {
 			expect(deliveryOption).toEqual(expected);
 		});
 	});
+
+	describe('Find CEMEA/APAC Delivery Option', () => {
+
+		it('returns CEMEA/APAC HD delivery option', () => {
+			stubOption.flightMarket = true;
+			stubOption.deliveryOnPublicationDate = false;
+			stubOption.mailDelivery = false;
+			const expected = {
+				title: 'Hand Delivery',
+				description:
+					'Enjoy the delivery of the newspaper to your home or office address. Please note we fly the newspaper to your location which means delivery is subject to flight delays/cancellations outside of the FT’s control. In those circumstances, your newspaper will be delivered the next delivery day. Please also be aware that your FT weekend will be delivered on Sunday.',
+			};
+
+			const deliveryOption = getDeliveryOption(
+				'N6D',
+				stubOption,
+				'CEMEA_V1'
+			);
+
+			expect(deliveryOption).toEqual(expected);
+		});
+
+		it('returns CEMEA/APAC ML delivery option', () => {
+			stubOption.mailDelivery = true;
+
+			const expected = {
+				title: 'Mail Delivery',
+				customId: 'ML',
+				description:
+					'We can only deliver the newspaper to your location by postal mail which means your delivery will arrive up to 3 business days after the date of publication and will not include the HTSI Magazine. We also fly the newspaper to your location which means delivery is subject to flight delays/cancellations outside the FT\'s control. If you prefer to read the printed content on the day of publication, please proceed to subscribe to the FT ePaper - a digital replica of the print edition.',
+			};
+
+			const deliveryOption = getDeliveryOption(
+				'N6D',
+				stubOption,
+				'APAC'
+			);
+
+			expect(deliveryOption).toEqual(expected);
+		});
+	});
 });


### PR DESCRIPTION
### Description

*Show the correct delivery options for CEMEA and APAC regions (adding the Mail Delivery option in this PR).
*Make the delivery type (home, company, pobox) non-editable in edit mode.

### Ticket
[JIRA](https://financialtimes.atlassian.net/jira/software/c/projects/ACC/boards/1461?modal=detail&selectedIssue=ACC-1807)
[JIRA](https://financialtimes.atlassian.net/jira/software/c/projects/ACC/boards/1461?modal=detail&selectedIssue=ACC-1810)

### Screenshots
![Screenshot 2022-07-12 at 09 25 31](https://user-images.githubusercontent.com/10453619/178492216-ef910be6-e310-4dbe-b18f-c01ed4524909.png)
