### PR TITLE
ACQ-2088 refactor accept terms component for next subscribe sign up forms

### DIFF
--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -1,47 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AcceptTerms renders a component matching snapshot when \`withB2BTerms\` is true 1`] = `
-<div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
-     data-validate="required,checked"
->
-  <ul class="o-typography-list ncf__accept-terms-list">
-    <li>
-      <span class="terms-default">
-        I confirm I am 16 years or older and have read and agree to the
-        <a class="ncf__link--external"
-           href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-           target="_blank"
-           rel="noopener noreferrer"
-           data-trackable="terms-and-conditions"
-        >
-          Terms &amp; Conditions
-        </a>
-        .
-      </span>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the above terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
-      Please accept our terms &amp; conditions
-    </p>
-  </label>
-</div>
-`;
-
 exports[`AcceptTerms renders a component matching snapshot when withPrivacyPolicyTerms is true 1`] = `
 <div id="acceptTermsField"
      class="o-forms-field o-layout-typography ncf__validation-error"

--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -58,92 +58,6 @@ exports[`AcceptTerms renders appropriately if a isAccessPage 1`] = `
 </div>
 `;
 
-exports[`AcceptTerms renders appropriately if a isAuthFirstAccount 1`] = `
-<div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
-     data-validate="required,checked"
->
-  <div class="auth-first-step-terms">
-    <span class="consent-text--top">
-      For more information about how we use your data, please refer to our
-      <a class="ncf__link--external"
-         href="https://help.ft.com/legal-privacy/privacy-policy/"
-         target="_blank"
-         rel="noopener noreferrer"
-         data-trackable="privacy-policy-info"
-      >
-        privacy
-      </a>
-      and 
-      <a class="ncf__link--external"
-         href="https://help.ft.com/legal-privacy/cookies/"
-         target="_blank"
-         rel="noopener noreferrer"
-         data-trackable="cookies-info"
-      >
-        cookie
-      </a>
-      policies.
-    </span>
-    <label class="o-forms-input o-forms-input--checkbox"
-           for="termsAcceptance"
-    >
-      <input type="checkbox"
-             id="termsAcceptance"
-             name="termsAcceptance"
-             value="true"
-             data-trackable="field-terms"
-             aria-required="true"
-             required
-      >
-      <span class="o-forms-input__label">
-        I confirm that I am 16 years or older and agree to the full
-        <a class="ncf__link--external"
-           href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-           target="_blank"
-           rel="noopener noreferrer"
-           data-trackable="terms-and-conditions"
-        >
-          Terms &amp; Conditions
-        </a>
-        .
-      </span>
-      <p class="o-forms-input__error">
-        Please accept our terms &amp; conditions
-      </p>
-    </label>
-  </div>
-</div>
-`;
-
-exports[`AcceptTerms renders appropriately if a isAuthFirstPayment 1`] = `
-<div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
-     data-validate="required,checked"
->
-  <ul class="o-typography-list ncf__accept-terms-list">
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the above terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
-      Please accept our terms &amp; conditions
-    </p>
-  </label>
-</div>
-`;
-
 exports[`AcceptTerms renders appropriately if a isPaymentPage 1`] = `
 <div id="acceptTermsField"
      class="o-forms-field o-layout-typography ncf__validation-error"
