### PR TITLE
ACC-2134-common static data migration

### DIFF
--- a/components/__snapshots__/graduation-date.spec.js.snap
+++ b/components/__snapshots__/graduation-date.spec.js.snap
@@ -71,9 +71,6 @@ exports[`GraduationDate renders with default props 1`] = `
                 name="graduationDateYear"
                 aria-required="false"
         >
-          <option value="2018">
-            2018
-          </option>
           <option value="2019">
             2019
           </option>
@@ -97,6 +94,9 @@ exports[`GraduationDate renders with default props 1`] = `
           </option>
           <option value="2026">
             2026
+          </option>
+          <option value="2027">
+            2027
           </option>
         </select>
       </span>

--- a/helpers/billing-countries.js
+++ b/helpers/billing-countries.js
@@ -1,0 +1,3 @@
+import { billingCountries } from 'n-common-static-data';
+
+export { billingCountries };

--- a/helpers/demographics.js
+++ b/helpers/demographics.js
@@ -1,0 +1,3 @@
+import { demographics } from 'n-common-static-data';
+
+export { demographics };

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -12,4 +12,6 @@ module.exports = {
 		.supportedPostcodeValidators,
 	allSupportedPostcodeExamples: require('./supportedPostcodeExamples')
 		.allSupportedPostcodeExamples,
+	demographics: require('./demographics').demographics,
+	billingCountries: require('./billing-countries').billingCountries,
 };

