### PR TITLE
ACC-1980: change dev dependency to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "classnames": "2.3.1",
     "fetchres": "1.7.2",
     "lodash.get": "4.4.2",
-    "n-common-static-data": "github:Financial-Times/n-common-static-data#v1.7.1"
+    "n-common-static-data": "github:Financial-Times/n-common-static-data#v1.7.1",
+    "@financial-times/n-pricing": "5.5.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",
@@ -40,7 +41,6 @@
     "@financial-times/eslint-config-next": "^3.0.0",
     "@financial-times/jest-browser-resolver": "^1.0.2",
     "@financial-times/n-gage": "^8.2.0",
-    "@financial-times/n-pricing": "5.5.0",
     "@storybook/addon-a11y": "^6.5.13",
     "@storybook/addon-essentials": "6.5.13",
     "@storybook/react": "^6.5.13",


### PR DESCRIPTION
### Description
Our shared library n-conversion-forms has n-pricing in devDependencies. Not sure how it got there since it is a hard dependency and it needs to be installed for it to work. 

It should go to dependencies (or maybe peerDependencies), otherwise any app using n-conversion-forms that doesn’t have n-pricing as well will inexplicably fail in weird ways.
### Ticket
[Ticket](https://financialtimes.atlassian.net/browse/ACQ-1980)