### PR TITLE
Re-enable Storybook for Node.js v18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 	npm run build
 
 run:
-	npm run storybook
+	NODE_OPTIONS=--openssl-legacy-provider npm run storybook
 
 test:
 	make jest


### PR DESCRIPTION
### Description
I ran the command `make run` (which in turn calls `npm run storybook`) with the intention of running Storybook to develop a confirmation component and encountered:

```
Note — An .env file exists. Its contents have been exported as environment variables.
npm run storybook

> @financial-times/n-conversion-forms@0.0.0 storybook
> start-storybook -p 5005

info @storybook/react v6.5.16
info
info => Loading presets
info Addon-docs: using MDX1
info => Using implicit CSS loaders
(node:10658) DeprecationWarning: Default PostCSS plugins are deprecated. When switching to '@storybook/addon-postcss',
you will need to add your own plugins, such as 'postcss-flexbugs-fixes' and 'autoprefixer'.

See https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-default-postcss-plugins for details.
(Use `node --trace-deprecation ...` to show where the warning was created)
info => Using default Webpack4 setup
10% building 1/7 modules 6 active ...uments/n-conversion-forms/node_modules/@storybook/addon-a11y/preview.js-generated-config-entry.jsnode:internal/crypto/hash:69
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:69:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (/{PATH}/n-conversion-forms/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/{PATH}/n-conversion-forms/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/{PATH}/n-conversion-forms/node_modules/webpack/lib/NormalModule.js:471:10)
    at /{PATH}/n-conversion-forms/node_modules/webpack/lib/NormalModule.js:503:5
    at /{PATH}/n-conversion-forms/node_modules/webpack/lib/NormalModule.js:358:12
    at /{PATH}/n-conversion-forms/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/{PATH}/n-conversion-forms/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at /{PATH}/n-conversion-forms/node_modules/loader-runner/lib/LoaderRunner.js:205:4 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v18.17.0
make: *** [run] Error 1
```

Some Googling led me to this issue: [GitHub: storybookjs/storybook — [Bug]: envelope routines::unsupported](https://github.com/storybookjs/storybook/issues/21739) where it is reported that Storybook does not run on Node.js v18. I checked out the code prior to this PR https://github.com/Financial-Times/n-conversion-forms/pull/744 and Storybook ran successfully.

Fixes suggested in the issue are:
- add the `--openssl-legacy-provider` flag to `NODE_OPTIONS` as has been done in this PR
- upgrade Storybook and Webpack to the latest versions, which for this repo requires a major bump for each of those and so feel like a substantial piece of yak-shaving I was not anticipating as part of the work to develop a new confirmation component
  - [Storybook migration guide: 6.x to 7.0](https://storybook.js.org/docs/7.0/react/migration-guide)
  - [Webpack migration guide: v4 to v5](https://webpack.js.org/migrate/5).

### Ticket
N/A

### Screenshots
N/A

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner