### PR TITLE
add ePaper to b2c-partnership-confirmation

### DIFF
--- a/components/__snapshots__/b2c-partnership-confirmation.spec.js.snap
+++ b/components/__snapshots__/b2c-partnership-confirmation.spec.js.snap
@@ -1,6 +1,86 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`B2CPartnershipConfirmation renders Premium access for premium subscription 1`] = `
+exports[`B2CPartnershipConfirmation renders FT access if subscription prop is null 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <div class="ncf__paragraph">
+      <h1 class="ncf__header ncf__header--confirmation">
+        Welcome to your FT access
+      </h1>
+    </div>
+  </div>
+  <p class="ncf__paragraph">
+    Please check your email to confirm your account and set your password.
+  </p>
+  <p class="ncf__paragraph">
+    Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
+  </p>
+  hello
+  <p class="ncf__paragraph ncf__center">
+    <a href="/"
+       class="ncf__link"
+    >
+      Start reading
+    </a>
+  </p>
+  <p class="ncf__paragraph">
+    <div class="ncf__strong">
+      Can we help?
+    </div>
+    For any queries about your Premium subscription please
+    <a href="https://help.ft.com/"
+       class="ncf__link"
+    >
+      contact Customer Care
+    </a>
+    .
+  </p>
+</div>
+`;
+
+exports[`B2CPartnershipConfirmation renders FT access if subscription prop is undefined 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <div class="ncf__paragraph">
+      <h1 class="ncf__header ncf__header--confirmation">
+        Welcome to your FT access
+      </h1>
+    </div>
+  </div>
+  <p class="ncf__paragraph">
+    Please check your email to confirm your account and set your password.
+  </p>
+  <p class="ncf__paragraph">
+    Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
+  </p>
+  hello
+  <p class="ncf__paragraph ncf__center">
+    <a href="/"
+       class="ncf__link"
+    >
+      Start reading
+    </a>
+  </p>
+  <p class="ncf__paragraph">
+    <div class="ncf__strong">
+      Can we help?
+    </div>
+    For any queries about your Premium subscription please
+    <a href="https://help.ft.com/"
+       class="ncf__link"
+    >
+      contact Customer Care
+    </a>
+    .
+  </p>
+</div>
+`;
+
+exports[`B2CPartnershipConfirmation renders Premium access for premium subscription lowercase 1`] = `
 <div class="ncf ncf__wrapper">
   <div class="ncf__center">
     <div class="ncf__icon ncf__icon--tick ncf__icon--large">
