### PR TITLE
ACC-2134-fix: change exports to use module.export

### DIFF
--- a/helpers/billing-countries.js
+++ b/helpers/billing-countries.js
@@ -1,3 +1,3 @@
 const { billingCountries } = require('n-common-static-data');
 
-export { billingCountries };
+module.exports = { billingCountries };

--- a/helpers/demographics.js
+++ b/helpers/demographics.js
@@ -1,3 +1,3 @@
 const { demographics } = require('n-common-static-data');
 
-export { demographics };
+module.exports = { demographics };


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
This PR is a fix that changes the exports in billing-countries and demographics helpers to module.exports because it's failing on consuming apps.
PS: I hate to keep having a do-over 😟

### Ticket
<!-- Add link to the corresponding ticket -->
[Jira ticket](https://financialtimes.atlassian.net/browse/ACC-2134)