@@ -164,42 +78,6 @@ exports[`AcceptTerms renders appropriately if a isPaymentPage 1`] = `
     >
     <span class="o-forms-input__label">
       I agree to the above terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
-      Please accept our terms &amp; conditions
-    </p>
-  </label>
-</div>
-`;
-
-exports[`AcceptTerms renders appropriately if a registration 1`] = `
-<div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
-     data-validate="required,checked"
-     data-trackable="register-up-terms"
->
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label terms-register">
-      I confirm I am 16 years or older and have read and agree to the
-      <a class="ncf__link--external"
-         href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-         target="_blank"
-         rel="noopener noreferrer"
-         data-trackable="terms-and-conditions"
-      >
-        Terms &amp; Conditions
-      </a>
-      .
     </span>
     <p class="o-forms-input__error">
       Please accept our terms &amp; conditions

--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -1,5 +1,63 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AcceptTerms renders appropriately if a isAccessPage 1`] = `
+<div id="acceptTermsField"
+     class="o-forms-field o-layout-typography ncf__validation-error"
+     data-validate="required,checked"
+>
+  <div class="auth-first-step-terms">
+    <span class="consent-text--top">
+      For more information about how we use your data, please refer to our
+      <a class="ncf__link--external"
+         href="https://help.ft.com/legal-privacy/privacy-policy/"
+         target="_blank"
+         rel="noopener noreferrer"
+         data-trackable="privacy-policy-info"
+      >
+        privacy
+      </a>
+      and 
+      <a class="ncf__link--external"
+         href="https://help.ft.com/legal-privacy/cookies/"
+         target="_blank"
+         rel="noopener noreferrer"
+         data-trackable="cookies-info"
+      >
+        cookie
+      </a>
+      policies.
+    </span>
+    <label class="o-forms-input o-forms-input--checkbox"
+           for="termsAcceptance"
+    >
+      <input type="checkbox"
+             id="termsAcceptance"
+             name="termsAcceptance"
+             value="true"
+             data-trackable="field-terms"
+             aria-required="true"
+             required
+      >
+      <span class="o-forms-input__label">
+        I confirm that I am 16 years or older and agree to the full
+        <a class="ncf__link--external"
+           href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+           target="_blank"
+           rel="noopener noreferrer"
+           data-trackable="terms-and-conditions"
+        >
+          Terms &amp; Conditions
+        </a>
+        .
+      </span>
+      <p class="o-forms-input__error">
+        Please accept our terms &amp; conditions
+      </p>
+    </label>
+  </div>
+</div>
+`;
+
 exports[`AcceptTerms renders appropriately if a isAuthFirstAccount 1`] = `
 <div id="acceptTermsField"
      class="o-forms-field o-layout-typography ncf__validation-error"
@@ -59,6 +117,34 @@ exports[`AcceptTerms renders appropriately if a isAuthFirstAccount 1`] = `
 `;
 
 exports[`AcceptTerms renders appropriately if a isAuthFirstPayment 1`] = `
+<div id="acceptTermsField"
+     class="o-forms-field o-layout-typography ncf__validation-error"
+     data-validate="required,checked"
+>
+  <ul class="o-typography-list ncf__accept-terms-list">
+  </ul>
+  <label class="o-forms-input o-forms-input--checkbox"
+         for="termsAcceptance"
+  >
+    <input type="checkbox"
+           id="termsAcceptance"
+           name="termsAcceptance"
+           value="true"
+           data-trackable="field-terms"
+           aria-required="true"
+           required
+    >
+    <span class="o-forms-input__label">
+      I agree to the above terms &amp; conditions.
+    </span>
+    <p class="o-forms-input__error">
+      Please accept our terms &amp; conditions
+    </p>
+  </label>
+</div>
+`;
+
+exports[`AcceptTerms renders appropriately if a isPaymentPage 1`] = `
 <div id="acceptTermsField"
      class="o-forms-field o-layout-typography ncf__validation-error"
      data-validate="required,checked"

