### PR TITLE
ACC-2067-chore: Bumping up n-common-static-data version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "classnames": "2.3.1",
         "fetchres": "1.7.2",
         "lodash.get": "4.4.2",
-        "n-common-static-data": "github:Financial-Times/n-common-static-data#v1.7.1"
+        "n-common-static-data": "github:Financial-Times/n-common-static-data#v1.8.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.10.5",
@@ -29267,6 +29267,23 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
+    "node_modules/snyk/node_modules/esprima": {
+      "version": "4.0.1",
+      "extraneous": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/snyk/node_modules/inherits": {
+      "version": "2.0.4",
+      "extraneous": true,
+      "license": "ISC"
+    },
     "node_modules/snyk/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
@@ -29289,6 +29306,13 @@
       "version": "2.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/snyk/node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "extraneous": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/snyk/node_modules/proxy-agent": {
       "version": "3.1.0",
@@ -29923,6 +29947,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/snyk/node_modules/type-check": {
+      "version": "0.3.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/snyk/node_modules/uuid": {
@@ -51337,7 +51372,7 @@
     },
     "n-common-static-data": {
       "version": "git+ssh://git@github.com/Financial-Times/n-common-static-data.git#bc4ac35d786ed747f026a5e131dd1ce80d746d6a",
-      "from": "n-common-static-data@github:Financial-Times/n-common-static-data#v1.7.1"
+      "from": "n-common-static-data@github:Financial-Times/n-common-static-data#v1.8.1"
     },
     "nan": {
       "version": "2.15.0",
@@ -55175,6 +55210,14 @@
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
+        "esprima": {
+          "version": "4.0.1",
+          "extraneous": true
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "extraneous": true
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
@@ -55192,6 +55235,10 @@
         "ms": {
           "version": "2.1.2",
           "dev": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "extraneous": true
         },
         "proxy-agent": {
           "version": "3.1.0",
@@ -55662,6 +55709,13 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
+          }
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "extraneous": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
           }
         },
         "uuid": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "classnames": "2.3.1",
     "fetchres": "1.7.2",
     "lodash.get": "4.4.2",
-    "n-common-static-data": "github:Financial-Times/n-common-static-data#v1.7.1"
+    "n-common-static-data": "github:Financial-Times/n-common-static-data#v1.8.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",


### PR DESCRIPTION
The First Party Data programme (FPDP) have been working on standardising the FPD data they collect from users on [FT.com](http://ft.com/) B2C, [FT.com](http://ft.com/) B2B and FT Live businesses.

The first part of the standardisation is the Job Position field. This PR updates some of the fields and also add new fields to be consistent with other apps

[Jira Ticket](https://financialtimes.atlassian.net/browse/ACC-2067)