### PR TITLE
add dynamic access label to b2c-partnership-confirmation

### DIFF
--- a/components/__snapshots__/b2c-partnership-confirmation.spec.js.snap
+++ b/components/__snapshots__/b2c-partnership-confirmation.spec.js.snap
@@ -1,5 +1,125 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`B2CPartnershipConfirmation renders Premium access for premium subscription 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <div class="ncf__paragraph">
+      <h1 class="ncf__header ncf__header--confirmation">
+        Welcome to your Premium access
+      </h1>
+    </div>
+  </div>
+  <p class="ncf__paragraph">
+    Please check your email to confirm your account and set your password.
+  </p>
+  <p class="ncf__paragraph">
+    Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
+  </p>
+  hello
+  <p class="ncf__paragraph ncf__center">
+    <a href="/"
+       class="ncf__link"
+    >
+      Start reading
+    </a>
+  </p>
+  <p class="ncf__paragraph">
+    <div class="ncf__strong">
+      Can we help?
+    </div>
+    For any queries about your Premium subscription please
+    <a href="https://help.ft.com/"
+       class="ncf__link"
+    >
+      contact Customer Care
+    </a>
+    .
+  </p>
+</div>
+`;
+
+exports[`B2CPartnershipConfirmation renders Premium access if subscription prop is null 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <div class="ncf__paragraph">
+      <h1 class="ncf__header ncf__header--confirmation">
+        Welcome to your Premium access
+      </h1>
+    </div>
+  </div>
+  <p class="ncf__paragraph">
+    Please check your email to confirm your account and set your password.
+  </p>
+  <p class="ncf__paragraph">
+    Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
+  </p>
+  hello
+  <p class="ncf__paragraph ncf__center">
+    <a href="/"
+       class="ncf__link"
+    >
+      Start reading
+    </a>
+  </p>
+  <p class="ncf__paragraph">
+    <div class="ncf__strong">
+      Can we help?
+    </div>
+    For any queries about your Premium subscription please
+    <a href="https://help.ft.com/"
+       class="ncf__link"
+    >
+      contact Customer Care
+    </a>
+    .
+  </p>
+</div>
+`;
+
+exports[`B2CPartnershipConfirmation renders Standard access for standard subscription 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <div class="ncf__paragraph">
+      <h1 class="ncf__header ncf__header--confirmation">
+        Welcome to your Standard access
+      </h1>
+    </div>
+  </div>
+  <p class="ncf__paragraph">
+    Please check your email to confirm your account and set your password.
+  </p>
+  <p class="ncf__paragraph">
+    Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
+  </p>
+  hello
+  <p class="ncf__paragraph ncf__center">
+    <a href="/"
+       class="ncf__link"
+    >
+      Start reading
+    </a>
+  </p>
+  <p class="ncf__paragraph">
+    <div class="ncf__strong">
+      Can we help?
+    </div>
+    For any queries about your Premium subscription please
+    <a href="https://help.ft.com/"
+       class="ncf__link"
+    >
+      contact Customer Care
+    </a>
+    .
+  </p>
+</div>
+`;
+
 exports[`B2CPartnershipConfirmation renders as default 1`] = `
 <div class="ncf ncf__wrapper">
   <div class="ncf__center">

--- a/components/b2c-partnership-confirmation.jsx
+++ b/components/b2c-partnership-confirmation.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export function B2CPartnershipConfirmation({ ctaElement = null }) {
+export function B2CPartnershipConfirmation({
+	ctaElement = null,
+	productCode = null,
+}) {
 	const readingLinkProps = {
 		href: '/',
 		className: 'ncf__link',
@@ -12,6 +15,9 @@ export function B2CPartnershipConfirmation({ ctaElement = null }) {
 		className: 'ncf__link',
 	};
 
+	const accessType =
+		productCode?.toUpperCase() === 'P1' ? 'Standard' : 'Premium';
+
 	return (
 		<div className="ncf ncf__wrapper">
 			<div className="ncf__center">
@@ -19,7 +25,7 @@ export function B2CPartnershipConfirmation({ ctaElement = null }) {
 				<div className="ncf__paragraph">
 					{
 						<h1 className="ncf__header ncf__header--confirmation">
-							{'Welcome to your Premium access'}
+							{`Welcome to your ${accessType} access`}
 						</h1>
 					}
 				</div>
@@ -57,4 +63,5 @@ export function B2CPartnershipConfirmation({ ctaElement = null }) {
 
 B2CPartnershipConfirmation.propTypes = {
 	ctaElement: PropTypes.node,
+	productCode: PropTypes.string,
 };

--- a/components/b2c-partnership-confirmation.spec.js
+++ b/components/b2c-partnership-confirmation.spec.js
@@ -9,4 +9,22 @@ describe('B2CPartnershipConfirmation', () => {
 
 		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
 	});
+
+	it('renders Premium access for premium subscription', () => {
+		const props = { ctaElement: 'hello', productCode: 'p2' };
+
+		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
+	});
+
+	it('renders Standard access for standard subscription', () => {
+		const props = { ctaElement: 'hello', productCode: 'p1' };
+
+		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
+	});
+
+	it('renders Premium access if subscription prop is null', () => {
+		const props = { ctaElement: 'hello', productCode: null };
+
+		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
+	});
 });


### PR DESCRIPTION
### Description
Make `Welcome to your Premium access` label dynamic based on licence product code.
Add `productCode` to `props` to change label.

Values
- p1 or P1 - Standard
- any other value - Premium

### Ticket
https://financialtimes.slack.com/archives/C052K8ARM9A/p1685958677283739

### Screenshots

| Before | After |
| ------ | ----- |
|![image](https://github.com/Financial-Times/n-conversion-forms/assets/110386755/8bb0e428-5010-4ceb-89cf-8c63aa04093e)|<img width="1176" alt="image" src="https://github.com/Financial-Times/n-conversion-forms/assets/110386755/a7e7e4d4-df97-44f2-8158-a20f53a1cc61">|

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [X] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
