### PR TITLE
Modify secret-squirrel.js

### DIFF
--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -9,6 +9,7 @@ module.exports = {
 			'createB2cDiscountCopy',
 			'test@example\\.com', // components/__snapshots__/confirmation.spec.js.snap:544|606, components/__snapshots__/email.spec.js.snap:154|186, components/__snapshots__/registration-confirmation.spec.js.snap:15|62, components/confirmation.spec.js:29, components/email.spec.js:30, components/registration-confirmation.spec.js:21, docs/PARTIALS.md:106|357, test/partials/confirmation.spec.js:12, test/partials/registration-confirmation.spec.js:12, test/utils/email.spec.js:148|159|168|178|188
 			'd19dc7a6-c33b-4931-9a7e-4a74674da29a', // components/__snapshots__/licence-confirmation.spec.js.snap:28|62, components/licence-confirmation.spec.js:44
+			'addressLine3MaxLength', // components/delivery-address-map.jsx:63|138|198|132
 		],
 	},
 };


### PR DESCRIPTION
### Description
[secret-squirrel](https://github.com/Financial-Times/secret-squirrel) is deprecated but while it remains in usage by this repo and is compatible with my operating system, my commits are being blocked by the presence of `addressLine3MaxLength`.

This PR adds that value to the list of `denyOverrides` in `secret-squirrel.js` to avoid this from happening.

### Ticket
N/A

### Screenshots
N/A

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