@@ -40,7 +120,7 @@ exports[`B2CPartnershipConfirmation renders Premium access for premium subscript
 </div>
 `;
 
-exports[`B2CPartnershipConfirmation renders Premium access if subscription prop is null 1`] = `
+exports[`B2CPartnershipConfirmation renders Premium access for premium subscription uppercase 1`] = `
 <div class="ncf ncf__wrapper">
   <div class="ncf__center">
     <div class="ncf__icon ncf__icon--tick ncf__icon--large">
@@ -80,7 +160,47 @@ exports[`B2CPartnershipConfirmation renders Premium access if subscription prop 
 </div>
 `;
 
-exports[`B2CPartnershipConfirmation renders Standard access for standard subscription 1`] = `
+exports[`B2CPartnershipConfirmation renders Standard access for standard subscription lowercase 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <div class="ncf__paragraph">
+      <h1 class="ncf__header ncf__header--confirmation">
+        Welcome to your Standard access
+      </h1>
+    </div>
+  </div>
+  <p class="ncf__paragraph">
+    Please check your email to confirm your account and set your password.
+  </p>
+  <p class="ncf__paragraph">
+    Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
+  </p>
+  hello
+  <p class="ncf__paragraph ncf__center">
+    <a href="/"
+       class="ncf__link"
+    >
+      Start reading
+    </a>
+  </p>
+  <p class="ncf__paragraph">
+    <div class="ncf__strong">
+      Can we help?
+    </div>
+    For any queries about your Premium subscription please
+    <a href="https://help.ft.com/"
+       class="ncf__link"
+    >
+      contact Customer Care
+    </a>
+    .
+  </p>
+</div>
+`;
+
+exports[`B2CPartnershipConfirmation renders Standard access for standard subscription uppercase 1`] = `
 <div class="ncf ncf__wrapper">
   <div class="ncf__center">
     <div class="ncf__icon ncf__icon--tick ncf__icon--large">
@@ -127,7 +247,87 @@ exports[`B2CPartnershipConfirmation renders as default 1`] = `
     </div>
     <div class="ncf__paragraph">
       <h1 class="ncf__header ncf__header--confirmation">
-        Welcome to your Premium access
+        Welcome to your FT access
+      </h1>
+    </div>
+  </div>
+  <p class="ncf__paragraph">
+    Please check your email to confirm your account and set your password.
+  </p>
+  <p class="ncf__paragraph">
+    Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
+  </p>
+  hello
+  <p class="ncf__paragraph ncf__center">
+    <a href="/"
+       class="ncf__link"
+    >
+      Start reading
+    </a>
+  </p>
+  <p class="ncf__paragraph">
+    <div class="ncf__strong">
+      Can we help?
+    </div>
+    For any queries about your Premium subscription please
+    <a href="https://help.ft.com/"
+       class="ncf__link"
+    >
+      contact Customer Care
+    </a>
+    .
+  </p>
+</div>
+`;
+
+exports[`B2CPartnershipConfirmation renders ePaper access for ePaper subscription lowercase 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <div class="ncf__paragraph">
+      <h1 class="ncf__header ncf__header--confirmation">
+        Welcome to your ePaper access
+      </h1>
+    </div>
+  </div>
+  <p class="ncf__paragraph">
+    Please check your email to confirm your account and set your password.
+  </p>
+  <p class="ncf__paragraph">
+    Explore the homepage &amp; enjoy your unlimited access &amp; exclusive content.
+  </p>
+  hello
+  <p class="ncf__paragraph ncf__center">
+    <a href="/"
+       class="ncf__link"
+    >
+      Start reading
+    </a>
+  </p>
+  <p class="ncf__paragraph">
+    <div class="ncf__strong">
+      Can we help?
+    </div>
+    For any queries about your Premium subscription please
+    <a href="https://help.ft.com/"
+       class="ncf__link"
+    >
+      contact Customer Care
+    </a>
+    .
+  </p>
+</div>
+`;
+
+exports[`B2CPartnershipConfirmation renders ePaper access for ePaper subscription uppercase 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <div class="ncf__paragraph">
+      <h1 class="ncf__header ncf__header--confirmation">
+        Welcome to your ePaper access
       </h1>
     </div>
   </div>

--- a/components/b2c-partnership-confirmation.jsx
+++ b/components/b2c-partnership-confirmation.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+const productCodeMapping = {
+	P1: 'Standard',
+	P2: 'Premium',
+	EP: 'ePaper',
+};
+
 export function B2CPartnershipConfirmation({
 	ctaElement = null,
 	productCode = null,
@@ -15,8 +21,11 @@ export function B2CPartnershipConfirmation({
 		className: 'ncf__link',
 	};
 
-	const accessType =
-		productCode?.toUpperCase() === 'P1' ? 'Standard' : 'Premium';
+	// Welcome to your Standard access
+	// Welcome to your Premium access
+	// Welcome to your ePaper access
+	// Welcome to your FT access (default)
+	const accessType = productCodeMapping[productCode?.toUpperCase()] || 'FT';
 
 	return (
 		<div className="ncf ncf__wrapper">

--- a/components/b2c-partnership-confirmation.spec.js
+++ b/components/b2c-partnership-confirmation.spec.js
@@ -10,20 +10,50 @@ describe('B2CPartnershipConfirmation', () => {
 		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
 	});
 
-	it('renders Premium access for premium subscription', () => {
+	it('renders Premium access for premium subscription lowercase', () => {
 		const props = { ctaElement: 'hello', productCode: 'p2' };
 
 		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
 	});
 
-	it('renders Standard access for standard subscription', () => {
+	it('renders Premium access for premium subscription uppercase', () => {
+		const props = { ctaElement: 'hello', productCode: 'P2' };
+
+		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
+	});
+
+	it('renders Standard access for standard subscription lowercase', () => {
 		const props = { ctaElement: 'hello', productCode: 'p1' };
 
 		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
 	});
 
-	it('renders Premium access if subscription prop is null', () => {
+	it('renders Standard access for standard subscription uppercase', () => {
+		const props = { ctaElement: 'hello', productCode: 'P1' };
+
+		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
+	});
+
+	it('renders ePaper access for ePaper subscription lowercase', () => {
+		const props = { ctaElement: 'hello', productCode: 'ep' };
+
+		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
+	});
+
+	it('renders ePaper access for ePaper subscription uppercase', () => {
+		const props = { ctaElement: 'hello', productCode: 'EP' };
+
+		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
+	});
+
+	it('renders FT access if subscription prop is null', () => {
 		const props = { ctaElement: 'hello', productCode: null };
+
+		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
+	});
+
+	it('renders FT access if subscription prop is undefined', () => {
+		const props = { ctaElement: 'hello', productCode: undefined };
 
 		expect(B2CPartnershipConfirmation).toRenderCorrectly(props);
 	});


### PR DESCRIPTION
### Description
Add ePaper to B2C partnership licence confirmation component
Change default welcome text
Old `Welcome to your Premium access`
New `Welcome to your FT access`

### Ticket
[Slack](https://financialtimes.slack.com/archives/C052K8ARM9A/p1686659166680829?thread_ts=1686647251.963659&cid=C052K8ARM9A)

### Screenshots

| Before | After |
| ------ | ----- |
|ePaper|<img width="1091" alt="image" src="https://github.com/Financial-Times/n-conversion-forms/assets/110386755/e212a27e-2e8e-478c-af8d-89690bd237a8">|
|default |<img width="992" alt="image" src="https://github.com/Financial-Times/n-conversion-forms/assets/110386755/cd0628fc-9cd6-4637-ab51-35bdba143e91">|

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [X] **Tests** written for new or updated for existing functionality
- [X] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
