### PR TITLE
ACC-1643: add hide panel method for payment type

### DIFF
--- a/utils/payment-type.js
+++ b/utils/payment-type.js
@@ -115,6 +115,18 @@ class PaymentType {
 			}
 		}
 	}
+	/**
+	 * Hide the payment types panel
+	 */
+	hidePanel () {
+		const content = this.$paymentType.querySelectorAll(
+			'.ncf__payment-type-panel'
+		);
+		for (let i = 0; i < content.length; i++) {
+			const element = content[i];
+			element.classList.add('ncf__hidden');
+		}
+	}
 
 	static get CREDITCARD () {
 		return 'creditcard';


### PR DESCRIPTION
### Description
as part of this ticket [ACQ-1643]([ACQ-1643](https://financialtimes.atlassian.net/browse/ACQ-1643)) we need to create a new client method hidePanel on payment type because in the client side we need to show paypal as unique option in case of an error configuring the payment gateway
### Ticket
[ACQ-1643]([ACQ-1643](https://financialtimes.atlassian.net/browse/ACQ-1643))
### Screenshots
<img width="734" alt="Captura de pantalla 2022-08-29 a las 15 43 10" src="https://user-images.githubusercontent.com/98393608/187215609-80cd5325-9858-4034-b10f-ffeefb3686c8.png">
