### PR TITLE
feat: add optional children and policies position to accept-terms

### DIFF
--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -5,58 +5,56 @@ exports[`AcceptTerms renders appropriately if a isAuthFirstAccount 1`] = `
      class="o-forms-field o-layout-typography ncf__validation-error"
      data-validate="required,checked"
 >
-  <ul class="o-typography-list ncf__accept-terms-list">
-    <li>
-      <span class="terms-auth-first-step">
-        For more information about how we use your data, please refer to our
-        <a class="ncf__link--external"
-           href="https://help.ft.com/legal-privacy/privacy-policy/"
-           target="_blank"
-           rel="noopener noreferrer"
-           data-trackable="privacy-policy-info"
-        >
-          privacy
-        </a>
-        and 
-        <a class="ncf__link--external"
-           href="https://help.ft.com/legal-privacy/cookies/"
-           target="_blank"
-           rel="noopener noreferrer"
-           data-trackable="cookies-info"
-        >
-          cookie
-        </a>
-        policies.
-      </span>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label terms-auth-first-step">
-      I confirm that I am 16 years or older and agree to the full
+  <div class="auth-first-step-terms">
+    <span class="consent-text--top">
+      For more information about how we use your data, please refer to our
       <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+         href="https://help.ft.com/legal-privacy/privacy-policy/"
          target="_blank"
          rel="noopener noreferrer"
-         data-trackable="terms-and-conditions"
+         data-trackable="privacy-policy-info"
       >
-        Terms &amp; Conditions
+        privacy
       </a>
-      .
+      and 
+      <a class="ncf__link--external"
+         href="https://help.ft.com/legal-privacy/cookies/"
+         target="_blank"
+         rel="noopener noreferrer"
+         data-trackable="cookies-info"
+      >
+        cookie
+      </a>
+      policies.
     </span>
-    <p class="o-forms-input__error">
-      Please accept our terms &amp; conditions
-    </p>
-  </label>
+    <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+           for="termsAcceptance"
+    >
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span class="o-forms-input__label">
+        I confirm I am 16 years or older and have read and agree to the
+        <a class="ncf__link--external"
+           href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+           target="_blank"
+           rel="noopener noreferrer"
+           data-trackable="terms-and-conditions"
+        >
+          Terms &amp; Conditions
+        </a>
+        .
+      </span>
+      <p class="o-forms-input__error">
+        Please accept our terms &amp; conditions
+      </p>
+    </label>
+  </div>
 </div>
 `;
 
@@ -67,7 +65,7 @@ exports[`AcceptTerms renders appropriately if a isAuthFirstPayment 1`] = `
 >
   <ul class="o-typography-list ncf__accept-terms-list">
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -94,7 +92,7 @@ exports[`AcceptTerms renders appropriately if a registration 1`] = `
      data-validate="required,checked"
      data-trackable="register-up-terms"
 >
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -177,7 +175,7 @@ exports[`AcceptTerms renders appropriately if a signup 1`] = `
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -256,7 +254,7 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 1`]
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -317,7 +315,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product 1`]
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -378,7 +376,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -439,7 +437,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -513,7 +511,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -587,7 +585,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -661,7 +659,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -703,7 +701,7 @@ exports[`AcceptTerms renders appropriately if input is checked 1`] = `
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -737,7 +735,7 @@ exports[`AcceptTerms renders appropriately if is B2B 1`] = `
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -763,7 +761,7 @@ exports[`AcceptTerms renders appropriately if is B2C Partnership 1`] = `
      class="o-forms-field o-layout-typography ncf__validation-error"
      data-validate="required,checked"
 >
-  <label class="o-forms-input o-forms-input--checkbox checkbox-two-lines">
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom checkbox-two-lines">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -827,7 +825,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup 1`] = `
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -884,7 +882,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup and not trial 
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -946,7 +944,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup and trial 1`] 
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -988,7 +986,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1030,7 +1028,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1072,7 +1070,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1114,7 +1112,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1187,7 +1185,7 @@ exports[`AcceptTerms renders appropriately if is transition 1`] = `
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1260,7 +1258,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1333,7 +1331,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1393,7 +1391,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1435,7 +1433,7 @@ exports[`AcceptTerms renders with an error 1`] = `
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox o-forms-input--invalid"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom o-forms-input--invalid"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1477,7 +1475,7 @@ exports[`AcceptTerms renders with default props 1`] = `
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
+  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
          for="termsAcceptance"
   >
     <input type="checkbox"

