### PR TITLE
ACQ-2116: fix captcha in next subscribe to trigger after client validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "@financial-times/o-buttons": "^7.5.0",
         "@financial-times/o-colors": "^6.4.2",
         "@financial-times/o-expander": "^6.2.2",
-        "@financial-times/o-forms": "^9.4.2",
+        "@financial-times/o-forms": "^9.6.0",
         "@financial-times/o-grid": "^6.1.5",
         "@financial-times/o-header-services": "^5.2.2",
         "@financial-times/o-icons": "^7.2.1",
@@ -2587,10 +2587,14 @@
       }
     },
     "node_modules/@financial-times/o-forms": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-9.4.2.tgz",
-      "integrity": "sha512-j8Hh+LF6OvZcxkNqUDaMEui0C3KcOpY4fLPevTY5Q87YcStzRn7mhphIVvpj6Pt+3AqpZmm1Kv1n65QgRoll+g==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-9.6.0.tgz",
+      "integrity": "sha512-PzskWdHCHApEOzobN05Hmig1C2xFsq0/kPdrApPli1dl8K32RGx5K7HRPwPVl9dwvcQifwccDxDMVAHpoQPFJg==",
       "peer": true,
+      "dependencies": {
+        "@types/lodash.uniqueid": "^4.0.7",
+        "lodash.uniqueid": "^4.0.1"
+      },
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -2602,7 +2606,7 @@
         "@financial-times/o-grid": "^6.0.0",
         "@financial-times/o-icons": "^7.0.0",
         "@financial-times/o-loading": "^5.0.0",
-        "@financial-times/o-normalise": "^3.2.0",
+        "@financial-times/o-normalise": "^3.3.0",
         "@financial-times/o-spacing": "^3.0.0",
         "@financial-times/o-typography": "^7.0.1"
       }
@@ -2708,9 +2712,9 @@
       }
     },
     "node_modules/@financial-times/o-normalise": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-normalise/-/o-normalise-3.2.2.tgz",
-      "integrity": "sha512-w7eYm2EB4Wf4cY5IJ/B55xst32mFQIW41f+HZpfykJEvI0ohBM2ghfaLu+JpJdaAv8kRaV8245FdDcngDst3wA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-normalise/-/o-normalise-3.3.0.tgz",
+      "integrity": "sha512-1ibVtNNZGODl4l9nOBQ1CS9wwdqP4m26p4AWTrJ1glIx/DXR14n3V0W+ZwKIyohUcNkfZJsPtax1laeS9wgPcg==",
       "peer": true,
       "engines": {
         "npm": "^7 || ^8"
@@ -9770,8 +9774,16 @@
     "node_modules/@types/lodash": {
       "version": "4.14.186",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
-      "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==",
-      "dev": true
+      "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
+    },
+    "node_modules/@types/lodash.uniqueid": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.uniqueid/-/lodash.uniqueid-4.0.7.tgz",
+      "integrity": "sha512-ipMGW5nR+DTR6U5O08k1Ufr1F9iH+F3p7bhdwsnq6V6nCn/HgMq22UalDq4n91+03+pHFKyeXV1Y7vdJrm7S4g==",
+      "peer": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mdast": {
       "version": "3.0.10",
@@ -22753,6 +22765,12 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
+    "node_modules/lodash.uniqueid": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
+      "integrity": "sha512-GQQWaIeGlL6DIIr06kj1j6sSmBxyNMwI8kaX9aKpHR/XsMTiaXDVPNPAkiboOTK9OJpTJF/dXT3xYoFQnj386Q==",
+      "peer": true
+    },
     "node_modules/lodash.values": {
       "version": "4.3.0",
       "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=",
@@ -35194,11 +35212,14 @@
       "requires": {}
     },
     "@financial-times/o-forms": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-9.4.2.tgz",
-      "integrity": "sha512-j8Hh+LF6OvZcxkNqUDaMEui0C3KcOpY4fLPevTY5Q87YcStzRn7mhphIVvpj6Pt+3AqpZmm1Kv1n65QgRoll+g==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-9.6.0.tgz",
+      "integrity": "sha512-PzskWdHCHApEOzobN05Hmig1C2xFsq0/kPdrApPli1dl8K32RGx5K7HRPwPVl9dwvcQifwccDxDMVAHpoQPFJg==",
       "peer": true,
-      "requires": {}
+      "requires": {
+        "@types/lodash.uniqueid": "^4.0.7",
+        "lodash.uniqueid": "^4.0.1"
+      }
     },
     "@financial-times/o-grid": {
       "version": "6.1.5",
@@ -35243,9 +35264,9 @@
       "requires": {}
     },
     "@financial-times/o-normalise": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-normalise/-/o-normalise-3.2.2.tgz",
-      "integrity": "sha512-w7eYm2EB4Wf4cY5IJ/B55xst32mFQIW41f+HZpfykJEvI0ohBM2ghfaLu+JpJdaAv8kRaV8245FdDcngDst3wA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-normalise/-/o-normalise-3.3.0.tgz",
+      "integrity": "sha512-1ibVtNNZGODl4l9nOBQ1CS9wwdqP4m26p4AWTrJ1glIx/DXR14n3V0W+ZwKIyohUcNkfZJsPtax1laeS9wgPcg==",
       "peer": true,
       "requires": {}
     },
