### PR TITLE
ACQ-2228: converting paymentTerms from an array to an "indexed" collection (by an object)

### DIFF
--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -406,6 +406,7 @@ PaymentTerm.propTypes = {
 			subTitle: PropTypes.string,
 			bestOffer: PropTypes.bool,
 			chargeOnText: PropTypes.string,
+			fulfilmentOption: PropTypes.string,
 		})
 	),
 	isFixedTermOffer: PropTypes.bool,

--- a/utils/payment-term.js
+++ b/utils/payment-term.js
@@ -104,8 +104,9 @@ class PaymentTerm {
 	}
 
 	/**
-	 * Update the payment term options
-	 * @param {Array} options Array of objects contain terms information
+	 * Updates the payment term options.
+	 * @param {Object} options - indexed Object about Array of objects containing terms information. E.g.: { P1Y: {...}, P3M: {...}}
+	 * @throws Will throw an error if a payment term update is not found for a given value.
 	 */
 	updateOptions(options) {
 		const terms = this.$paymentTerm.querySelectorAll(ITEM_CLASS);
@@ -115,7 +116,7 @@ class PaymentTerm {
 			const price = term.querySelector(PRICE_CLASS);
 			const trialPrice = term.querySelector(TRIAL_PRICE_CLASS);
 			const monthlyPrice = term.querySelector(MONTHLY_PRICE_CLASS);
-			const update = options.find((option) => option.value === value);
+			const update = options[value];
 
 			if (!update) {
 				throw new Error(`Payment term update not found for "${value}"`);

--- a/utils/payment-term.spec.js
+++ b/utils/payment-term.spec.js
@@ -94,7 +94,7 @@ describe('PaymentTerm', () => {
 
 			it('throws an error if not all terms have an update', () => {
 				expect(() => {
-					paymentTerm.updateOptions([]);
+					paymentTerm.updateOptions({});
 				}).toThrow();
 			});
 
@@ -105,12 +105,12 @@ describe('PaymentTerm', () => {
 						? priceStub
 						: elementStub;
 				});
-				paymentTerm.updateOptions([
-					{
+				paymentTerm.updateOptions({
+					test: {
 						value: 'test',
 						price: '£1.01',
 					},
-				]);
+				});
 				expect(priceStub.innerHTML).toEqual('£1.01');
 			});
 
@@ -121,12 +121,12 @@ describe('PaymentTerm', () => {
 						? trialPriceStub
 						: elementStub;
 				});
-				paymentTerm.updateOptions([
-					{
+				paymentTerm.updateOptions({
+					test: {
 						value: 'test',
 						trialPrice: '£1.01',
 					},
-				]);
+				});
 				expect(trialPriceStub.innerHTML).toEqual('£1.01');
 			});
 
@@ -137,31 +137,31 @@ describe('PaymentTerm', () => {
 						? monthlyPriceStub
 						: elementStub;
 				});
-				paymentTerm.updateOptions([
-					{
+				paymentTerm.updateOptions({
+					test: {
 						value: 'test',
 						monthlyPrice: '£1.01',
 					},
-				]);
+				});
 				expect(monthlyPriceStub.innerHTML).toEqual('£1.01');
 			});
 
 			describe('updating base amount', () => {
-				const updatedOptions = [
-					{
+				const updatedOptions = {
+					test: {
 						value: 'test',
 						monthlyPrice: '£1.01',
 						amount: 500,
 						trialAmount: 1,
 					},
-				];
+				};
 
 				beforeEach(() => {
 					elementStub.querySelector.mockReturnValue(elementStub);
 				});
 
 				it('replaces the base amount with the correct updated trial amount', () => {
-					updatedOptions[0].isTrial = true;
+					updatedOptions.test.isTrial = true;
 					paymentTerm.updateOptions(updatedOptions);
 					expect(elementStub.setAttribute).toHaveBeenCalledWith(
 						'data-base-amount',
@@ -170,7 +170,7 @@ describe('PaymentTerm', () => {
 				});
 
 				it('replaces the base amount with the correct updated amount', () => {
-					updatedOptions[0].isTrial = false;
+					updatedOptions.test.isTrial = false;
 					paymentTerm.updateOptions(updatedOptions);
 					expect(elementStub.setAttribute).toHaveBeenCalledWith(
 						'data-base-amount',


### PR DESCRIPTION
### Description
[ACQ-2228](https://financialtimes.atlassian.net/browse/ACQ-2228) is big enough to split the story into multiple PRs.

**PART 1**: convert paymentTerms response from a regular array to a indexed collection by using an object to contain them.
Before:
```Javascript
const paymentTerms = [
  { name: 'annual', value: 'P1Y' },
  { name: 'quarterly', value: 'P3M' },
];
// if looking for a specific term --> paymentTerms.find(term => term.value === 'P3M')
```
After:
```Javascript
const paymentTerms = {
  P1Y: { name: 'annual', value: 'P1Y' },
  P3M: { name: 'quarterly', value: 'P3M' },
};
// if looking for a specific term --> paymentTerms['P3M']
```

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner


[ACQ-2228]: https://financialtimes.atlassian.net/browse/ACQ-2228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