--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -65,7 +65,7 @@ exports[`AcceptTerms renders appropriately if a isAuthFirstPayment 1`] = `
 >
   <ul class="o-typography-list ncf__accept-terms-list">
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -92,7 +92,7 @@ exports[`AcceptTerms renders appropriately if a registration 1`] = `
      data-validate="required,checked"
      data-trackable="register-up-terms"
 >
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -175,7 +175,7 @@ exports[`AcceptTerms renders appropriately if a signup 1`] = `
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -254,7 +254,7 @@ exports[`AcceptTerms renders appropriately if a signup and has special terms 1`]
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -315,7 +315,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product 1`]
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -376,7 +376,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -437,7 +437,7 @@ exports[`AcceptTerms renders appropriately if a signup for the print product and
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -511,7 +511,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -585,7 +585,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -659,7 +659,7 @@ exports[`AcceptTerms renders appropriately if a signup not for the print product
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -701,7 +701,7 @@ exports[`AcceptTerms renders appropriately if input is checked 1`] = `
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -735,7 +735,7 @@ exports[`AcceptTerms renders appropriately if is B2B 1`] = `
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -761,7 +761,7 @@ exports[`AcceptTerms renders appropriately if is B2C Partnership 1`] = `
      class="o-forms-field o-layout-typography ncf__validation-error"
      data-validate="required,checked"
 >
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom checkbox-two-lines">
+  <label class="o-forms-input o-forms-input--checkbox checkbox-two-lines">
     <input type="checkbox"
            id="termsAcceptance"
            name="termsAcceptance"
@@ -825,7 +825,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup 1`] = `
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -882,7 +882,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup and not trial 
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -944,7 +944,7 @@ exports[`AcceptTerms renders appropriately if is corporate signup and trial 1`] 
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -986,7 +986,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1028,7 +1028,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1070,7 +1070,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1112,7 +1112,7 @@ exports[`AcceptTerms renders appropriately if is not B2B (i.e. default terms dis
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1185,7 +1185,7 @@ exports[`AcceptTerms renders appropriately if is transition 1`] = `
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1258,7 +1258,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1331,7 +1331,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1391,7 +1391,7 @@ exports[`AcceptTerms renders appropriately if is transition with transition type
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1433,7 +1433,7 @@ exports[`AcceptTerms renders with an error 1`] = `
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom o-forms-input--invalid"
+  <label class="o-forms-input o-forms-input--checkbox o-forms-input--invalid"
          for="termsAcceptance"
   >
     <input type="checkbox"
@@ -1475,7 +1475,7 @@ exports[`AcceptTerms renders with default props 1`] = `
       </span>
     </li>
   </ul>
-  <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+  <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
   >
     <input type="checkbox"

--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -39,7 +39,7 @@ exports[`AcceptTerms renders appropriately if a isAuthFirstAccount 1`] = `
              required
       >
       <span class="o-forms-input__label">
-        I confirm that I am 16 years or older and agree to the ful
+        I confirm that I am 16 years or older and agree to the full
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
            target="_blank"

--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -27,7 +27,7 @@ exports[`AcceptTerms renders appropriately if a isAuthFirstAccount 1`] = `
       </a>
       policies.
     </span>
-    <label class="o-forms-input o-forms-input--checkbox consent-text--bottom"
+    <label class="o-forms-input o-forms-input--checkbox"
            for="termsAcceptance"
     >
       <input type="checkbox"
@@ -39,7 +39,7 @@ exports[`AcceptTerms renders appropriately if a isAuthFirstAccount 1`] = `
              required
       >
       <span class="o-forms-input__label">
-        I confirm I am 16 years or older and have read and agree to the
+        I confirm that I am 16 years or older and agree to the ful
         <a class="ncf__link--external"
            href="http://help.ft.com/help/legal-privacy/terms-conditions/"
            target="_blank"

--- a/components/__snapshots__/graduation-date.spec.js.snap
+++ b/components/__snapshots__/graduation-date.spec.js.snap
@@ -71,9 +71,6 @@ exports[`GraduationDate renders with default props 1`] = `
                 name="graduationDateYear"
                 aria-required="false"
         >
-          <option value="2018">
-            2018
-          </option>
           <option value="2019">
             2019
           </option>
@@ -97,6 +94,9 @@ exports[`GraduationDate renders with default props 1`] = `
           </option>
           <option value="2026">
             2026
+          </option>
+          <option value="2027">
+            2027
           </option>
         </select>
       </span>

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -85,7 +85,7 @@ export function AcceptTerms({
 					<input {...inputProps} />
 					<span className="o-forms-input__label">
 						I confirm that I am {ageRestriction} years or older and agree to the
-						ful{' '}
+						full{' '}
 						<a
 							className="ncf__link--external"
 							href="http://help.ft.com/help/legal-privacy/terms-conditions/"

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 const DEFAULT_AGE_RESTRICTION = '16';
+const DEFAULT_PRIVACY_POLICIES_POSITION = 'top';
 
 export function AcceptTerms({
 	isAuthFirstAccount = false,
@@ -24,6 +25,8 @@ export function AcceptTerms({
 	isSingleTerm = false,
 	isDeferredBilling = false,
 	hideConfirmTermsAndConditions = false,
+	children,
+	privacyPoliciesPosition = DEFAULT_PRIVACY_POLICIES_POSITION,
 }) {
 	const divProps = {
 		id: 'acceptTermsField',
@@ -36,6 +39,7 @@ export function AcceptTerms({
 	const labelClassName = classNames([
 		'o-forms-input',
 		'o-forms-input--checkbox',
+		`consent-text--${privacyPoliciesPosition === 'top' ? 'bottom' : 'top'}`,
 		{ 'o-forms-input--invalid': hasError },
 	]);
 
@@ -51,43 +55,37 @@ export function AcceptTerms({
 	};
 
 	const authFirstStepTerms = (
-		<>
-			{
-				<ul className="o-typography-list ncf__accept-terms-list">
-					<li>
-						<span className="terms-auth-first-step">
-							For more information about how we use your data, please refer to
-							our{' '}
-							<a
-								className="ncf__link--external"
-								href="https://help.ft.com/legal-privacy/privacy-policy/"
-								target="_blank"
-								rel="noopener noreferrer"
-								data-trackable="privacy-policy-info"
-							>
-								privacy
-							</a>{' '}
-							and&nbsp;
-							<a
-								className="ncf__link--external"
-								href="https://help.ft.com/legal-privacy/cookies/"
-								target="_blank"
-								rel="noopener noreferrer"
-								data-trackable="cookies-info"
-							>
-								cookie
-							</a>{' '}
-							policies.
-						</span>
-					</li>
-				</ul>
-			}
+		<div className="auth-first-step-terms">
+			<span className={`consent-text--${privacyPoliciesPosition}`}>
+				For more information about how we use your data, please refer to our{' '}
+				<a
+					className="ncf__link--external"
+					href="https://help.ft.com/legal-privacy/privacy-policy/"
+					target="_blank"
+					rel="noopener noreferrer"
+					data-trackable="privacy-policy-info"
+				>
+					privacy
+				</a>{' '}
+				and&nbsp;
+				<a
+					className="ncf__link--external"
+					href="https://help.ft.com/legal-privacy/cookies/"
+					target="_blank"
+					rel="noopener noreferrer"
+					data-trackable="cookies-info"
+				>
+					cookie
+				</a>{' '}
+				policies.
+			</span>
+			{children && <div className="children-container">{children}</div>}
 			{!hideConfirmTermsAndConditions && (
 				<label className={labelClassName} htmlFor="termsAcceptance">
 					<input {...inputProps} />
-					<span className="o-forms-input__label terms-auth-first-step">
-						I confirm that I am {ageRestriction} years or older and agree to the
-						full{' '}
+					<span className="o-forms-input__label">
+						I confirm I am {ageRestriction} years or older and have read and
+						agree to the{' '}
 						<a
 							className="ncf__link--external"
 							href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -104,7 +102,7 @@ export function AcceptTerms({
 					</p>
 				</label>
 			)}
-		</>
+		</div>
 	);
 
 	const registerTerms = (
@@ -416,4 +414,9 @@ AcceptTerms.propTypes = {
 	isSingleTerm: PropTypes.bool,
 	isDeferredBilling: PropTypes.bool,
 	hideConfirmTermsAndConditions: PropTypes.bool,
+	children: PropTypes.oneOfType([
+		PropTypes.arrayOf(PropTypes.node),
+		PropTypes.node,
+	]),
+	privacyPoliciesPosition: PropTypes.oneOf(['top', 'bottom']),
 };

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -36,11 +36,18 @@ export function AcceptTerms({
 		...(isRegister && { 'data-trackable': 'register-up-terms' }),
 	};
 
+	const labelPositionClassnameRelatedToPrivacyPoliciesPosition = `consent-text--${
+		privacyPoliciesPosition === 'top' ? 'bottom' : 'top'
+	}`;
+
 	const labelClassName = classNames([
 		'o-forms-input',
 		'o-forms-input--checkbox',
-		`consent-text--${privacyPoliciesPosition === 'top' ? 'bottom' : 'top'}`,
-		{ 'o-forms-input--invalid': hasError },
+		{
+			'o-forms-input--invalid': hasError,
+			[labelPositionClassnameRelatedToPrivacyPoliciesPosition]:
+				isAuthFirstAccount,
+		},
 	]);
 
 	const inputProps = {

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -36,17 +36,11 @@ export function AcceptTerms({
 		...(isRegister && { 'data-trackable': 'register-up-terms' }),
 	};
 
-	const labelPositionClassnameRelatedToPrivacyPoliciesPosition = `consent-text--${
-		privacyPoliciesPosition === 'top' ? 'bottom' : 'top'
-	}`;
-
 	const labelClassName = classNames([
 		'o-forms-input',
 		'o-forms-input--checkbox',
 		{
 			'o-forms-input--invalid': hasError,
-			[labelPositionClassnameRelatedToPrivacyPoliciesPosition]:
-				isAuthFirstAccount,
 		},
 	]);
 
@@ -86,7 +80,6 @@ export function AcceptTerms({
 				</a>{' '}
 				policies.
 			</span>
-			{children && <div className="children-container">{children}</div>}
 			{!hideConfirmTermsAndConditions && (
 				<label className={labelClassName} htmlFor="termsAcceptance">
 					<input {...inputProps} />
@@ -109,6 +102,7 @@ export function AcceptTerms({
 					</p>
 				</label>
 			)}
+			{children && <div className="children-container">{children}</div>}
 		</div>
 	);
 

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -84,8 +84,8 @@ export function AcceptTerms({
 				<label className={labelClassName} htmlFor="termsAcceptance">
 					<input {...inputProps} />
 					<span className="o-forms-input__label">
-						I confirm I am {ageRestriction} years or older and have read and
-						agree to the{' '}
+						I confirm that I am {ageRestriction} years or older and agree to the
+						ful{' '}
 						<a
 							className="ncf__link--external"
 							href="http://help.ft.com/help/legal-privacy/terms-conditions/"

--- a/components/accept-terms.stories.js
+++ b/components/accept-terms.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AcceptTerms } from './accept-terms';
+import { Submit } from './submit';
 
 export default {
 	title: 'Basic Accept Terms',
@@ -11,7 +12,12 @@ export default {
 				options: ['immediate', 'endOfTerm'],
 			},
 		},
-		isAuthFirstAccount: { control: 'boolean' },
+		isAuthFirstAccount: {
+			control: 'boolean',
+			table: {
+				type: { summary: 'Show new buy flow design' },
+			},
+		},
 		isAuthFirstPayment: { control: 'boolean' },
 		hasError: { control: 'boolean' },
 		isSignup: { control: 'boolean' },
@@ -28,6 +34,21 @@ export default {
 		isNewDigitalBuyFlowConsent: { control: 'boolean' },
 		hideConfirmTermsAndConditions: { control: 'boolean' },
 		isDeferredBilling: { control: 'boolean' },
+		children: {
+			control: false,
+			table: {
+				type: { summary: "Only rendered when 'isAuthFirstAccount' is true" },
+			},
+		},
+		privacyPoliciesPosition: {
+			options: ['top', 'bottom'],
+			control: {
+				type: 'inline-radio',
+			},
+			table: {
+				type: { summary: "Placement of the 'Privacy Policies' text" },
+			},
+		},
 	},
 };
 
@@ -43,4 +64,20 @@ export const NewBuyFlowEmailVerification = (args) => <AcceptTerms {...args} />;
 NewBuyFlowEmailVerification.args = {
 	isAuthFirstAccount: true,
 	hideConfirmTermsAndConditions: true,
+};
+
+export const NewBuyFlowWithChildren = (args) => (
+	<AcceptTerms {...args}>
+		<Submit />
+	</AcceptTerms>
+);
+NewBuyFlowWithChildren.args = {
+	isAuthFirstAccount: true,
+	privacyPoliciesPosition: 'bottom',
+};
+NewBuyFlowWithChildren.parameters = {
+	controls: {
+		include: ['privacyPoliciesPosition', 'isAuthFirstAccount', 'children'],
+		expanded: true,
+	},
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -29267,23 +29267,6 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
-    "node_modules/snyk/node_modules/esprima": {
-      "version": "4.0.1",
-      "extraneous": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/snyk/node_modules/inherits": {
-      "version": "2.0.4",
-      "extraneous": true,
-      "license": "ISC"
-    },
     "node_modules/snyk/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
@@ -29306,13 +29289,6 @@
       "version": "2.1.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/snyk/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "extraneous": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
     },
     "node_modules/snyk/node_modules/proxy-agent": {
       "version": "3.1.0",
@@ -29947,17 +29923,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/snyk/node_modules/type-check": {
-      "version": "0.3.2",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/snyk/node_modules/uuid": {
@@ -55210,14 +55175,6 @@
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
-        "esprima": {
-          "version": "4.0.1",
-          "extraneous": true
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "extraneous": true
-        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
@@ -55235,10 +55192,6 @@
         "ms": {
           "version": "2.1.2",
           "dev": true
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "extraneous": true
         },
         "proxy-agent": {
           "version": "3.1.0",
@@ -55709,13 +55662,6 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
-          }
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "extraneous": true,
-          "requires": {
-            "prelude-ls": "~1.1.2"
           }
         },
         "uuid": {

--- a/styles/accept-terms.scss
+++ b/styles/accept-terms.scss
@@ -26,11 +26,12 @@
   .consent-text {
     &--top {
       order: -1;
+      margin-bottom: oSpacingByName('s4');
     }
 
     &--bottom {
-      order: 99;
       margin-top: oSpacingByName('s4');
+      order: 99;
     }
   }
 

--- a/styles/accept-terms.scss
+++ b/styles/accept-terms.scss
@@ -18,3 +18,25 @@
 		}
 	}
 }
+
+.auth-first-step-terms {
+  display: flex;
+  flex-direction: column;
+
+  .consent-text {
+    &--top {
+      order: -1;
+    }
+
+    &--bottom {
+      order: 99;
+      margin-top: oSpacingByName('s4');
+    }
+  }
+
+  .children-container {
+    display: flex;
+    flex-direction: column;
+    margin-top: oSpacingByName('s4');
+  }
+}


### PR DESCRIPTION
### Description
- Add optional children to render between Policies and Cookies text and Accept Terms checkbox. 
- Add `privacyPoliciesPosition` prop to choose if Policies and Cookies text should go in top or bottom (defaults to top).

EDIT: Changed images to reflect request by Ludo.

### Ticket
- https://financialtimes.atlassian.net/browse/ACQ-2077

### Screenshots

| Without children | 
| ------ |
|   ![image](https://user-images.githubusercontent.com/22417566/212907233-8d0b00a2-bbe5-4a85-8c83-53d9ad1651f4.png)    |
#### With Children 
|  `privacyPoliciesPosition` top |  `privacyPoliciesPosition` bottom | 
| ----- | ----- |  
 |  ![image](https://user-images.githubusercontent.com/22417566/214045308-e2118bd3-25a2-4274-a337-10f7e671dbe7.png)   | ![image](https://user-images.githubusercontent.com/22417566/214045407-1c72eee0-dc84-4676-a0ce-1ddbec50e043.png) |
### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [x] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
