### PR TITLE
Adds logo to the licenses

### DIFF
--- a/components/__snapshots__/licence-header.spec.js.snap
+++ b/components/__snapshots__/licence-header.spec.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LicenceHeader renders if is isB2cPartnershipLicence 1`] = `
-<h1 class="ncf__header ncf__center">
+<h1 class="ncf__header">
   Welcome to the Financial Times
 </h1>
 `;
 
 exports[`LicenceHeader renders if is trial 1`] = `
-<h1 class="ncf__header ncf__center">
+<h1 class="ncf__header">
   Welcome to the Financial Times
 </h1>
 `;
 
 exports[`LicenceHeader renders if url is defined 1`] = `
-<h1 class="ncf__header ncf__center">
+<h1 class="ncf__header">
   Join your FT.com subscription
 </h1>
 <div class="ncf__center">
@@ -31,7 +31,7 @@ exports[`LicenceHeader renders if url is defined 1`] = `
 `;
 
 exports[`LicenceHeader renders with custom display name 1`] = `
-<h1 class="ncf__header ncf__center">
+<h1 class="ncf__header">
   <span class="ncf__light-licence-text">
     Great news!
     <span class="ncf__bold-licence-text">
@@ -60,7 +60,7 @@ exports[`LicenceHeader renders with custom display name 1`] = `
 `;
 
 exports[`LicenceHeader renders with custom welcome text (that requires escaping, e.g. ampersand) 1`] = `
-<h1 class="ncf__header ncf__center">
+<h1 class="ncf__header">
   Join your FT.com subscription
 </h1>
 <div class="ncf__center">
@@ -74,7 +74,7 @@ exports[`LicenceHeader renders with custom welcome text (that requires escaping,
 `;
 
 exports[`LicenceHeader renders with default props 1`] = `
-<h1 class="ncf__header ncf__center">
+<h1 class="ncf__header">
   Join your FT.com subscription
 </h1>
 <div class="ncf__center">

--- a/components/__snapshots__/licence-title.spec.js.snap
+++ b/components/__snapshots__/licence-title.spec.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LicenceTitle renders if is isB2cPartnershipLicence 1`] = `
-<h1 class="ncf__header ncf__center">
+<h1 class="ncf__header">
   Welcome to the Financial Times
 </h1>
 `;
 
 exports[`LicenceTitle renders if is trial 1`] = `
-<h1 class="ncf__header ncf__center">
+<h1 class="ncf__header">
   Welcome to the Financial Times
 </h1>
 `;
 
 exports[`LicenceTitle renders with custom display name 1`] = `
-<h1 class="ncf__header ncf__center">
+<h1 class="ncf__header">
   <span class="ncf__light-licence-text">
     Great news!
     <span class="ncf__bold-licence-text">
@@ -29,7 +29,7 @@ exports[`LicenceTitle renders with custom display name 1`] = `
 `;
 
 exports[`LicenceTitle renders with default props 1`] = `
-<h1 class="ncf__header ncf__center">
+<h1 class="ncf__header">
   Join your FT.com subscription
 </h1>
 `;

--- a/components/licence-header.jsx
+++ b/components/licence-header.jsx
@@ -6,6 +6,7 @@ import { LicenceTitle } from './licence-title';
 export function LicenceHeader (props) {
 	const {
 		displayName = '',
+		logoUrl = '',
 		isTrial = false,
 		isB2cPartnershipLicence = false,
 		welcomeText = '',
@@ -17,6 +18,10 @@ export function LicenceHeader (props) {
 
 	return (
 		<React.Fragment>
+			{Boolean(logoUrl) && (
+				<img className="ncf__logo" alt="logo" src={logoUrl}/>
+			)}
+
 			<LicenceTitle
 				displayName={displayName}
 				isTrial={isTrial}
@@ -34,6 +39,7 @@ export function LicenceHeader (props) {
 
 LicenceHeader.propTypes = {
 	displayName: PropTypes.string,
+	logoUrl: PropTypes.string,
 	isTrial: PropTypes.bool,
 	welcomeText: PropTypes.string,
 	isB2cPartnershipLicence: PropTypes.bool,

--- a/components/licence-title.jsx
+++ b/components/licence-title.jsx
@@ -8,7 +8,7 @@ export function LicenceTitle ({
 }) {
 	if (isB2cPartnershipLicence || isTrial) {
 		return (
-			<h1 className="ncf__header ncf__center">
+			<h1 className="ncf__header">
 				{displayName || 'Welcome to the Financial Times'}
 			</h1>
 		);
@@ -20,13 +20,11 @@ export function LicenceTitle ({
 
 function renderB2BTitle (displayName) {
 	if (!displayName) {
-		return (
-			<h1 className="ncf__header ncf__center">Join your FT.com subscription</h1>
-		);
+		return <h1 className="ncf__header">Join your FT.com subscription</h1>;
 	}
 
 	return (
-		<h1 className="ncf__header ncf__center">
+		<h1 className="ncf__header">
 			<span className="ncf__light-licence-text">
 				Great news!
 				<span className="ncf__bold-licence-text"> {displayName} </span>

--- a/main.scss
+++ b/main.scss
@@ -432,6 +432,12 @@
 		}
 	}
 
+	&__logo {
+		display: block;
+		margin: 0 auto 2rem;
+		width: 40%;
+	}
+
 	@include ncfMessage();
 	@include ncfPackageChange();
 	@include ncfPaymentTerm();


### PR DESCRIPTION
### Description
Adds a logo to the licence header. Also aligns title to the left as per request: https://financialtimes.slack.com/archives/C03NJHLTY7P/p1658925951790209?thread_ts=1658923616.759849&cid=C03NJHLTY7P

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-1767

### Screenshots

| Before | After |
| ------ | ----- |
|![Screenshot 2022-07-27 at 15 16 36](https://user-images.githubusercontent.com/1725956/181256371-6ad69dcd-1419-4e71-b4b2-fc6b5f175bfa.png)|![Screenshot 2022-07-27 at 15 16 19](https://user-images.githubusercontent.com/1725956/181256385-7ad8a204-67c0-4241-acaf-d6b975fe8be1.png)|
