### PR TITLE
ACQ-2228: removing paymentTerm.updateOptions method because is not longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,16 +225,6 @@ const paymentTerm = new PaymentTerm(document);
 
 // Return the currently selected payment term
 paymentTerm.getSelected();
-
-// Update the payment term options displayed
-const options = [
-	{
-		name: 'Name of term',
-		value: 'Value to send',
-		description: 'Can contain <strong>HTML</strong>',
-	},
-];
-paymentTerm.updateOptions(options);
 ```
 
 Update and get the currently selected payment term on the form

--- a/utils/payment-term.js
+++ b/utils/payment-term.js
@@ -7,22 +7,7 @@ const { Period } = require('@financial-times/n-pricing');
  *
  * // Return the currently selected payment term
  * paymentTerm.getSelected();
- *
- * // Update the payment term options displayed
- * const options = [{
- * 	name: 'Name of term',
- * 	value: 'Value to send',
- * 	description: 'Can contain <strong>HTML</strong>'
- * }];
- * paymentTerm.updateOptions(options);
  */
-
-const ITEM_CLASS = '.ncf__payment-term__item';
-const VALUE_CLASS = '.ncf__payment-term__item input';
-const PRICE_CLASS = '.ncf__payment-term__price';
-const TRIAL_PRICE_CLASS = '.ncf__payment-term__trial-price';
-const MONTHLY_PRICE_CLASS = '.ncf__payment-term__monthly-price';
-
 class PaymentTerm {
 	/**
 	 * Initalise the PaymentTerm utility
@@ -100,41 +85,6 @@ class PaymentTerm {
 			return true;
 		} catch (e) {
 			return false;
-		}
-	}
-
-	/**
-	 * Updates the payment term options.
-	 * @param {Object} options - indexed Object about Array of objects containing terms information. E.g.: { P1Y: {...}, P3M: {...}}
-	 * @throws Will throw an error if a payment term update is not found for a given value.
-	 */
-	updateOptions(options) {
-		const terms = this.$paymentTerm.querySelectorAll(ITEM_CLASS);
-		for (let i = 0; i < terms.length; i++) {
-			const term = terms[i];
-			const value = term.querySelector(VALUE_CLASS).value;
-			const price = term.querySelector(PRICE_CLASS);
-			const trialPrice = term.querySelector(TRIAL_PRICE_CLASS);
-			const monthlyPrice = term.querySelector(MONTHLY_PRICE_CLASS);
-			const update = options[value];
-
-			if (!update) {
-				throw new Error(`Payment term update not found for "${value}"`);
-			}
-
-			const baseAmount = update.isTrial ? update.trialAmount : update.amount;
-			term.setAttribute('data-base-amount', baseAmount);
-
-			// Update prices if they are found in the term
-			if (price) {
-				price.innerHTML = update.price;
-			}
-			if (trialPrice) {
-				trialPrice.innerHTML = update.trialPrice;
-			}
-			if (monthlyPrice && update.monthlyPrice) {
-				monthlyPrice.innerHTML = update.monthlyPrice;
-			}
 		}
 	}
 }

--- a/utils/payment-term.spec.js
+++ b/utils/payment-term.spec.js
@@ -84,122 +84,26 @@ describe('PaymentTerm', () => {
 			});
 		});
 
-		describe('updateOptions', () => {
-			beforeEach(() => {
-				paymentTerm.getSelected = jest.fn().mockReturnValue(true);
-				elementStub.querySelector.mockReturnValue(elementStub);
-				elementStub.cloneNode.mockReturnValue(elementStub);
-				elementStub.querySelectorAll.mockReturnValue([elementStub]);
-			});
-
-			it('throws an error if not all terms have an update', () => {
+		describe('getBaseAmount', () => {
+			it('throws an error if nothing selected', () => {
+				elementStub.querySelector.mockReturnValue(false);
 				expect(() => {
-					paymentTerm.updateOptions({});
+					paymentTerm.getBaseAmount();
 				}).toThrow();
 			});
 
-			it('replaces the price with the correct updated price', () => {
-				const priceStub = {};
-				elementStub.querySelector.mockImplementation((elementId) => {
-					return elementId === '.ncf__payment-term__price'
-						? priceStub
-						: elementStub;
-				});
-				paymentTerm.updateOptions({
-					test: {
-						value: 'test',
-						price: '£1.01',
-					},
-				});
-				expect(priceStub.innerHTML).toEqual('£1.01');
+			it('returns base amount of the selected term', () => {
+				elementStub.dataset.baseAmount = 99;
+				elementStub.querySelector.mockReturnValue(elementStub);
+				const returnedAmount = paymentTerm.getBaseAmount();
+				expect(returnedAmount).toBe(99);
 			});
+		});
 
-			it('replaces the trial price with the correct updated trial price', () => {
-				const trialPriceStub = {};
-				elementStub.querySelector.mockImplementation((elementId) => {
-					return elementId === '.ncf__payment-term__trial-price'
-						? trialPriceStub
-						: elementStub;
-				});
-				paymentTerm.updateOptions({
-					test: {
-						value: 'test',
-						trialPrice: '£1.01',
-					},
-				});
-				expect(trialPriceStub.innerHTML).toEqual('£1.01');
-			});
-
-			it('replaces the monthly price with the correct updated monthly price', () => {
-				const monthlyPriceStub = {};
-				elementStub.querySelector.mockImplementation((elementId) => {
-					return elementId === '.ncf__payment-term__monthly-price'
-						? monthlyPriceStub
-						: elementStub;
-				});
-				paymentTerm.updateOptions({
-					test: {
-						value: 'test',
-						monthlyPrice: '£1.01',
-					},
-				});
-				expect(monthlyPriceStub.innerHTML).toEqual('£1.01');
-			});
-
-			describe('updating base amount', () => {
-				const updatedOptions = {
-					test: {
-						value: 'test',
-						monthlyPrice: '£1.01',
-						amount: 500,
-						trialAmount: 1,
-					},
-				};
-
-				beforeEach(() => {
-					elementStub.querySelector.mockReturnValue(elementStub);
-				});
-
-				it('replaces the base amount with the correct updated trial amount', () => {
-					updatedOptions.test.isTrial = true;
-					paymentTerm.updateOptions(updatedOptions);
-					expect(elementStub.setAttribute).toHaveBeenCalledWith(
-						'data-base-amount',
-						1
-					);
-				});
-
-				it('replaces the base amount with the correct updated amount', () => {
-					updatedOptions.test.isTrial = false;
-					paymentTerm.updateOptions(updatedOptions);
-					expect(elementStub.setAttribute).toHaveBeenCalledWith(
-						'data-base-amount',
-						500
-					);
-				});
-			});
-
-			describe('getBaseAmount', () => {
-				it('throws an error if nothing selected', () => {
-					elementStub.querySelector.mockReturnValue(false);
-					expect(() => {
-						paymentTerm.getBaseAmount();
-					}).toThrow();
-				});
-
-				it('returns base amount of the selected term', () => {
-					elementStub.dataset.baseAmount = 99;
-					elementStub.querySelector.mockReturnValue(elementStub);
-					const returnedAmount = paymentTerm.getBaseAmount();
-					expect(returnedAmount).toBe(99);
-				});
-			});
-
-			describe('getCountryCode', () => {
-				it('returns countryCode of the selected term', () => {
-					const countryCode = paymentTerm.getCountryCode();
-					expect(countryCode).toBe('GBP');
-				});
+		describe('getCountryCode', () => {
+			it('returns countryCode of the selected term', () => {
+				const countryCode = paymentTerm.getCountryCode();
+				expect(countryCode).toBe('GBP');
 			});
 		});
 	});


### PR DESCRIPTION
### Description
Removing paymentTerm.updateOptions method because is not longer used.

This change is related (but not blocked) to:
- https://github.com/Financial-Times/n-membership-sdk/pull/631
- https://github.com/Financial-Times/next-subscribe/pull/2588

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-2228

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
