### PR TITLE
Acc 2075 banktransfer payment type

### DIFF
--- a/components/__snapshots__/payment-type.spec.js.snap
+++ b/components/__snapshots__/payment-type.spec.js.snap
@@ -67,6 +67,21 @@ exports[`PaymentType can initialise with the loader visible 1`] = `
         </span>
       </label>
     </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--banktransfer ncf__hidden">
+      <label for="banktransfer">
+        <input type="radio"
+               name="paymentType"
+               value="banktransfer"
+               id="banktransfer"
+               aria-label="Bank Transfer"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Bank Transfer
+        </span>
+      </label>
+    </div>
   </div>
   <div class="o-forms-input__error">
     Please enter a valid payment type
@@ -140,6 +155,21 @@ exports[`PaymentType render with default props 1`] = `
               aria-hidden="true"
         >
           Apple Pay
+        </span>
+      </label>
+    </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--banktransfer ncf__hidden">
+      <label for="banktransfer">
+        <input type="radio"
+               name="paymentType"
+               value="banktransfer"
+               id="banktransfer"
+               aria-label="Bank Transfer"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Bank Transfer
         </span>
       </label>
     </div>
@@ -219,6 +249,112 @@ exports[`PaymentType render with enableApplepay 1`] = `
         </span>
       </label>
     </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--banktransfer ncf__hidden">
+      <label for="banktransfer">
+        <input type="radio"
+               name="paymentType"
+               value="banktransfer"
+               id="banktransfer"
+               aria-label="Bank Transfer"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Bank Transfer
+        </span>
+      </label>
+    </div>
+  </div>
+  <div class="o-forms-input__error">
+    Please enter a valid payment type
+  </div>
+</div>
+<div class="o-forms-field">
+</div>
+`;
+
+exports[`PaymentType render with enableBankTransfer 1`] = `
+<div class="ncf__security-seal">
+</div>
+<div id="paymentTypeField"
+     class="o-forms-field"
+>
+  <div class="o-forms-input o-forms-input--radio-box ncf__payment-type-selector">
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--creditcard ncf__hidden">
+      <label for="creditcard">
+        <input type="radio"
+               name="paymentType"
+               value="creditcard"
+               id="creditcard"
+               aria-label="Credit / Debit Card"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Credit / Debit Card
+        </span>
+      </label>
+    </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--paypal ncf__hidden">
+      <label for="paypal">
+        <input type="radio"
+               name="paymentType"
+               value="paypal"
+               id="paypal"
+               aria-label="PayPal"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          PayPal
+        </span>
+      </label>
+    </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--directdebit ncf__hidden">
+      <label for="directdebit">
+        <input type="radio"
+               name="paymentType"
+               value="directdebit"
+               id="directdebit"
+               aria-label="Direct Debit"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Direct Debit
+        </span>
+      </label>
+    </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--applepay ncf__hidden">
+      <label for="applepay">
+        <input type="radio"
+               name="paymentType"
+               value="applepay"
+               id="applepay"
+               aria-label="Apple Pay"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Apple Pay
+        </span>
+      </label>
+    </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--banktransfer">
+      <label for="banktransfer">
+        <input type="radio"
+               name="paymentType"
+               value="banktransfer"
+               id="banktransfer"
+               aria-label="Bank Transfer"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Bank Transfer
+        </span>
+      </label>
+    </div>
   </div>
   <div class="o-forms-input__error">
     Please enter a valid payment type
@@ -292,6 +428,21 @@ exports[`PaymentType render with enableCreditcard 1`] = `
               aria-hidden="true"
         >
           Apple Pay
+        </span>
+      </label>
+    </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--banktransfer ncf__hidden">
+      <label for="banktransfer">
+        <input type="radio"
+               name="paymentType"
+               value="banktransfer"
+               id="banktransfer"
+               aria-label="Bank Transfer"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Bank Transfer
         </span>
       </label>
     </div>
