### PR TITLE
ACQ-2147 Refactor Country and BillingCountry

### DIFF
--- a/components/__snapshots__/billing-country.spec.js.snap
+++ b/components/__snapshots__/billing-country.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Country renders with default props 1`] = `
+exports[`BillingCountry renders with default props 1`] = `
 <label id="billingCountryField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="billingCountry"
 >
@@ -13,7 +13,6 @@ exports[`Country renders with default props 1`] = `
   </span>
   <span class="o-forms-input o-forms-input--select">
     <select id="billingCountry"
-            class="js-field__input js-item__value"
             aria-required="true"
             required
             name="billingCountry"
@@ -798,9 +797,9 @@ exports[`Country renders with default props 1`] = `
 </label>
 `;
 
-exports[`Country renders with hasError 1`] = `
+exports[`BillingCountry renders with hasError 1`] = `
 <label id="billingCountryField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="billingCountry"
 >
@@ -811,7 +810,6 @@ exports[`Country renders with hasError 1`] = `
   </span>
   <span class="o-forms-input o-forms-input--select o-forms-input--invalid">
     <select id="billingCountry"
-            class="js-field__input js-item__value"
             aria-required="true"
             required
             name="billingCountry"
@@ -1596,9 +1594,9 @@ exports[`Country renders with hasError 1`] = `
 </label>
 `;
 
-exports[`Country renders with isDisabled 1`] = `
+exports[`BillingCountry renders with isDisabled 1`] = `
 <label id="billingCountryField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="billingCountry"
 >
@@ -1609,7 +1607,6 @@ exports[`Country renders with isDisabled 1`] = `
   </span>
   <span class="o-forms-input o-forms-input--select">
     <select id="billingCountry"
-            class="js-field__input js-item__value"
             aria-required="true"
             required
             name="billingCountry"
@@ -2395,9 +2392,9 @@ exports[`Country renders with isDisabled 1`] = `
 </label>
 `;
 
-exports[`Country renders with large filterList 1`] = `
+exports[`BillingCountry renders with large filterList 1`] = `
 <label id="billingCountryField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="billingCountry"
 >
@@ -2408,7 +2405,6 @@ exports[`Country renders with large filterList 1`] = `
   </span>
   <span class="o-forms-input o-forms-input--select">
     <select id="billingCountry"
-            class="js-field__input js-item__value"
             aria-required="true"
             required
             name="billingCountry"
@@ -2487,9 +2483,9 @@ exports[`Country renders with large filterList 1`] = `
 </label>
 `;
 
-exports[`Country renders with small filterList 1`] = `
+exports[`BillingCountry renders with small filterList 1`] = `
 <label id="billingCountryField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="billingCountry"
 >
@@ -2500,7 +2496,6 @@ exports[`Country renders with small filterList 1`] = `
   </span>
   <span class="o-forms-input o-forms-input--select">
     <select id="billingCountry"
-            class="js-field__input js-item__value"
             aria-required="true"
             required
             name="billingCountry"
@@ -2522,9 +2517,9 @@ exports[`Country renders with small filterList 1`] = `
 </label>
 `;
 
-exports[`Country renders with value 1`] = `
+exports[`BillingCountry renders with value 1`] = `
 <label id="billingCountryField"
-       class="o-forms-field"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="billingCountry"
 >
@@ -2535,7 +2530,6 @@ exports[`Country renders with value 1`] = `
   </span>
   <span class="o-forms-input o-forms-input--select">
     <select id="billingCountry"
-            class="js-field__input js-item__value"
             aria-required="true"
             required
             name="billingCountry"

--- a/components/__snapshots__/country.spec.js.snap
+++ b/components/__snapshots__/country.spec.js.snap
@@ -1,8 +1,803 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Country renders with dataTrackable 1`] = `
+<label id="countryField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="country"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="some-trackable"
+    >
+      <option value>
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+    <span class="o-forms-input__error">
+      Please select your country
+    </span>
+  </span>
+</label>
+`;
+
 exports[`Country renders with default props 1`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field ncf__validation-error"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -795,9 +1590,804 @@ exports[`Country renders with default props 1`] = `
 </label>
 `;
 
+exports[`Country renders with errorText 1`] = `
+<label id="countryField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="country"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="field-country"
+    >
+      <option value>
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+    <span class="o-forms-input__error">
+      Some Error Text
+    </span>
+  </span>
+</label>
+`;
+
 exports[`Country renders with hasError 1`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field ncf__validation-error"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -1590,9 +3180,804 @@ exports[`Country renders with hasError 1`] = `
 </label>
 `;
 
+exports[`Country renders with inputId 1`] = `
+<label id="countryField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="some-other-name"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Country
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="some-other-name"
+            aria-required="true"
+            required
+            name="some-other-name"
+            data-trackable="field-country"
+    >
+      <option value>
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+    <span class="o-forms-input__error">
+      Please select your country
+    </span>
+  </span>
+</label>
+`;
+
 exports[`Country renders with isB2b 1`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field ncf__validation-error"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -2387,7 +4772,7 @@ exports[`Country renders with isB2b 1`] = `
 
 exports[`Country renders with isDisabled 1`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field ncf__validation-error"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -3181,9 +5566,804 @@ exports[`Country renders with isDisabled 1`] = `
 </label>
 `;
 
+exports[`Country renders with label 1`] = `
+<label id="countryField"
+       class="o-forms-field ncf__validation-error"
+       data-validate="required"
+       for="country"
+>
+  <span class="o-forms-title">
+    <span class="o-forms-title__main">
+      Some Label
+    </span>
+  </span>
+  <span class="o-forms-input o-forms-input--select">
+    <select id="country"
+            aria-required="true"
+            required
+            name="country"
+            data-trackable="field-country"
+    >
+      <option value>
+        Please select a country
+      </option>
+      <optgroup label="Frequently Used">
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+      </optgroup>
+      <optgroup label="Alphabetical">
+        <option value="AFG">
+          Afghanistan
+        </option>
+        <option value="ALA">
+          Aland Islands
+        </option>
+        <option value="ALB">
+          Albania
+        </option>
+        <option value="DZA">
+          Algeria
+        </option>
+        <option value="ASM">
+          American Samoa
+        </option>
+        <option value="AND">
+          Andorra
+        </option>
+        <option value="AGO">
+          Angola
+        </option>
+        <option value="AIA">
+          Anguilla
+        </option>
+        <option value="ATA">
+          Antarctica
+        </option>
+        <option value="ATG">
+          Antigua And Barbuda
+        </option>
+        <option value="ARG">
+          Argentina
+        </option>
+        <option value="ARM">
+          Armenia
+        </option>
+        <option value="ABW">
+          Aruba
+        </option>
+        <option value="AUS">
+          Australia
+        </option>
+        <option value="AUT">
+          Austria
+        </option>
+        <option value="AZE">
+          Azerbaijan
+        </option>
+        <option value="BHS">
+          Bahamas
+        </option>
+        <option value="BHR">
+          Bahrain
+        </option>
+        <option value="BGD">
+          Bangladesh
+        </option>
+        <option value="BRB">
+          Barbados
+        </option>
+        <option value="BLR">
+          Belarus
+        </option>
+        <option value="BEL">
+          Belgium
+        </option>
+        <option value="BLZ">
+          Belize
+        </option>
+        <option value="BEN">
+          Benin
+        </option>
+        <option value="BMU">
+          Bermuda
+        </option>
+        <option value="BTN">
+          Bhutan
+        </option>
+        <option value="BOL">
+          Bolivia
+        </option>
+        <option value="BES">
+          Bonaire, Saint Eustatius and Saba
+        </option>
+        <option value="BIH">
+          Bosnia and Herzegovina
+        </option>
+        <option value="BWA">
+          Botswana
+        </option>
+        <option value="BVT">
+          Bouvet Island
+        </option>
+        <option value="BRA">
+          Brazil
+        </option>
+        <option value="IOT">
+          British Indian Ocean Territory
+        </option>
+        <option value="BRN">
+          Brunei Darussalam
+        </option>
+        <option value="BGR">
+          Bulgaria
+        </option>
+        <option value="BFA">
+          Burkina Faso
+        </option>
+        <option value="BDI">
+          Burundi
+        </option>
+        <option value="KHM">
+          Cambodia
+        </option>
+        <option value="CMR">
+          Cameroon
+        </option>
+        <option value="CAN">
+          Canada
+        </option>
+        <option value="CPV">
+          Cape Verde
+        </option>
+        <option value="CYM">
+          Cayman Islands
+        </option>
+        <option value="CAF">
+          Central African Republic
+        </option>
+        <option value="TCD">
+          Chad
+        </option>
+        <option value="CHL">
+          Chile
+        </option>
+        <option value="CHN">
+          China
+        </option>
+        <option value="CXR">
+          Christmas Island
+        </option>
+        <option value="CCK">
+          Cocos (Keeling) Islands
+        </option>
+        <option value="COL">
+          Colombia
+        </option>
+        <option value="COM">
+          Comoros
+        </option>
+        <option value="COG">
+          Congo
+        </option>
+        <option value="COD">
+          Congo, the Democratic Republic of the
+        </option>
+        <option value="COK">
+          Cook Islands
+        </option>
+        <option value="CRI">
+          Costa Rica
+        </option>
+        <option value="CIV">
+          Cote d&#x27;Ivoire
+        </option>
+        <option value="HRV">
+          Croatia
+        </option>
+        <option value="CUB">
+          Cuba
+        </option>
+        <option value="CUW">
+          Curacao
+        </option>
+        <option value="CYP">
+          Cyprus
+        </option>
+        <option value="CZE">
+          Czech Republic
+        </option>
+        <option value="DNK">
+          Denmark
+        </option>
+        <option value="DJI">
+          Djibouti
+        </option>
+        <option value="DMA">
+          Dominica
+        </option>
+        <option value="DOM">
+          Dominican Republic
+        </option>
+        <option value="ECU">
+          Ecuador
+        </option>
+        <option value="EGY">
+          Egypt
+        </option>
+        <option value="SLV">
+          El Salvador
+        </option>
+        <option value="GNQ">
+          Equatorial Guinea
+        </option>
+        <option value="ERI">
+          Eritrea
+        </option>
+        <option value="EST">
+          Estonia
+        </option>
+        <option value="ETH">
+          Ethiopia
+        </option>
+        <option value="FLK">
+          Falkland Islands (Malvinas)
+        </option>
+        <option value="FRO">
+          Faroe Islands
+        </option>
+        <option value="FJI">
+          Fiji
+        </option>
+        <option value="FIN">
+          Finland
+        </option>
+        <option value="FRA">
+          France
+        </option>
+        <option value="GUF">
+          French Guiana
+        </option>
+        <option value="PYF">
+          French Polynesia
+        </option>
+        <option value="ATF">
+          French Southern Territories
+        </option>
+        <option value="GAB">
+          Gabon
+        </option>
+        <option value="GMB">
+          Gambia
+        </option>
+        <option value="GEO">
+          Georgia
+        </option>
+        <option value="DEU">
+          Germany
+        </option>
+        <option value="GHA">
+          Ghana
+        </option>
+        <option value="GIB">
+          Gibraltar
+        </option>
+        <option value="GRC">
+          Greece
+        </option>
+        <option value="GRL">
+          Greenland
+        </option>
+        <option value="GRD">
+          Grenada
+        </option>
+        <option value="GLP">
+          Guadeloupe
+        </option>
+        <option value="GUM">
+          Guam
+        </option>
+        <option value="GTM">
+          Guatemala
+        </option>
+        <option value="GGY">
+          Guernsey
+        </option>
+        <option value="GIN">
+          Guinea
+        </option>
+        <option value="GNB">
+          Guinea-Bissau
+        </option>
+        <option value="GUY">
+          Guyana
+        </option>
+        <option value="HTI">
+          Haiti
+        </option>
+        <option value="HMD">
+          Heard Island and McDonald Islands
+        </option>
+        <option value="VAT">
+          Holy See (Vatican City State)
+        </option>
+        <option value="HND">
+          Honduras
+        </option>
+        <option value="HKG">
+          Hong Kong
+        </option>
+        <option value="HUN">
+          Hungary
+        </option>
+        <option value="ISL">
+          Iceland
+        </option>
+        <option value="IND">
+          India
+        </option>
+        <option value="IDN">
+          Indonesia
+        </option>
+        <option value="IRN">
+          Iran, Islamic Republic of
+        </option>
+        <option value="IRQ">
+          Iraq
+        </option>
+        <option value="IRL">
+          Ireland
+        </option>
+        <option value="IMN">
+          Isle of Man
+        </option>
+        <option value="ISR">
+          Israel
+        </option>
+        <option value="ITA">
+          Italy
+        </option>
+        <option value="JAM">
+          Jamaica
+        </option>
+        <option value="JPN">
+          Japan
+        </option>
+        <option value="JEY">
+          Jersey
+        </option>
+        <option value="JOR">
+          Jordan
+        </option>
+        <option value="KAZ">
+          Kazakhstan
+        </option>
+        <option value="KEN">
+          Kenya
+        </option>
+        <option value="KIR">
+          Kiribati
+        </option>
+        <option value="PRK">
+          Korea, Democratic People&#x27;s Republic of
+        </option>
+        <option value="KOR">
+          Korea, Republic of
+        </option>
+        <option value="XKX">
+          Kosovo
+        </option>
+        <option value="KWT">
+          Kuwait
+        </option>
+        <option value="KGZ">
+          Kyrgyzstan
+        </option>
+        <option value="LAO">
+          Lao People&#x27;s Democratic Republic
+        </option>
+        <option value="LVA">
+          Latvia
+        </option>
+        <option value="LBN">
+          Lebanon
+        </option>
+        <option value="LSO">
+          Lesotho
+        </option>
+        <option value="LBR">
+          Liberia
+        </option>
+        <option value="LBY">
+          Libyan Arab Jamahiriya
+        </option>
+        <option value="LIE">
+          Liechtenstein
+        </option>
+        <option value="LTU">
+          Lithuania
+        </option>
+        <option value="LUX">
+          Luxembourg
+        </option>
+        <option value="MAC">
+          Macao
+        </option>
+        <option value="MKD">
+          Macedonia, the former Yugoslav Republic of
+        </option>
+        <option value="MDG">
+          Madagascar
+        </option>
+        <option value="MWI">
+          Malawi
+        </option>
+        <option value="MYS">
+          Malaysia
+        </option>
+        <option value="MDV">
+          Maldives
+        </option>
+        <option value="MLI">
+          Mali
+        </option>
+        <option value="MLT">
+          Malta
+        </option>
+        <option value="MHL">
+          Marshall Islands
+        </option>
+        <option value="MTQ">
+          Martinique
+        </option>
+        <option value="MRT">
+          Mauritania
+        </option>
+        <option value="MUS">
+          Mauritius
+        </option>
+        <option value="MYT">
+          Mayotte
+        </option>
+        <option value="MEX">
+          Mexico
+        </option>
+        <option value="FSM">
+          Micronesia, Federated States of
+        </option>
+        <option value="MDA">
+          Moldova, Republic of
+        </option>
+        <option value="MCO">
+          Monaco
+        </option>
+        <option value="MNG">
+          Mongolia
+        </option>
+        <option value="MNE">
+          Montenegro
+        </option>
+        <option value="MSR">
+          Montserrat
+        </option>
+        <option value="MAR">
+          Morocco
+        </option>
+        <option value="MOZ">
+          Mozambique
+        </option>
+        <option value="MMR">
+          Myanmar
+        </option>
+        <option value="NAM">
+          Namibia
+        </option>
+        <option value="NRU">
+          Nauru
+        </option>
+        <option value="NPL">
+          Nepal
+        </option>
+        <option value="NLD">
+          Netherlands
+        </option>
+        <option value="NCL">
+          New Caledonia
+        </option>
+        <option value="NZL">
+          New Zealand
+        </option>
+        <option value="NIC">
+          Nicaragua
+        </option>
+        <option value="NER">
+          Niger
+        </option>
+        <option value="NGA">
+          Nigeria
+        </option>
+        <option value="NIU">
+          Niue
+        </option>
+        <option value="NFK">
+          Norfolk Island
+        </option>
+        <option value="MNP">
+          Northern Mariana Islands
+        </option>
+        <option value="NOR">
+          Norway
+        </option>
+        <option value="OMN">
+          Oman
+        </option>
+        <option value="PAK">
+          Pakistan
+        </option>
+        <option value="PLW">
+          Palau
+        </option>
+        <option value="PSE">
+          Palestinian Territory, Occupied
+        </option>
+        <option value="PAN">
+          Panama
+        </option>
+        <option value="PNG">
+          Papua New Guinea
+        </option>
+        <option value="PRY">
+          Paraguay
+        </option>
+        <option value="PER">
+          Peru
+        </option>
+        <option value="PHL">
+          Philippines
+        </option>
+        <option value="PCN">
+          Pitcairn
+        </option>
+        <option value="POL">
+          Poland
+        </option>
+        <option value="PRT">
+          Portugal
+        </option>
+        <option value="PRI">
+          Puerto Rico
+        </option>
+        <option value="QAT">
+          Qatar
+        </option>
+        <option value="REU">
+          Reunion
+        </option>
+        <option value="ROU">
+          Romania
+        </option>
+        <option value="RUS">
+          Russian Federation
+        </option>
+        <option value="RWA">
+          Rwanda
+        </option>
+        <option value="BLM">
+          Saint Barthelemy
+        </option>
+        <option value="SHN">
+          Saint Helena
+        </option>
+        <option value="KNA">
+          Saint Kitts and Nevis
+        </option>
+        <option value="LCA">
+          Saint Lucia
+        </option>
+        <option value="MAF">
+          Saint Martin (French part)
+        </option>
+        <option value="SPM">
+          Saint Pierre and Miquelon
+        </option>
+        <option value="VCT">
+          Saint Vincent and the Grenadines
+        </option>
+        <option value="WSM">
+          Samoa
+        </option>
+        <option value="SMR">
+          San Marino
+        </option>
+        <option value="STP">
+          Sao Tome and Principe
+        </option>
+        <option value="SAU">
+          Saudi Arabia
+        </option>
+        <option value="SEN">
+          Senegal
+        </option>
+        <option value="SRB">
+          Serbia
+        </option>
+        <option value="SYC">
+          Seychelles
+        </option>
+        <option value="SLE">
+          Sierra Leone
+        </option>
+        <option value="SGP">
+          Singapore
+        </option>
+        <option value="SXM">
+          Sint Maarten
+        </option>
+        <option value="SVK">
+          Slovakia
+        </option>
+        <option value="SVN">
+          Slovenia
+        </option>
+        <option value="SLB">
+          Solomon Islands
+        </option>
+        <option value="SOM">
+          Somalia
+        </option>
+        <option value="ZAF">
+          South Africa
+        </option>
+        <option value="SGS">
+          South Georgia and the South Sandwich Islands
+        </option>
+        <option value="ESP">
+          Spain
+        </option>
+        <option value="LKA">
+          Sri Lanka
+        </option>
+        <option value="SDN">
+          Sudan
+        </option>
+        <option value="SUR">
+          Suriname
+        </option>
+        <option value="SJM">
+          Svalbard and Jan Mayen
+        </option>
+        <option value="SWZ">
+          Swaziland
+        </option>
+        <option value="SWE">
+          Sweden
+        </option>
+        <option value="CHE">
+          Switzerland
+        </option>
+        <option value="SYR">
+          Syrian Arab Republic
+        </option>
+        <option value="TWN">
+          Taiwan
+        </option>
+        <option value="TJK">
+          Tajikistan
+        </option>
+        <option value="TZA">
+          Tanzania, United Republic of
+        </option>
+        <option value="THA">
+          Thailand
+        </option>
+        <option value="TLS">
+          Timor-Leste
+        </option>
+        <option value="TGO">
+          Togo
+        </option>
+        <option value="TKL">
+          Tokelau
+        </option>
+        <option value="TON">
+          Tonga
+        </option>
+        <option value="TTO">
+          Trinidad and Tobago
+        </option>
+        <option value="TUN">
+          Tunisia
+        </option>
+        <option value="TUR">
+          Turkey
+        </option>
+        <option value="TKM">
+          Turkmenistan
+        </option>
+        <option value="TCA">
+          Turks and Caicos Islands
+        </option>
+        <option value="TUV">
+          Tuvalu
+        </option>
+        <option value="UGA">
+          Uganda
+        </option>
+        <option value="UKR">
+          Ukraine
+        </option>
+        <option value="ARE">
+          United Arab Emirates
+        </option>
+        <option value="GBR">
+          United Kingdom
+        </option>
+        <option value="USA">
+          United States
+        </option>
+        <option value="UMI">
+          United States Minor Outlying Islands
+        </option>
+        <option value="URY">
+          Uruguay
+        </option>
+        <option value="UZB">
+          Uzbekistan
+        </option>
+        <option value="VUT">
+          Vanuatu
+        </option>
+        <option value="VEN">
+          Venezuela
+        </option>
+        <option value="VNM">
+          Viet Nam
+        </option>
+        <option value="VGB">
+          Virgin Islands, British
+        </option>
+        <option value="VIR">
+          Virgin Islands, U.S.
+        </option>
+        <option value="WLF">
+          Wallis and Futuna
+        </option>
+        <option value="ESH">
+          Western Sahara
+        </option>
+        <option value="YEM">
+          Yemen
+        </option>
+        <option value="ZMB">
+          Zambia
+        </option>
+        <option value="ZWE">
+          Zimbabwe
+        </option>
+      </optgroup>
+    </select>
+    <span class="o-forms-input__error">
+      Please select your country
+    </span>
+  </span>
+</label>
+`;
+
 exports[`Country renders with large filterList 1`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field ncf__validation-error"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -3272,7 +6452,7 @@ exports[`Country renders with large filterList 1`] = `
 
 exports[`Country renders with small filterList 1`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field ncf__validation-error"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="country"
 >
@@ -3304,7 +6484,7 @@ exports[`Country renders with small filterList 1`] = `
 
 exports[`Country renders with value 1`] = `
 <label id="countryField"
-       class="o-forms-field js-unknown-user-field ncf__validation-error"
+       class="o-forms-field ncf__validation-error"
        data-validate="required"
        for="country"
 >

--- a/components/billing-country.jsx
+++ b/components/billing-country.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import { getCountries } from '../utils/countries';
+import { Country } from './country';
 
 export function BillingCountry({
 	fieldId = 'billingCountryField',
@@ -11,58 +10,19 @@ export function BillingCountry({
 	isDisabled = false,
 	value,
 }) {
-	const selectWrapperClassName = classNames([
-		'o-forms-input',
-		'o-forms-input--select',
-		{ 'o-forms-input--invalid': hasError },
-	]);
-	const props = {
-		id: inputId,
-		className: 'js-field__input js-item__value',
-		'aria-required': true,
-		required: true,
-		name: inputId,
-		'data-trackable': 'field-billing-country',
-		disabled: isDisabled,
-	};
-	const countries = getCountries({ filter: filterList, value });
-
-	const createOption = (country) => (
-		<option key={country.code} value={country.code} selected={country.selected}>
-			{country.name}
-		</option>
-	);
-	const createOptGroup = (country) => (
-		<optgroup key={country.label} label={country.label}>
-			{country.countries.map((country) => createOption(country))}
-		</optgroup>
-	);
-	const createSelect = (countries) => (
-		<select {...props}>
-			<option value="" disabled>
-				Please select a country
-			</option>
-			{countries.map((country) =>
-				country.label ? createOptGroup(country) : createOption(country)
-			)}
-		</select>
-	);
-
 	return (
-		<label
-			id={fieldId}
-			className="o-forms-field"
-			data-validate="required"
-			htmlFor={inputId}
-		>
-			<span className="o-forms-title">
-				<span className="o-forms-title__main">Billing Country</span>
-			</span>
-			<span className={selectWrapperClassName}>
-				{createSelect(countries)}
-				<span className="o-forms-input__error">Please select your country</span>
-			</span>
-		</label>
+		<Country
+			dataTrackable="field-billing-country"
+			fieldId={fieldId}
+			filterList={filterList}
+			hasError={hasError}
+			inputId={inputId}
+			isB2b={false}
+			isDisabled={isDisabled}
+			isPlaceholderDisabled={true}
+			value={value}
+			label="Billing Country"
+		/>
 	);
 }
 

--- a/components/billing-country.jsx
+++ b/components/billing-country.jsx
@@ -20,8 +20,8 @@ export function BillingCountry({
 			isB2b={false}
 			isDisabled={isDisabled}
 			isPlaceholderDisabled={true}
-			value={value}
 			label="Billing Country"
+			value={value}
 		/>
 	);
 }

--- a/components/billing-country.spec.js
+++ b/components/billing-country.spec.js
@@ -3,7 +3,7 @@ import { expectToRenderCorrectly } from '../test-jest/helpers/expect-to-render-c
 
 expect.extend(expectToRenderCorrectly);
 
-describe('Country', () => {
+describe('BillingCountry', () => {
 	it('renders with default props', () => {
 		const props = {};
 

--- a/components/country.jsx
+++ b/components/country.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { getCountries } from '../utils/countries';
 
 export function Country({
+	additionalFieldInformation,
 	dataTrackable = 'field-country',
 	fieldId = 'countryField',
 	filterList = [],
@@ -15,7 +16,6 @@ export function Country({
 	value,
 	label = `Country${isB2b ? '/Region' : ''}`,
 	errorText = `Please select your country${isB2b ? '/region' : ''}`,
-	additionalFieldInformation,
 }) {
 	const selectWrapperClassName = classNames([
 		'o-forms-input',
@@ -85,7 +85,9 @@ export function Country({
 }
 
 Country.propTypes = {
+	additionalFieldInformation: PropTypes.node,
 	dataTrackable: PropTypes.string,
+	errorText: PropTypes.string,
 	fieldId: PropTypes.string,
 	filterList: PropTypes.arrayOf(PropTypes.string),
 	hasError: PropTypes.bool,
@@ -93,8 +95,6 @@ Country.propTypes = {
 	isB2b: PropTypes.bool,
 	isDisabled: PropTypes.bool,
 	isPlaceholderDisabled: PropTypes.bool,
-	value: PropTypes.string,
 	label: PropTypes.string,
-	errorText: PropTypes.string,
-	additionalFieldInformation: PropTypes.node,
+	value: PropTypes.string,
 };

--- a/components/country.jsx
+++ b/components/country.jsx
@@ -4,13 +4,17 @@ import classNames from 'classnames';
 import { getCountries } from '../utils/countries';
 
 export function Country({
+	dataTrackable = 'field-country',
 	fieldId = 'countryField',
 	filterList = [],
 	hasError = false,
 	inputId = 'country',
 	isB2b = false,
 	isDisabled = false,
+	isPlaceholderDisabled = false,
 	value,
+	label = `Country${isB2b ? '/Region' : ''}`,
+	errorText = `Please select your country${isB2b ? '/region' : ''}`,
 	additionalFieldInformation,
 }) {
 	const selectWrapperClassName = classNames([
@@ -18,14 +22,12 @@ export function Country({
 		'o-forms-input--select',
 		{ 'o-forms-input--invalid': hasError },
 	]);
-	const label = `Country${isB2b ? '/Region' : ''}`;
-	const error = `Please select your country${isB2b ? '/region' : ''}`;
 	const selectProps = {
 		id: inputId,
 		'aria-required': true,
 		required: true,
-		name: 'country',
-		'data-trackable': 'field-country',
+		name: inputId,
+		'data-trackable': dataTrackable,
 		disabled: isDisabled,
 	};
 	const countries = getCountries({ filter: filterList, value });
@@ -42,7 +44,9 @@ export function Country({
 	);
 	const createSelect = (countries) => (
 		<select {...selectProps}>
-			<option value="">Please select a country{isB2b ? '/region' : ''}</option>
+			<option value="" disabled={isPlaceholderDisabled}>
+				Please select a country{isB2b ? '/region' : ''}
+			</option>
 			{countries.map((country) =>
 				country.label ? createOptGroup(country) : createOption(country)
 			)}
@@ -60,7 +64,7 @@ export function Country({
 	return (
 		<label
 			id={fieldId}
-			className="o-forms-field js-unknown-user-field ncf__validation-error"
+			className="o-forms-field ncf__validation-error"
 			data-validate="required"
 			htmlFor={selectProps.id}
 		>
@@ -69,7 +73,7 @@ export function Country({
 			</span>
 			<span className={selectWrapperClassName}>
 				{createSelect(countries)}
-				<span className={fieldErrorClassNames}>{error}</span>
+				<span className={fieldErrorClassNames}>{errorText}</span>
 				{additionalFieldInformation ? (
 					<p className="additional-field-information">
 						{additionalFieldInformation}
@@ -81,12 +85,16 @@ export function Country({
 }
 
 Country.propTypes = {
+	dataTrackable: PropTypes.string,
 	fieldId: PropTypes.string,
 	filterList: PropTypes.arrayOf(PropTypes.string),
 	hasError: PropTypes.bool,
 	inputId: PropTypes.string,
 	isB2b: PropTypes.bool,
 	isDisabled: PropTypes.bool,
+	isPlaceholderDisabled: PropTypes.bool,
 	value: PropTypes.string,
+	label: PropTypes.string,
+	errorText: PropTypes.string,
 	additionalFieldInformation: PropTypes.node,
 };

--- a/components/country.spec.js
+++ b/components/country.spec.js
@@ -18,6 +18,14 @@ describe('Country', () => {
 		expect(Country).toRenderCorrectly(props);
 	});
 
+	it('renders with dataTrackable', () => {
+		const props = {
+			dataTrackable: 'some-trackable',
+		};
+
+		expect(Country).toRenderCorrectly(props);
+	});
+
 	it('renders with large filterList', () => {
 		const props = {
 			filterList: [
@@ -74,6 +82,30 @@ describe('Country', () => {
 	it('renders with value', () => {
 		const props = {
 			value: 'GBR',
+		};
+
+		expect(Country).toRenderCorrectly(props);
+	});
+
+	it('renders with inputId', () => {
+		const props = {
+			inputId: 'some-other-name',
+		};
+
+		expect(Country).toRenderCorrectly(props);
+	});
+
+	it('renders with label', () => {
+		const props = {
+			label: 'Some Label',
+		};
+
+		expect(Country).toRenderCorrectly(props);
+	});
+
+	it('renders with errorText', () => {
+		const props = {
+			errorText: 'Some Error Text',
 		};
 
 		expect(Country).toRenderCorrectly(props);


### PR DESCRIPTION
### Description

Note that there should be no visual changes that should've occurred here.

Summary: We make `BillingCountry` use `Country` as a shallow wrapper around it to prevent duplication.

We also remove classes `js-field__input`, `js-item__value` and `js-unknown-user-field` since I can't see them as a CSS in our codebase:

https://github.com/search?q=repo%3AFinancial-Times%2Fn-conversion-forms+js-field__input&type=code
https://github.com/search?q=repo%3AFinancial-Times%2Fn-conversion-forms+js-item__value&type=code
https://github.com/search?q=repo%3AFinancial-Times%2Fn-conversion-forms+js-unknown-user-field&type=code

### Ticket

https://financialtimes.atlassian.net/browse/ACQ-2147

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [x] **Stories** updated to use this change
- [x] **Accessibility** checked for screen readers and contrast
- [x] **Design Review** ran past the designer
- [x] **Product Review** ran past the product owner
