### PR TITLE
update snapshot to correct available dates

### DIFF
--- a/components/__snapshots__/graduation-date.spec.js.snap
+++ b/components/__snapshots__/graduation-date.spec.js.snap
@@ -71,9 +71,6 @@ exports[`GraduationDate renders with default props 1`] = `
                 name="graduationDateYear"
                 aria-required="false"
         >
-          <option value="2018">
-            2018
-          </option>
           <option value="2019">
             2019
           </option>
@@ -97,6 +94,9 @@ exports[`GraduationDate renders with default props 1`] = `
           </option>
           <option value="2026">
             2026
+          </option>
+          <option value="2027">
+            2027
           </option>
         </select>
       </span>


### PR DESCRIPTION
The years we show to users changed on 1 Jan 2023, so the snapshot needed updating

### Description
I reran the tests to create a new snapshot, so that the tests pass (and the nightly build will no longer fail :) )