### PR TITLE
ACQ-2013: change background color

### DIFF
--- a/styles/message.scss
+++ b/styles/message.scss
@@ -10,8 +10,7 @@
 	.ncf__wrapper & &__message {
 		.o-message--error {
 			color: oColorsByName('crimson');
-			background-color: oColorsMix('crimson', 'white', 10);
-
+		  	background-color: oColorsMix(_oFormsGet('invalid-base'), $percentage: 10);
 			.o-message__actions__primary {
 				background-color: oColorsMix('crimson', 'white', 10);
 				&:hover {


### PR DESCRIPTION
### Description
The colour of the “sorry” error does not align with the new errors colour scheme 

### Ticket
[Ticket](https://financialtimes.atlassian.net/browse/ACQ-2013)
### Screenshots
![image](https://user-images.githubusercontent.com/98393608/201883522-e2b9e361-6e66-4229-9d1d-fad1e1be687e.png)