@@ -388,6 +539,21 @@ exports[`PaymentType render with enableDirectdebit 1`] = `
               aria-hidden="true"
         >
           Apple Pay
+        </span>
+      </label>
+    </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--banktransfer ncf__hidden">
+      <label for="banktransfer">
+        <input type="radio"
+               name="paymentType"
+               value="banktransfer"
+               id="banktransfer"
+               aria-label="Bank Transfer"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Bank Transfer
         </span>
       </label>
     </div>
@@ -526,6 +692,21 @@ exports[`PaymentType render with enablePaypal 1`] = `
         </span>
       </label>
     </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--banktransfer ncf__hidden">
+      <label for="banktransfer">
+        <input type="radio"
+               name="paymentType"
+               value="banktransfer"
+               id="banktransfer"
+               aria-label="Bank Transfer"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Bank Transfer
+        </span>
+      </label>
+    </div>
   </div>
   <div class="o-forms-input__error">
     Please enter a valid payment type
@@ -599,6 +780,21 @@ exports[`PaymentType render with isSingleTerm 1`] = `
               aria-hidden="true"
         >
           Apple Pay
+        </span>
+      </label>
+    </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--banktransfer ncf__hidden">
+      <label for="banktransfer">
+        <input type="radio"
+               name="paymentType"
+               value="banktransfer"
+               id="banktransfer"
+               aria-label="Bank Transfer"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Bank Transfer
         </span>
       </label>
     </div>
@@ -691,6 +887,21 @@ exports[`PaymentType render with isSingleTermChecked 1`] = `
         </span>
       </label>
     </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--banktransfer ncf__hidden">
+      <label for="banktransfer">
+        <input type="radio"
+               name="paymentType"
+               value="banktransfer"
+               id="banktransfer"
+               aria-label="Bank Transfer"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Bank Transfer
+        </span>
+      </label>
+    </div>
   </div>
   <div class="o-forms-input__error">
     Please enter a valid payment type