--- a/helpers/index.spec.js
+++ b/helpers/index.spec.js
@@ -8,4 +8,46 @@ describe('helpers', () => {
 	it('exports a "ncf-countries" helper', () => {
 		expect(helpers).toHaveProperty('ncf-countries');
 	});
+
+	it('export billingCountries', () => {
+		expect(helpers).toHaveProperty('billingCountries');
+		expect(helpers['billingCountries']).toHaveProperty('countries');
+	});
+
+	it('export demographics', () => {
+		expect(helpers).toHaveProperty('demographics');
+		expect(helpers['demographics']).toHaveProperty('industries');
+	});
+
+	it('export cemeaV1ISO', () => {
+		expect(helpers).toHaveProperty('cemeaV1ISO');
+	});
+
+	it('export cemeaV2ISO', () => {
+		expect(helpers).toHaveProperty('cemeaV2ISO');
+	});
+
+	it('export apacISO', () => {
+		expect(helpers).toHaveProperty('apacISO');
+	});
+
+	it('export identifyFTShippingZone', () => {
+		expect(helpers).toHaveProperty('identifyFTShippingZone');
+	});
+
+	it('export countriesSupported', () => {
+		expect(helpers).toHaveProperty('countriesSupported');
+	});
+
+	it('export countriesSupportedISO', () => {
+		expect(helpers).toHaveProperty('countriesSupportedISO');
+	});
+
+	it('export supportedPostcodeValidators', () => {
+		expect(helpers).toHaveProperty('supportedPostcodeValidators');
+	});
+
+	it('export allSupportedPostcodeExamples', () => {
+		expect(helpers).toHaveProperty('allSupportedPostcodeExamples');
+	});
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -29267,23 +29267,6 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
-    "node_modules/snyk/node_modules/esprima": {
-      "version": "4.0.1",
-      "extraneous": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/snyk/node_modules/inherits": {
-      "version": "2.0.4",
-      "extraneous": true,
-      "license": "ISC"
-    },
     "node_modules/snyk/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
@@ -29294,7 +29277,6 @@
     },
     "node_modules/snyk/node_modules/lru-cache": {
       "version": "4.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -29307,20 +29289,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/snyk/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "extraneous": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/snyk/node_modules/proxy-agent": {
       "version": "3.1.0",
       "bundleDependencies": [
         "https-proxy-agent-snyk-fork",
         "pac-proxy-agent"
       ],
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29339,7 +29313,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/agent-base": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29351,7 +29324,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/ast-types": {
       "version": "0.13.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29360,7 +29332,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/bytes": {
       "version": "3.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29369,7 +29340,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/co": {
       "version": "4.6.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29379,19 +29349,16 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/core-util-is": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/data-uri-to-buffer": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/debug": {
       "version": "3.2.6",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29400,13 +29367,11 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/deep-is": {
       "version": "0.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/degenerator": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29417,7 +29382,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/depd": {
       "version": "1.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29426,13 +29390,11 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/es6-promise": {
       "version": "4.2.8",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/es6-promisify": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29441,7 +29403,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/escodegen": {
       "version": "1.12.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -29463,7 +29424,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/esprima": {
       "version": "3.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "bin": {
@@ -29476,7 +29436,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/estraverse": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -29485,7 +29444,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/esutils": {
       "version": "2.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -29494,25 +29452,21 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/extend": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/file-uri-to-path": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/ftp": {
       "version": "0.3.10",
-      "dev": true,
       "inBundle": true,
       "dependencies": {
         "readable-stream": "1.1.x",
@@ -29524,7 +29478,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/ftp/node_modules/readable-stream": {
       "version": "1.1.14",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29536,7 +29489,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/get-uri": {
       "version": "2.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29550,7 +29502,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/get-uri/node_modules/debug": {
       "version": "4.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29559,7 +29510,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/http-errors": {
       "version": "1.7.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29575,7 +29525,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/http-proxy-agent": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29588,7 +29537,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/http-proxy-agent/node_modules/debug": {
       "version": "3.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29597,13 +29545,11 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/http-proxy-agent/node_modules/ms": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/https-proxy-agent-snyk-fork": {
       "version": "2.2.2-fixed-mitm-vuln",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29616,7 +29562,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29628,25 +29573,21 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/ip": {
       "version": "1.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/isarray": {
       "version": "0.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/levn": {
       "version": "0.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29659,13 +29600,11 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/netmask": {
       "version": "1.0.6",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29674,7 +29613,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/optionator": {
       "version": "0.8.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29691,7 +29629,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/pac-proxy-agent": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29707,7 +29644,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/pac-resolver": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29720,7 +29656,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/prelude-ls": {
       "version": "1.1.2",
-      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -29728,7 +29663,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/raw-body": {
       "version": "2.4.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29743,7 +29677,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/readable-stream": {
       "version": "3.4.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29757,7 +29690,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/readable-stream/node_modules/string_decoder": {
       "version": "1.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29766,25 +29698,21 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/safe-buffer": {
       "version": "5.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/setprototypeof": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/smart-buffer": {
       "version": "4.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29794,7 +29722,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/socks": {
       "version": "2.3.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29808,7 +29735,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/socks-proxy-agent": {
       "version": "4.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29821,7 +29747,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/socks-proxy-agent/node_modules/agent-base": {
       "version": "4.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29833,17 +29758,14 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/statuses": {
       "version": "1.5.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29852,19 +29774,16 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/string_decoder": {
       "version": "0.10.31",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/thunkify": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/toidentifier": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29873,7 +29792,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/type-check": {
       "version": "0.3.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29885,7 +29803,6 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/unpipe": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29894,19 +29811,16 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/wordwrap": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/xregexp": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29915,13 +29829,11 @@
     },
     "node_modules/snyk/node_modules/proxy-from-env": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/pseudomap": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -29949,17 +29861,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/snyk/node_modules/type-check": {
-      "version": "0.3.2",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/snyk/node_modules/uuid": {
       "version": "3.4.0",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
@@ -29984,7 +29885,6 @@
     },
     "node_modules/snyk/node_modules/yallist": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -55210,14 +55110,6 @@
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
-        "esprima": {
-          "version": "4.0.1",
-          "extraneous": true
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "extraneous": true
-        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
@@ -55226,7 +55118,6 @@
         "lru-cache": {
           "version": "4.1.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
@@ -55236,14 +55127,9 @@
           "version": "2.1.2",
           "dev": true
         },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "extraneous": true
-        },
         "proxy-agent": {
           "version": "3.1.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "agent-base": "^4.2.0",
             "debug": "^3.1.0",
@@ -55258,53 +55144,44 @@
             "agent-base": {
               "version": "4.3.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "es6-promisify": "^5.0.0"
               }
             },
             "ast-types": {
               "version": "0.13.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "bytes": {
               "version": "3.1.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "co": {
               "version": "4.6.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "data-uri-to-buffer": {
               "version": "2.0.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "debug": {
               "version": "3.2.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "ms": "^2.1.1"
               }
             },
             "deep-is": {
               "version": "0.1.3",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "degenerator": {
               "version": "1.0.4",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "ast-types": "0.x.x",
                 "escodegen": "1.x.x",
@@ -55313,18 +55190,15 @@
             },
             "depd": {
               "version": "1.1.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "es6-promise": {
               "version": "4.2.8",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "es6-promisify": {
               "version": "5.0.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "es6-promise": "^4.0.3"
               }
@@ -55332,7 +55206,6 @@
             "escodegen": {
               "version": "1.12.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "esprima": "^3.1.3",
                 "estraverse": "^4.2.0",
@@ -55343,38 +55216,31 @@
             },
             "esprima": {
               "version": "3.1.3",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "estraverse": {
               "version": "4.3.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "esutils": {
               "version": "2.0.3",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "extend": {
               "version": "3.0.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "fast-levenshtein": {
               "version": "2.0.6",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "file-uri-to-path": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "ftp": {
               "version": "0.3.10",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "readable-stream": "1.1.x",
                 "xregexp": "2.0.0"
@@ -55383,7 +55249,6 @@
                 "readable-stream": {
                   "version": "1.1.14",
                   "bundled": true,
-                  "dev": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
                     "inherits": "~2.0.1",
@@ -55396,7 +55261,6 @@
             "get-uri": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "data-uri-to-buffer": "2",
                 "debug": "4",
@@ -55409,7 +55273,6 @@
                 "debug": {
                   "version": "4.1.1",
                   "bundled": true,
-                  "dev": true,
                   "requires": {
                     "ms": "^2.1.1"
                   }
@@ -55419,7 +55282,6 @@
             "http-errors": {
               "version": "1.7.3",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "depd": "~1.1.2",
                 "inherits": "2.0.4",
@@ -55431,7 +55293,6 @@
             "http-proxy-agent": {
               "version": "2.1.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "agent-base": "4",
                 "debug": "3.1.0"
@@ -55440,22 +55301,19 @@
                 "debug": {
                   "version": "3.1.0",
                   "bundled": true,
-                  "dev": true,
                   "requires": {
                     "ms": "2.0.0"
                   }
                 },
                 "ms": {
                   "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true
+                  "bundled": true
                 }
               }
             },
             "https-proxy-agent-snyk-fork": {
               "version": "2.2.2-fixed-mitm-vuln",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "agent-base": "^4.3.0",
                 "debug": "^3.1.0"
@@ -55464,30 +55322,25 @@
             "iconv-lite": {
               "version": "0.4.24",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
               }
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "ip": {
               "version": "1.1.5",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "isarray": {
               "version": "0.0.1",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "levn": {
               "version": "0.3.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2"
@@ -55495,18 +55348,15 @@
             },
             "ms": {
               "version": "2.1.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "netmask": {
               "version": "1.0.6",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "optionator": {
               "version": "0.8.2",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "deep-is": "~0.1.3",
                 "fast-levenshtein": "~2.0.4",
@@ -55519,7 +55369,6 @@
             "pac-proxy-agent": {
               "version": "3.0.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "agent-base": "^4.2.0",
                 "debug": "^3.1.0",
@@ -55534,7 +55383,6 @@
             "pac-resolver": {
               "version": "3.0.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "co": "^4.6.0",
                 "degenerator": "^1.0.4",
@@ -55545,13 +55393,11 @@
             },
             "prelude-ls": {
               "version": "1.1.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "raw-body": {
               "version": "2.4.1",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "bytes": "3.1.0",
                 "http-errors": "1.7.3",
@@ -55562,7 +55408,6 @@
             "readable-stream": {
               "version": "3.4.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -55572,7 +55417,6 @@
                 "string_decoder": {
                   "version": "1.3.0",
                   "bundled": true,
-                  "dev": true,
                   "requires": {
                     "safe-buffer": "~5.2.0"
                   }
@@ -55581,28 +55425,23 @@
             },
             "safe-buffer": {
               "version": "5.2.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "setprototypeof": {
               "version": "1.1.1",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "smart-buffer": {
               "version": "4.0.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "socks": {
               "version": "2.3.2",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "ip": "^1.1.5",
                 "smart-buffer": "4.0.2"
@@ -55611,7 +55450,6 @@
             "socks-proxy-agent": {
               "version": "4.0.2",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "agent-base": "~4.2.1",
                 "socks": "~2.3.2"
@@ -55620,7 +55458,6 @@
                 "agent-base": {
                   "version": "4.2.1",
                   "bundled": true,
-                  "dev": true,
                   "requires": {
                     "es6-promisify": "^5.0.0"
                   }
@@ -55629,69 +55466,56 @@
             },
             "source-map": {
               "version": "0.6.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "statuses": {
               "version": "1.5.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "string_decoder": {
               "version": "0.10.31",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "thunkify": {
               "version": "2.1.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "toidentifier": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "type-check": {
               "version": "0.3.2",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "prelude-ls": "~1.1.2"
               }
             },
             "unpipe": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "wordwrap": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "xregexp": {
               "version": "2.0.0",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "proxy-from-env": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "string-width": {
           "version": "3.1.0",
@@ -55711,13 +55535,6 @@
             "ansi-regex": "^4.1.0"
           }
         },
-        "type-check": {
-          "version": "0.3.2",
-          "extraneous": true,
-          "requires": {
-            "prelude-ls": "~1.1.2"
-          }
-        },
         "uuid": {
           "version": "3.4.0",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
@@ -55735,8 +55552,7 @@
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "classnames": "2.3.1",
         "fetchres": "1.7.2",
         "lodash.get": "4.4.2",
-        "n-common-static-data": "github:Financial-Times/n-common-static-data#v1.8.1"
+        "n-common-static-data": "github:Financial-Times/n-common-static-data#v1.8.2"
       },
       "devDependencies": {
         "@babel/cli": "^7.10.5",
@@ -29267,6 +29267,23 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
+    "node_modules/snyk/node_modules/esprima": {
+      "version": "4.0.1",
+      "extraneous": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/snyk/node_modules/inherits": {
+      "version": "2.0.4",
+      "extraneous": true,
+      "license": "ISC"
+    },
     "node_modules/snyk/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
@@ -29277,6 +29294,7 @@
     },
     "node_modules/snyk/node_modules/lru-cache": {
       "version": "4.1.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -29289,12 +29307,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/snyk/node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "extraneous": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/snyk/node_modules/proxy-agent": {
       "version": "3.1.0",
       "bundleDependencies": [
         "https-proxy-agent-snyk-fork",
         "pac-proxy-agent"
       ],
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29313,6 +29339,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/agent-base": {
       "version": "4.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29324,6 +29351,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/ast-types": {
       "version": "0.13.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29332,6 +29360,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/bytes": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29340,6 +29369,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/co": {
       "version": "4.6.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29349,16 +29379,19 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/core-util-is": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/data-uri-to-buffer": {
       "version": "2.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/debug": {
       "version": "3.2.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29367,11 +29400,13 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/deep-is": {
       "version": "0.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/degenerator": {
       "version": "1.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29382,6 +29417,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/depd": {
       "version": "1.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29390,11 +29426,13 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/es6-promise": {
       "version": "4.2.8",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/es6-promisify": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29403,6 +29441,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/escodegen": {
       "version": "1.12.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -29424,6 +29463,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/esprima": {
       "version": "3.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "bin": {
@@ -29436,6 +29476,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/estraverse": {
       "version": "4.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -29444,6 +29485,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/esutils": {
       "version": "2.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -29452,21 +29494,25 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/extend": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/fast-levenshtein": {
       "version": "2.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/file-uri-to-path": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/ftp": {
       "version": "0.3.10",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "readable-stream": "1.1.x",
@@ -29478,6 +29524,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/ftp/node_modules/readable-stream": {
       "version": "1.1.14",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29489,6 +29536,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/get-uri": {
       "version": "2.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29502,6 +29550,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/get-uri/node_modules/debug": {
       "version": "4.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29510,6 +29559,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/http-errors": {
       "version": "1.7.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29525,6 +29575,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/http-proxy-agent": {
       "version": "2.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29537,6 +29588,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/http-proxy-agent/node_modules/debug": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29545,11 +29597,13 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/http-proxy-agent/node_modules/ms": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/https-proxy-agent-snyk-fork": {
       "version": "2.2.2-fixed-mitm-vuln",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29562,6 +29616,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/iconv-lite": {
       "version": "0.4.24",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29573,21 +29628,25 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/ip": {
       "version": "1.1.5",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/isarray": {
       "version": "0.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/levn": {
       "version": "0.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29600,11 +29659,13 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/netmask": {
       "version": "1.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29613,6 +29674,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/optionator": {
       "version": "0.8.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29629,6 +29691,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/pac-proxy-agent": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29644,6 +29707,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/pac-resolver": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29656,6 +29720,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/prelude-ls": {
       "version": "1.1.2",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -29663,6 +29728,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/raw-body": {
       "version": "2.4.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29677,6 +29743,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/readable-stream": {
       "version": "3.4.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29690,6 +29757,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/readable-stream/node_modules/string_decoder": {
       "version": "1.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29698,21 +29766,25 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/safe-buffer": {
       "version": "5.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/setprototypeof": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/smart-buffer": {
       "version": "4.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29722,6 +29794,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/socks": {
       "version": "2.3.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29735,6 +29808,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/socks-proxy-agent": {
       "version": "4.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29747,6 +29821,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/socks-proxy-agent/node_modules/agent-base": {
       "version": "4.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29758,14 +29833,17 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/source-map": {
       "version": "0.6.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/statuses": {
       "version": "1.5.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29774,16 +29852,19 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/string_decoder": {
       "version": "0.10.31",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/thunkify": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/toidentifier": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29792,6 +29873,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/type-check": {
       "version": "0.3.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -29803,6 +29885,7 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/unpipe": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29811,16 +29894,19 @@
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/wordwrap": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/proxy-agent/node_modules/xregexp": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -29829,11 +29915,13 @@
     },
     "node_modules/snyk/node_modules/proxy-from-env": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/snyk/node_modules/pseudomap": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -29861,6 +29949,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/snyk/node_modules/type-check": {
+      "version": "0.3.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/snyk/node_modules/uuid": {
       "version": "3.4.0",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
@@ -29885,6 +29984,7 @@
     },
     "node_modules/snyk/node_modules/yallist": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -51272,7 +51372,7 @@
     },
     "n-common-static-data": {
       "version": "git+ssh://git@github.com/Financial-Times/n-common-static-data.git#bc4ac35d786ed747f026a5e131dd1ce80d746d6a",
-      "from": "n-common-static-data@github:Financial-Times/n-common-static-data#v1.8.1"
+      "from": "n-common-static-data@github:Financial-Times/n-common-static-data#v1.8.2"
     },
     "nan": {
       "version": "2.15.0",
@@ -55110,6 +55210,14 @@
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
+        "esprima": {
+          "version": "4.0.1",
+          "extraneous": true
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "extraneous": true
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
@@ -55118,6 +55226,7 @@
         "lru-cache": {
           "version": "4.1.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
@@ -55127,9 +55236,14 @@
           "version": "2.1.2",
           "dev": true
         },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "extraneous": true
+        },
         "proxy-agent": {
           "version": "3.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "agent-base": "^4.2.0",
             "debug": "^3.1.0",
@@ -55144,44 +55258,53 @@
             "agent-base": {
               "version": "4.3.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "es6-promisify": "^5.0.0"
               }
             },
             "ast-types": {
               "version": "0.13.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "bytes": {
               "version": "3.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "co": {
               "version": "4.6.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "data-uri-to-buffer": {
               "version": "2.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "debug": {
               "version": "3.2.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ms": "^2.1.1"
               }
             },
             "deep-is": {
               "version": "0.1.3",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "degenerator": {
               "version": "1.0.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ast-types": "0.x.x",
                 "escodegen": "1.x.x",
@@ -55190,15 +55313,18 @@
             },
             "depd": {
               "version": "1.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "es6-promise": {
               "version": "4.2.8",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "es6-promisify": {
               "version": "5.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "es6-promise": "^4.0.3"
               }
@@ -55206,6 +55332,7 @@
             "escodegen": {
               "version": "1.12.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "esprima": "^3.1.3",
                 "estraverse": "^4.2.0",
@@ -55216,31 +55343,38 @@
             },
             "esprima": {
               "version": "3.1.3",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "estraverse": {
               "version": "4.3.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "esutils": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "extend": {
               "version": "3.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "fast-levenshtein": {
               "version": "2.0.6",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "file-uri-to-path": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "ftp": {
               "version": "0.3.10",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "readable-stream": "1.1.x",
                 "xregexp": "2.0.0"
@@ -55249,6 +55383,7 @@
                 "readable-stream": {
                   "version": "1.1.14",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
                     "inherits": "~2.0.1",
@@ -55261,6 +55396,7 @@
             "get-uri": {
               "version": "2.0.3",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "data-uri-to-buffer": "2",
                 "debug": "4",
@@ -55273,6 +55409,7 @@
                 "debug": {
                   "version": "4.1.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "ms": "^2.1.1"
                   }
@@ -55282,6 +55419,7 @@
             "http-errors": {
               "version": "1.7.3",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "depd": "~1.1.2",
                 "inherits": "2.0.4",
@@ -55293,6 +55431,7 @@
             "http-proxy-agent": {
               "version": "2.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "agent-base": "4",
                 "debug": "3.1.0"
@@ -55301,19 +55440,22 @@
                 "debug": {
                   "version": "3.1.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "ms": "2.0.0"
                   }
                 },
                 "ms": {
                   "version": "2.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "https-proxy-agent-snyk-fork": {
               "version": "2.2.2-fixed-mitm-vuln",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "agent-base": "^4.3.0",
                 "debug": "^3.1.0"
@@ -55322,25 +55464,30 @@
             "iconv-lite": {
               "version": "0.4.24",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
               }
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "ip": {
               "version": "1.1.5",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "isarray": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "levn": {
               "version": "0.3.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2"
@@ -55348,15 +55495,18 @@
             },
             "ms": {
               "version": "2.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "netmask": {
               "version": "1.0.6",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "optionator": {
               "version": "0.8.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "deep-is": "~0.1.3",
                 "fast-levenshtein": "~2.0.4",
@@ -55369,6 +55519,7 @@
             "pac-proxy-agent": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "agent-base": "^4.2.0",
                 "debug": "^3.1.0",
@@ -55383,6 +55534,7 @@
             "pac-resolver": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "co": "^4.6.0",
                 "degenerator": "^1.0.4",
@@ -55393,11 +55545,13 @@
             },
             "prelude-ls": {
               "version": "1.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "raw-body": {
               "version": "2.4.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "bytes": "3.1.0",
                 "http-errors": "1.7.3",
@@ -55408,6 +55562,7 @@
             "readable-stream": {
               "version": "3.4.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -55417,6 +55572,7 @@
                 "string_decoder": {
                   "version": "1.3.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "safe-buffer": "~5.2.0"
                   }
@@ -55425,23 +55581,28 @@
             },
             "safe-buffer": {
               "version": "5.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "setprototypeof": {
               "version": "1.1.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "smart-buffer": {
               "version": "4.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "socks": {
               "version": "2.3.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ip": "^1.1.5",
                 "smart-buffer": "4.0.2"
@@ -55450,6 +55611,7 @@
             "socks-proxy-agent": {
               "version": "4.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "agent-base": "~4.2.1",
                 "socks": "~2.3.2"
@@ -55458,6 +55620,7 @@
                 "agent-base": {
                   "version": "4.2.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "es6-promisify": "^5.0.0"
                   }
@@ -55466,56 +55629,69 @@
             },
             "source-map": {
               "version": "0.6.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "statuses": {
               "version": "1.5.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "string_decoder": {
               "version": "0.10.31",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "thunkify": {
               "version": "2.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "toidentifier": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "type-check": {
               "version": "0.3.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "prelude-ls": "~1.1.2"
               }
             },
             "unpipe": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "wordwrap": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "xregexp": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "proxy-from-env": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "string-width": {
           "version": "3.1.0",
@@ -55535,6 +55711,13 @@
             "ansi-regex": "^4.1.0"
           }
         },
+        "type-check": {
+          "version": "0.3.2",
+          "extraneous": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        },
         "uuid": {
           "version": "3.4.0",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
@@ -55552,7 +55735,8 @@
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "classnames": "2.3.1",
     "fetchres": "1.7.2",
     "lodash.get": "4.4.2",
-    "n-common-static-data": "github:Financial-Times/n-common-static-data#v1.8.1"
+    "n-common-static-data": "github:Financial-Times/n-common-static-data#v1.8.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

This PR refactors the piece of code we are using in `next-profile` from `n-common-static-data` package for demographic form, country form & your organisation form in `next-profile` so that we could get rid of the `n-common-static-data`  completely from `next-profile` for better consistency and a single source of truth which would help us also avoid issues like [this one here](https://financialtimes.slack.com/archives/CSVRXFV6F/p1670504977875609). 

This PR also added some tests for the helpers that were not added.

### Ticket
<!-- Add link to the corresponding ticket -->
[Jira ticket](https://financialtimes.atlassian.net/browse/ACC-2134)



### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