--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -6,6 +6,20 @@ exports[`AcceptTerms renders a component matching snapshot when \`withB2BTerms\`
      data-validate="required,checked"
 >
   <ul class="o-typography-list ncf__accept-terms-list">
+    <li>
+      <span class="terms-default">
+        I confirm I am 16 years or older and have read and agree to the
+        <a class="ncf__link--external"
+           href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+           target="_blank"
+           rel="noopener noreferrer"
+           data-trackable="terms-and-conditions"
+        >
+          Terms &amp; Conditions
+        </a>
+        .
+      </span>
+    </li>
   </ul>
   <label class="o-forms-input o-forms-input--checkbox"
          for="termsAcceptance"
@@ -136,85 +150,6 @@ exports[`AcceptTerms renders appropriately if a signup 1`] = `
           Terms &amp; Conditions
         </a>
         .
-      </span>
-    </li>
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the above terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
-      Please accept our terms &amp; conditions
-    </p>
-  </label>
-</div>
-`;
-
-exports[`AcceptTerms renders appropriately if a signup and has special terms 1`] = `
-<div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
-     data-validate="required,checked"
-     data-trackable="sign-up-terms"
->
-  <ul class="o-typography-list ncf__accept-terms-list">
-    <li>
-      <span class="terms-default">
-        I confirm I am 16 years or older and have read and agree to the
-        <a class="ncf__link--external"
-           href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-           target="_blank"
-           rel="noopener noreferrer"
-           data-trackable="terms-and-conditions"
-        >
-          Terms &amp; Conditions
-        </a>
-        .
-      </span>
-    </li>
-    <li>
-      <span class="terms-signup">
-        I give consent for my chosen payment method to be charged automatically at the end of each subscription term until I cancel it by contacting
-        <a class="ncf__link--external"
-           href="https://help.ft.com/help/contact-us/"
-           target="_blank"
-           rel="noopener noreferrer"
-        >
-          customer care through chat, phone or email
-        </a>
-        .
-      </span>
-    </li>
-    <li>
-      <span class="terms-signup">
-        By placing my order, my subscription will start immediately and I am aware and agree that I will therefore lose my statutory right to cancel my subscription within 14 days of acceptance of my order. Any notice of cancellation that I provide will only take effect at the end of my subscription period and previously paid amounts are non-refundable, except in the event that there is a fault in the provision of the services.
-      </span>
-    </li>
-    <li>
-      <span class="terms-signup">
-        Find out more about our cancellation policy in our
-        <a class="ncf__link--external"
-           href="https://help.ft.com/legal-privacy/terms-and-conditions/"
-           target="_blank"
-           rel="noopener noreferrer"
-        >
-          Terms &amp; Conditions
-        </a>
-        .
-      </span>
-    </li>
-    <li>
-      <span class="terms-special">
-        Special terms text
       </span>
     </li>
   </ul>

--- a/components/__snapshots__/accept-terms.spec.js.snap
+++ b/components/__snapshots__/accept-terms.spec.js.snap
@@ -1,11 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AcceptTerms renders appropriately if a isAccessPage 1`] = `
+exports[`AcceptTerms renders a component matching snapshot when \`withB2BTerms\` is true 1`] = `
 <div id="acceptTermsField"
      class="o-forms-field o-layout-typography ncf__validation-error"
      data-validate="required,checked"
 >
-  <div class="auth-first-step-terms">
+  <ul class="o-typography-list ncf__accept-terms-list">
+  </ul>
+  <label class="o-forms-input o-forms-input--checkbox"
+         for="termsAcceptance"
+  >
+    <input type="checkbox"
+           id="termsAcceptance"
+           name="termsAcceptance"
+           value="true"
+           data-trackable="field-terms"
+           aria-required="true"
+           required
+    >
+    <span class="o-forms-input__label">
+      I agree to the above terms &amp; conditions.
+    </span>
+    <p class="o-forms-input__error">
+      Please accept our terms &amp; conditions
+    </p>
+  </label>
+</div>
+`;
+
+exports[`AcceptTerms renders a component matching snapshot when withPrivacyPolicyTerms is true 1`] = `
+<div id="acceptTermsField"
+     class="o-forms-field o-layout-typography ncf__validation-error"
+     data-validate="required,checked"
+>
+  <div class="privacy-policy-terms">
     <span class="consent-text--top">
       For more information about how we use your data, please refer to our
       <a class="ncf__link--external"
@@ -55,34 +83,6 @@ exports[`AcceptTerms renders appropriately if a isAccessPage 1`] = `
       </p>
     </label>
   </div>
-</div>
-`;
-
-exports[`AcceptTerms renders appropriately if a isPaymentPage 1`] = `
-<div id="acceptTermsField"
-     class="o-forms-field o-layout-typography ncf__validation-error"
-     data-validate="required,checked"
->
-  <ul class="o-typography-list ncf__accept-terms-list">
-  </ul>
-  <label class="o-forms-input o-forms-input--checkbox"
-         for="termsAcceptance"
-  >
-    <input type="checkbox"
-           id="termsAcceptance"
-           name="termsAcceptance"
-           value="true"
-           data-trackable="field-terms"
-           aria-required="true"
-           required
-    >
-    <span class="o-forms-input__label">
-      I agree to the above terms &amp; conditions.
-    </span>
-    <p class="o-forms-input__error">
-      Please accept our terms &amp; conditions
-    </p>
-  </label>
 </div>
 `;
 

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -363,6 +363,7 @@ export function AcceptTerms({
 }
 
 AcceptTerms.propTypes = {
+	withPrivacyPolicyTerms: PropTypes.bool,
 	hasError: PropTypes.bool,
 	isSignup: PropTypes.bool,
 	isChecked: PropTypes.bool,

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -6,8 +6,8 @@ const DEFAULT_AGE_RESTRICTION = '16';
 const DEFAULT_PRIVACY_POLICIES_POSITION = 'top';
 
 export function AcceptTerms({
-	isAccessPage = false,
-	isPaymentPage = false,
+	withPrivacyPolicyTerms = false,
+	withB2BTerms = false,
 	hasError = false,
 	isSignup = false,
 	isChecked = false,
@@ -53,8 +53,8 @@ export function AcceptTerms({
 		...(isChecked && { defaultChecked: true }),
 	};
 
-	const terms = (
-		<div className="auth-first-step-terms">
+	const privacyPolicyTerms = (
+		<div className="privacy-policy-terms">
 			<span className={`consent-text--${privacyPoliciesPosition}`}>
 				For more information about how we use your data, please refer to our{' '}
 				<a
@@ -344,12 +344,12 @@ export function AcceptTerms({
 		<div {...divProps}>
 			{isB2cPartnership ? (
 				b2cPartnershipTerms
-			) : isAccessPage ? (
-				terms
+			) : withPrivacyPolicyTerms ? (
+				privacyPolicyTerms
 			) : (
 				<>
 					<ul className="o-typography-list ncf__accept-terms-list">
-						{!isPaymentPage && b2bTerms}
+						{!withB2BTerms && b2bTerms}
 						{corpSignupTerms}
 						{transitionTerms}
 						{signupTerms}

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -7,7 +7,6 @@ const DEFAULT_PRIVACY_POLICIES_POSITION = 'top';
 
 export function AcceptTerms({
 	withPrivacyPolicyTerms = false,
-	withB2BTerms = false,
 	hasError = false,
 	isSignup = false,
 	isChecked = false,
@@ -20,7 +19,6 @@ export function AcceptTerms({
 	isTransition = false,
 	transitionType = null,
 	isPrintProduct = false,
-	specialTerms = null,
 	isSingleTerm = false,
 	isDeferredBilling = false,
 	hideConfirmTermsAndConditions = false,
@@ -299,12 +297,6 @@ export function AcceptTerms({
 					</li>
 				</>
 			)}
-
-			{specialTerms && (
-				<li>
-					<span className="terms-special">{specialTerms}</span>
-				</li>
-			)}
 		</>
 	);
 
@@ -349,7 +341,7 @@ export function AcceptTerms({
 			) : (
 				<>
 					<ul className="o-typography-list ncf__accept-terms-list">
-						{!withB2BTerms && b2bTerms}
+						{b2bTerms}
 						{corpSignupTerms}
 						{transitionTerms}
 						{signupTerms}
@@ -383,7 +375,6 @@ AcceptTerms.propTypes = {
 	isTransition: PropTypes.bool,
 	transitionType: PropTypes.string,
 	isPrintProduct: PropTypes.bool,
-	specialTerms: PropTypes.string,
 	isSingleTerm: PropTypes.bool,
 	isDeferredBilling: PropTypes.bool,
 	hideConfirmTermsAndConditions: PropTypes.bool,

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -6,11 +6,10 @@ const DEFAULT_AGE_RESTRICTION = '16';
 const DEFAULT_PRIVACY_POLICIES_POSITION = 'top';
 
 export function AcceptTerms({
-	isAuthFirstAccount = false,
-	isAuthFirstPayment = false,
+	isAccessPage = false,
+	isPaymentPage = false,
 	hasError = false,
 	isSignup = false,
-	isRegister = false,
 	isChecked = false,
 	isB2b = false,
 	isB2cPartnership = false,
@@ -33,7 +32,6 @@ export function AcceptTerms({
 		className: 'o-forms-field o-layout-typography ncf__validation-error',
 		'data-validate': 'required,checked',
 		...(isSignup && { 'data-trackable': 'sign-up-terms' }),
-		...(isRegister && { 'data-trackable': 'register-up-terms' }),
 	};
 
 	const labelClassName = classNames([
@@ -369,14 +367,12 @@ export function AcceptTerms({
 		<div {...divProps}>
 			{isB2cPartnership ? (
 				b2cPartnershipTerms
-			) : isRegister ? (
-				registerTerms
-			) : isAuthFirstAccount ? (
+			) : isAccessPage ? (
 				authFirstStepTerms
 			) : (
 				<>
 					<ul className="o-typography-list ncf__accept-terms-list">
-						{!isAuthFirstPayment && b2bTerms}
+						{!isAccessPage && b2bTerms}
 						{corpSignupTerms}
 						{transitionTerms}
 						{signupTerms}
@@ -400,7 +396,6 @@ export function AcceptTerms({
 AcceptTerms.propTypes = {
 	hasError: PropTypes.bool,
 	isSignup: PropTypes.bool,
-	isRegister: PropTypes.bool,
 	isChecked: PropTypes.bool,
 	isB2b: PropTypes.bool,
 	isB2cPartnership: PropTypes.bool,

--- a/components/accept-terms.jsx
+++ b/components/accept-terms.jsx
@@ -53,7 +53,7 @@ export function AcceptTerms({
 		...(isChecked && { defaultChecked: true }),
 	};
 
-	const authFirstStepTerms = (
+	const terms = (
 		<div className="auth-first-step-terms">
 			<span className={`consent-text--${privacyPoliciesPosition}`}>
 				For more information about how we use your data, please refer to our{' '}
@@ -102,29 +102,6 @@ export function AcceptTerms({
 			)}
 			{children && <div className="children-container">{children}</div>}
 		</div>
-	);
-
-	const registerTerms = (
-		<label className={labelClassName} htmlFor="termsAcceptance">
-			<input {...inputProps} />
-			<span className="o-forms-input__label terms-register">
-				I confirm I am {ageRestriction} years or older and have read and agree
-				to the{' '}
-				<a
-					className="ncf__link--external"
-					href="http://help.ft.com/help/legal-privacy/terms-conditions/"
-					target={isEmbedded ? '_top' : '_blank'}
-					rel="noopener noreferrer"
-					data-trackable="terms-and-conditions"
-				>
-					Terms &amp; Conditions
-				</a>
-				.
-			</span>
-			<p className="o-forms-input__error">
-				Please accept our terms &amp; conditions
-			</p>
-		</label>
 	);
 
 	const b2bTerms = isB2b ? (
@@ -368,11 +345,11 @@ export function AcceptTerms({
 			{isB2cPartnership ? (
 				b2cPartnershipTerms
 			) : isAccessPage ? (
-				authFirstStepTerms
+				terms
 			) : (
 				<>
 					<ul className="o-typography-list ncf__accept-terms-list">
-						{!isAccessPage && b2bTerms}
+						{!isPaymentPage && b2bTerms}
 						{corpSignupTerms}
 						{transitionTerms}
 						{signupTerms}

--- a/components/accept-terms.spec.js
+++ b/components/accept-terms.spec.js
@@ -22,12 +22,6 @@ describe('AcceptTerms', () => {
 		expect(AcceptTerms).toRenderCorrectly(props);
 	});
 
-	it('renders a component matching snapshot when `withB2BTerms` is true', () => {
-		const props = { withB2BTerms: true };
-
-		expect(AcceptTerms).toRenderCorrectly(props);
-	});
-
 	it('renders appropriately if a signup', () => {
 		const props = { isSignup: true };
 

--- a/components/accept-terms.spec.js
+++ b/components/accept-terms.spec.js
@@ -16,14 +16,14 @@ describe('AcceptTerms', () => {
 		expect(AcceptTerms).toRenderCorrectly(props);
 	});
 
-	it('renders appropriately if a isAccessPage', () => {
-		const props = { isAccessPage: true };
+	it('renders a component matching snapshot when withPrivacyPolicyTerms is true', () => {
+		const props = { withPrivacyPolicyTerms: true };
 
 		expect(AcceptTerms).toRenderCorrectly(props);
 	});
 
-	it('renders appropriately if a isPaymentPage', () => {
-		const props = { isPaymentPage: true };
+	it('renders a component matching snapshot when `withB2BTerms` is true', () => {
+		const props = { withB2BTerms: true };
 
 		expect(AcceptTerms).toRenderCorrectly(props);
 	});

--- a/components/accept-terms.spec.js
+++ b/components/accept-terms.spec.js
@@ -16,14 +16,14 @@ describe('AcceptTerms', () => {
 		expect(AcceptTerms).toRenderCorrectly(props);
 	});
 
-	it('renders appropriately if a isAuthFirstAccount', () => {
-		const props = { isAuthFirstAccount: true };
+	it('renders appropriately if a isAccessPage', () => {
+		const props = { isAccessPage: true };
 
 		expect(AcceptTerms).toRenderCorrectly(props);
 	});
 
-	it('renders appropriately if a isAuthFirstPayment', () => {
-		const props = { isAuthFirstPayment: true };
+	it('renders appropriately if a isPaymentPage', () => {
+		const props = { isPaymentPage: true };
 
 		expect(AcceptTerms).toRenderCorrectly(props);
 	});
@@ -75,12 +75,6 @@ describe('AcceptTerms', () => {
 			isSignup: true,
 			specialTerms: 'Special terms text',
 		};
-
-		expect(AcceptTerms).toRenderCorrectly(props);
-	});
-
-	it('renders appropriately if a registration', () => {
-		const props = { isRegister: true };
 
 		expect(AcceptTerms).toRenderCorrectly(props);
 	});

--- a/components/accept-terms.spec.js
+++ b/components/accept-terms.spec.js
@@ -70,15 +70,6 @@ describe('AcceptTerms', () => {
 		expect(AcceptTerms).toRenderCorrectly(props);
 	});
 
-	it('renders appropriately if a signup and has special terms', () => {
-		const props = {
-			isSignup: true,
-			specialTerms: 'Special terms text',
-		};
-
-		expect(AcceptTerms).toRenderCorrectly(props);
-	});
-
 	it('renders appropriately if input is checked', () => {
 		const props = { isChecked: true };
 

--- a/components/accept-terms.stories.js
+++ b/components/accept-terms.stories.js
@@ -18,7 +18,6 @@ export default {
 				type: { summary: 'Show privacy policy terms' },
 			},
 		},
-		withB2BTerms: { control: 'boolean' },
 		hasError: { control: 'boolean' },
 		isSignup: { control: 'boolean' },
 		isChecked: { control: 'boolean' },

--- a/components/accept-terms.stories.js
+++ b/components/accept-terms.stories.js
@@ -56,12 +56,12 @@ Basic.args = {};
 
 export const NewBuyFlow = (args) => <AcceptTerms {...args} />;
 NewBuyFlow.args = {
-	isAccessPage: true,
+	withPrivacyPolicyTerms: true,
 };
 
 export const NewBuyFlowEmailVerification = (args) => <AcceptTerms {...args} />;
 NewBuyFlowEmailVerification.args = {
-	isAccessPage: true,
+	withPrivacyPolicyTerms: true,
 	hideConfirmTermsAndConditions: true,
 };
 
@@ -71,12 +71,12 @@ export const NewBuyFlowWithChildren = (args) => (
 	</AcceptTerms>
 );
 NewBuyFlowWithChildren.args = {
-	isAccessPage: true,
+	withPrivacyPolicyTerms: true,
 	privacyPoliciesPosition: 'bottom',
 };
 NewBuyFlowWithChildren.parameters = {
 	controls: {
-		include: ['privacyPoliciesPosition', 'isAccessPage', 'children'],
+		include: ['privacyPoliciesPosition', 'withPrivacyPolicyTerms', 'children'],
 		expanded: true,
 	},
 };

--- a/components/accept-terms.stories.js
+++ b/components/accept-terms.stories.js
@@ -12,16 +12,15 @@ export default {
 				options: ['immediate', 'endOfTerm'],
 			},
 		},
-		isAuthFirstAccount: {
+		isAccessPage: {
 			control: 'boolean',
 			table: {
 				type: { summary: 'Show new buy flow design' },
 			},
 		},
-		isAuthFirstPayment: { control: 'boolean' },
+		isPaymentPage: { control: 'boolean' },
 		hasError: { control: 'boolean' },
 		isSignup: { control: 'boolean' },
-		isRegister: { control: 'boolean' },
 		isChecked: { control: 'boolean' },
 		isB2b: { control: 'boolean' },
 		isB2cPartnership: { control: 'boolean' },
@@ -36,7 +35,7 @@ export default {
 		children: {
 			control: false,
 			table: {
-				type: { summary: "Only rendered when 'isAuthFirstAccount' is true" },
+				type: { summary: "Only rendered when 'isAccessPage' is true" },
 			},
 		},
 		privacyPoliciesPosition: {
@@ -56,12 +55,12 @@ Basic.args = {};
 
 export const NewBuyFlow = (args) => <AcceptTerms {...args} />;
 NewBuyFlow.args = {
-	isAuthFirstAccount: true,
+	isAccessPage: true,
 };
 
 export const NewBuyFlowEmailVerification = (args) => <AcceptTerms {...args} />;
 NewBuyFlowEmailVerification.args = {
-	isAuthFirstAccount: true,
+	isAccessPage: true,
 	hideConfirmTermsAndConditions: true,
 };
 
@@ -71,12 +70,12 @@ export const NewBuyFlowWithChildren = (args) => (
 	</AcceptTerms>
 );
 NewBuyFlowWithChildren.args = {
-	isAuthFirstAccount: true,
+	isAccessPage: true,
 	privacyPoliciesPosition: 'bottom',
 };
 NewBuyFlowWithChildren.parameters = {
 	controls: {
-		include: ['privacyPoliciesPosition', 'isAuthFirstAccount', 'children'],
+		include: ['privacyPoliciesPosition', 'isAccessPage', 'children'],
 		expanded: true,
 	},
 };

--- a/components/accept-terms.stories.js
+++ b/components/accept-terms.stories.js
@@ -34,7 +34,9 @@ export default {
 		children: {
 			control: false,
 			table: {
-				type: { summary: "Only rendered when 'isAccessPage' is true" },
+				type: {
+					summary: "Only rendered when 'withPrivacyPolicyTerms' is true",
+				},
 			},
 		},
 		privacyPoliciesPosition: {

--- a/components/accept-terms.stories.js
+++ b/components/accept-terms.stories.js
@@ -12,13 +12,13 @@ export default {
 				options: ['immediate', 'endOfTerm'],
 			},
 		},
-		isAccessPage: {
+		withPrivacyPolicyTerms: {
 			control: 'boolean',
 			table: {
-				type: { summary: 'Show new buy flow design' },
+				type: { summary: 'Show privacy policy terms' },
 			},
 		},
-		isPaymentPage: { control: 'boolean' },
+		withB2BTerms: { control: 'boolean' },
 		hasError: { control: 'boolean' },
 		isSignup: { control: 'boolean' },
 		isChecked: { control: 'boolean' },

--- a/styles/accept-terms.scss
+++ b/styles/accept-terms.scss
@@ -19,7 +19,7 @@
 	}
 }
 
-.auth-first-step-terms {
+.privacy-policy-terms {
   display: flex;
   flex-direction: column;
 


### PR DESCRIPTION
### Description
By adding Policies Text in Sign up forms isRegister and isAuthFirstAccount props names don’t make sense anymore. 

We need to check use cases and change their names and/or coding.   

Note: This ticket is not only meant to those 2 props. We should check the entire component and do refactors where needed. At the moment the component is filled with boolean props and rendering several different components that we are not sure which ones are being used and if others should be merged with each other. 

If any doubt check with Product for text definitions.

### Ticket
(https://financialtimes.atlassian.net/browse/ACQ-2088)

### Info

Document to clarify how accept terms is used and variables that we are not using.

https://docs.google.com/document/d/1RkanlvYZoSafEt4Oeg2TidhFy9qNx6R52T9dW6sqeLg/edit 

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