@@ -778,6 +989,21 @@ exports[`PaymentType render with value 1`] = `
               aria-hidden="true"
         >
           Apple Pay
+        </span>
+      </label>
+    </div>
+    <div class="o-forms-input--radio-box__container ncf__payment-type ncf__payment-type--banktransfer ncf__hidden">
+      <label for="banktransfer">
+        <input type="radio"
+               name="paymentType"
+               value="banktransfer"
+               id="banktransfer"
+               aria-label="Bank Transfer"
+        >
+        <span class="o-forms-input__label"
+              aria-hidden="true"
+        >
+          Bank Transfer
         </span>
       </label>
     </div>

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -412,5 +412,6 @@ AcceptTerms.propTypes = {
 	isPrintProduct: PropTypes.bool,
 	specialTerms: PropTypes.string,
 	isSingleTerm: PropTypes.bool,
+	isDeferredBilling: PropTypes.bool,
 	hideConfirmTermsAndConditions: PropTypes.bool,
 };

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -22,6 +22,7 @@ export function AcceptTerms ({
 	isPrintProduct = false,
 	specialTerms = null,
 	isSingleTerm = false,
+	isDeferredBilling = false,
 	hideConfirmTermsAndConditions = false,
 }) {
 	const divProps = {
@@ -331,6 +332,15 @@ export function AcceptTerms ({
 		</>
 	);
 
+	const deferredBillingTerms = isDeferredBilling && (
+		<li>
+			<span className="terms-deferred">
+				Please note if you fail to make payment for your deferred billing plan within due
+				date your subscription will be automatically cancelled.
+			</span>
+		</li>
+	);
+
 	const b2cPartnershipTerms = (
 		<label className={[labelClassName, 'checkbox-two-lines'].join(' ')}>
 			<input {...inputProps} />
@@ -369,6 +379,7 @@ export function AcceptTerms ({
 						{corpSignupTerms}
 						{transitionTerms}
 						{signupTerms}
+						{deferredBillingTerms}
 					</ul>
 					<label className={labelClassName} htmlFor="termsAcceptance">
 						<input {...inputProps} />

--- a/components/accept-terms.stories.js
+++ b/components/accept-terms.stories.js
@@ -27,6 +27,7 @@ export default {
 		isSingleTerm: { control: 'boolean' },
 		isNewDigitalBuyFlowConsent: { control: 'boolean' },
 		hideConfirmTermsAndConditions: { control: 'boolean' },
+		isDeferredBilling: { control: 'boolean' },
 	},
 };
 

--- a/components/payment-type.jsx
+++ b/components/payment-type.jsx
@@ -34,6 +34,7 @@ export function PaymentType ({
 	enableCreditcard = false,
 	enableDirectdebit = false,
 	enablePaypal = false,
+	enableBankTransfer = false,
 	showLoaderOnInit = false,
 	showPaypalCustomerCareMessage = false,
 	fieldId = 'paymentTypeField',
@@ -90,12 +91,19 @@ export function PaymentType ({
 		hide: !enableApplepay,
 	};
 
+	const paymentTypeBankTransfer = {
+		id: 'banktransfer',
+		label: 'Bank Transfer',
+		hide: !enableBankTransfer,
+	};
+
 	const createPaymentTypes = () => {
 		const paymentTypes = [
 			paymentTypeCreditCard,
 			paymentTypePaypal(),
 			paymentTypeDirectDebit,
 			paymentTypeApplePay,
+			paymentTypeBankTransfer
 		];
 		return paymentTypes.map((type) => {
 			if (type.id === undefined) {

--- a/components/payment-type.jsx
+++ b/components/payment-type.jsx
@@ -281,6 +281,7 @@ PaymentType.propTypes = {
 	enableCreditcard: PropTypes.bool,
 	enableDirectdebit: PropTypes.bool,
 	enablePaypal: PropTypes.bool,
+	enableBankTransfer: PropTypes.bool,
 	showLoaderOnInit: PropTypes.bool,
 	showPaypalCustomerCareMessage: PropTypes.bool,
 	fieldId: PropTypes.string,

--- a/components/payment-type.spec.js
+++ b/components/payment-type.spec.js
@@ -74,4 +74,12 @@ describe('PaymentType', () => {
 
 		expect(PaymentType).toRenderCorrectly(props);
 	});
+
+	it('render with enableBankTransfer', () => {
+		const props = {
+			enableBankTransfer: true,
+		};
+
+		expect(PaymentType).toRenderCorrectly(props);
+	});
 });

--- a/components/payment-type.stories.js
+++ b/components/payment-type.stories.js
@@ -14,4 +14,5 @@ Basic.args = {
 	enableCreditcard: true,
 	enablePaypal: true,
 	showPaypalCustomerCareMessage: true,
+	enableBankTransfer: true,
 };

--- a/utils/payment-type.js
+++ b/utils/payment-type.js
@@ -143,6 +143,10 @@ class PaymentType {
 	static get APPLEPAY () {
 		return 'applepay';
 	}
+
+	static get BANKTRANSFER () {
+		return 'banktransfer';
+	}
 }
 
 module.exports = PaymentType;


### PR DESCRIPTION
### Description
The following PR includes 2 changes. Both are required for the implementation of allowing Bank Transfer payments to be accepted within Next-Retention. 

1. Adds a `banktransfer` to option to the Payment Types, with the props `enableBankTransfer` 
2. Adds a `deferredBilling` to the Accept Terms, with the props `isDeferredBilling`

### Ticket
[ACC-2075](https://financialtimes.atlassian.net/browse/ACC-2075?atlOrigin=eyJpIjoiMTFlNjY1MzVlY2E1NDViOGIyN2U5ZDNmODY3ODkzODEiLCJwIjoiaiJ9)

### Screenshots

| Before | After |
| ------ | ----- |
|        |   <img width="914" alt="Screenshot 2022-11-16 at 14 32 39" src="https://user-images.githubusercontent.com/40343797/202213378-5ceedac6-3375-4fdb-825f-edef5ab3bbd6.png">    |
|        |   <img width="919" alt="Screenshot 2022-11-16 at 14 33 30" src="https://user-images.githubusercontent.com/40343797/202213412-d804347d-de2a-451f-b1b0-5791f8804496.png">    |


### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [X] **Tests** written for new or updated for existing functionality
- [X] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