@@ -40583,8 +40604,16 @@
     "@types/lodash": {
       "version": "4.14.186",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
-      "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==",
-      "dev": true
+      "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
+    },
+    "@types/lodash.uniqueid": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.uniqueid/-/lodash.uniqueid-4.0.7.tgz",
+      "integrity": "sha512-ipMGW5nR+DTR6U5O08k1Ufr1F9iH+F3p7bhdwsnq6V6nCn/HgMq22UalDq4n91+03+pHFKyeXV1Y7vdJrm7S4g==",
+      "peer": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/mdast": {
       "version": "3.0.10",
@@ -50557,6 +50586,12 @@
       "version": "4.5.0",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
+    },
+    "lodash.uniqueid": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
+      "integrity": "sha512-GQQWaIeGlL6DIIr06kj1j6sSmBxyNMwI8kaX9aKpHR/XsMTiaXDVPNPAkiboOTK9OJpTJF/dXT3xYoFQnj386Q==",
+      "peer": true
     },
     "lodash.values": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@financial-times/o-buttons": "^7.5.0",
     "@financial-times/o-colors": "^6.4.2",
     "@financial-times/o-expander": "^6.2.2",
-    "@financial-times/o-forms": "^9.4.2",
+    "@financial-times/o-forms": "^9.6.0",
     "@financial-times/o-grid": "^6.1.5",
     "@financial-times/o-header-services": "^5.2.2",
     "@financial-times/o-icons": "^7.2.1",

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -3,21 +3,19 @@ const Input = require('@financial-times/o-forms/src/js/input').default;
 
 class Validation {
 	/**
-	 * Set up the Validation utility
-	 * @param {Boolean} mutePromptBeforeLeaving (default: false) Whether to prompt the user before leaving if there have been changes in any of the fields.
-	 * @param {string} [errorSummaryMessage='There is a problem'] - A message to show in the header of the error summary. It defaults to: 'There is a problem'
-	 * @param {Boolean} [useBrowserValidation=false] - Whether to use the browsers validation and error messages. Defaults to `false`.
+	 * @typedef FormsOptions
+	 * @type {object}
+	 * @property {string} [errorSummaryMessage="There is a problem"] - A message to show in the header of the error summary. It defaults to: 'There is a problem'
 	 */
-	constructor({
-		errorSummaryMessage,
-		mutePromptBeforeLeaving,
-		useBrowserValidation,
-	} = {}) {
+
+	/**
+	 * Set up the Validation utility
+	 * @param {boolean} [mutePromptBeforeLeaving=false] (default: false) Whether to prompt the user before leaving if there have been changes in any of the fields.
+	 * @param {FormsOptions} [formsOptions={}] Options object for Origami Forms: https://github.com/Financial-Times/origami/blob/main/components/o-forms/src/js/forms.js
+	 */
+	constructor({ mutePromptBeforeLeaving, formsOptions } = {}) {
 		this.$form = document.querySelector('form.ncf');
-		this.oForms = OForms.init(this.$form, {
-			errorSummaryMessage,
-			useBrowserValidation,
-		});
+		this.oForms = OForms.init(this.$form, formsOptions);
 		this.$requiredEls = this.oForms.formInputs.filter(
 			({ input }) => input.type !== 'hidden' && input.required
 		);

--- a/utils/validation.spec.js
+++ b/utils/validation.spec.js
@@ -8,6 +8,7 @@ describe('Validation - Util', () => {
 	let validation;
 	const mockErrorSummaryMessage = 'mockError';
 	const mockUseBrowserValidation = false;
+	const mockPreventSubmit = true;
 
 	beforeEach(() => {
 		document.body.innerHTML = `
@@ -20,8 +21,11 @@ describe('Validation - Util', () => {
 			</html>`;
 
 		validation = new ValidationUtil({
-			errorSummaryMessage: mockErrorSummaryMessage,
-			useBrowserValidation: mockUseBrowserValidation,
+			formsOptions: {
+				errorSummaryMessage: mockErrorSummaryMessage,
+				useBrowserValidation: mockUseBrowserValidation,
+				preventSubmit: mockPreventSubmit,
+			},
 		});
 		jest.spyOn(validation, 'checkFormValidity');
 		validation.init();
@@ -38,6 +42,7 @@ describe('Validation - Util', () => {
 			expect(OForms.default.init).toHaveBeenCalledWith(form, {
 				errorSummaryMessage: mockErrorSummaryMessage,
 				useBrowserValidation: mockUseBrowserValidation,
+				preventSubmit: mockPreventSubmit,
 			});
 		});
 


### PR DESCRIPTION
### Description
 - refactor: refactor validation to make it easier to pass formOptions to origami forms
 - feat: update o-forms

**NOTE**: This change will only affect next-subscribe in https://github.com/Financial-Times/next-subscribe/blob/4ccd86829f9001309b6c10073139ec94b16b7eca/client/controller.js#L33. A PR is coming in that file after this is released.

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality

