### PR TITLE
ACQ-2174 Replace node-orb with npm global install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,6 @@ references:
 
 version: 2.1
 
-orbs:
-  node: circleci/node@4.9.0
-
 jobs:
 
   build:
@@ -66,8 +63,9 @@ jobs:
           name: Checkout next-ci-shared-helpers
           command: git clone --depth 1 git@github.com:Financial-Times/next-ci-shared-helpers.git .circleci/shared-helpers
       - *restore_npm_cache
-      - node/install-npm:
-          version: "^7"
+      - run:
+          name: Install npm v7
+          command: npm install -g npm@7
       - run:
           name: Install project dependencies
           command: make install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ references:
   container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
-      - image: cimg/node:16.17-browsers
+      - image: cimg/node:16.19-browsers
   workspace_root: &workspace_root
     ~/project
 


### PR DESCRIPTION
### Description
Following the footsteps of https://github.com/Financial-Times/n-membership-sdk/pull/623

Difference is, we don't have varying node versions so we just straight up install node version v7.

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-2174

