### PR TITLE
RS-310 Apply changes for 7-day pass experiment

### DIFF
--- a/components/__snapshots__/package-change.spec.js.snap
+++ b/components/__snapshots__/package-change.spec.js.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PackageChange annual render when is7DayPassExperiment is true 1`] = `
+<div class="ncf__package-change">
+  <div class="ncf__package-change__package">
+    <div class="ncf__package-change__content">
+      <p>
+        You have chosen
+        <span class="ncf__strong">
+          Trial
+        </span>
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`PackageChange annual render with defaults 1`] = `
 <div class="ncf__package-change">
   <div class="ncf__package-change__package">

--- a/components/accept-terms-subscription.jsx
+++ b/components/accept-terms-subscription.jsx
@@ -9,6 +9,7 @@ export function AcceptTermsSubscription({
 	isTrial = false,
 	isPrintProduct = false,
 	isSingleTerm = false,
+	is7DayPassExperiment = false,
 	isTransition = false,
 	transitionType = null,
 	isDeferredBilling = false,
@@ -36,6 +37,54 @@ export function AcceptTermsSubscription({
 		'aria-required': 'true',
 		required: true,
 	};
+
+	if (is7DayPassExperiment) {
+		return (
+			<div {...divProps}>
+				<ul className="o-typography-list ncf__accept-terms-list">
+					<li>
+						<span className="terms-transition terms-transition--immediate">
+							I give consent for my chosen payment method to be charged
+							automatically.
+						</span>
+					</li>
+					<li>
+						<span className="terms-transition terms-transition--immediate">
+							By placing your order subject to the Terms & Conditions (save for
+							section 2) referred to below, you are waiving your statutory right
+							to cancel our contract within 14 days of payment. Your payment is
+							a one-time payment collected at the time of checkout, and
+							unsubscribing or cancelling at any point (whether before or after
+							the 14-day period) will not entitle you to a refund.
+						</span>
+					</li>
+					<li>
+						<span className="terms-transition">
+							Please see here for the complete{' '}
+							<a
+								className="ncf__link--external"
+								href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								Terms &amp; Conditions
+							</a>
+							.
+						</span>
+					</li>
+				</ul>
+				<label className={labelClassName} htmlFor="termsAcceptance">
+					<input {...inputProps} />
+					<span className="o-forms-input__label">
+						I agree to the above terms &amp; conditions.
+					</span>
+					<p className="o-forms-input__error">
+						Please accept our terms &amp; conditions
+					</p>
+				</label>
+			</div>
+		);
+	}
 
 	const transitionTerms = isTransition && (
 		<>
@@ -209,6 +258,7 @@ AcceptTermsSubscription.propTypes = {
 	isTrial: PropTypes.bool,
 	isPrintProduct: PropTypes.bool,
 	isSingleTerm: PropTypes.bool,
+	is7DayPassExperiment: PropTypes.bool,
 	isTransition: PropTypes.bool,
 	transitionType: PropTypes.string,
 	isDeferredBilling: PropTypes.bool,

--- a/components/index.jsx
+++ b/components/index.jsx
@@ -49,6 +49,7 @@ export { Province } from './province';
 export { RegistrationConfirmation } from './registration-confirmation';
 export { Responsibility } from './responsibility';
 export { Section } from './section';
+export { SevenDayPassExperimentConfirmation } from './seven-day-pass-experiment-confirmation';
 export { State } from './state';
 export { Submit } from './submit';
 export { TrialBanner } from './trial-banner';

--- a/components/package-change.jsx
+++ b/components/package-change.jsx
@@ -5,6 +5,7 @@ export function PackageChange({
 	changePackageUrl,
 	currentPackage,
 	packageDescription,
+	is7DayPassExperiment,
 }) {
 	return (
 		<div className="ncf__package-change">
@@ -20,15 +21,17 @@ export function PackageChange({
 						</p>
 					)}
 				</div>
-				<div className="ncf__package-change__actions">
-					<a
-						href={changePackageUrl}
-						className="ncf__button ncf__button--mono ncf__button--baseline"
-						data-trackable="change"
-					>
-						Change
-					</a>
-				</div>
+				{!is7DayPassExperiment && (
+					<div className="ncf__package-change__actions">
+						<a
+							href={changePackageUrl}
+							className="ncf__button ncf__button--mono ncf__button--baseline"
+							data-trackable="change"
+						>
+							Change
+						</a>
+					</div>
+				)}
 			</div>
 		</div>
 	);
@@ -38,4 +41,5 @@ PackageChange.propTypes = {
 	changePackageUrl: PropTypes.string.isRequired,
 	currentPackage: PropTypes.string.isRequired,
 	packageDescription: PropTypes.string,
+	is7DayPassExperiment: PropTypes.bool,
 };

--- a/components/package-change.spec.js
+++ b/components/package-change.spec.js
@@ -74,6 +74,23 @@ describe('PackageChange', () => {
 
 				expect(PackageChange).toRenderCorrectly(props);
 			});
+
+			it('render when is7DayPassExperiment is true', () => {
+				const props = {
+					changePackageUrl: 'https://www.ft.com',
+					currentPackage: 'Trial',
+					is7DayPassExperiment: true,
+					terms: [
+						{
+							name: term,
+							price: '£1.00',
+							weeklyPrice: '£1.00',
+						},
+					],
+				};
+
+				expect(PackageChange).toRenderCorrectly(props);
+			});
 		});
 	});
 });

--- a/components/package-change.stories.js
+++ b/components/package-change.stories.js
@@ -18,3 +18,11 @@ WithPackageDescription.args = {
 	changePackageUrl: 'https://ft.com/products',
 	packageDescription: 'Personalised email briefings and alerts',
 };
+
+export const SevenDayPassExperiment = (args) => <PackageChange {...args} />;
+SevenDayPassExperiment.args = {
+	currentPackage: 'Premium Digital',
+	changePackageUrl: 'https://ft.com/products',
+	packageDescription: 'Personalised email briefings and alerts',
+	is7DayPassExperiment: true,
+};

--- a/components/payment-term.spec.js
+++ b/components/payment-term.spec.js
@@ -153,6 +153,37 @@ describe('PaymentTerm', () => {
 		});
 	});
 
+	describe('given is7DayPassExperiment is true', () => {
+		const options = [
+			{
+				name: 'monthly',
+				price: '$5.00',
+				value: 'monthly',
+				monthlyPrice: '$5.00',
+			},
+		];
+		const wrapper = shallow(
+			<PaymentTerm
+				isFixedTermOffer={true}
+				options={options}
+				offerDisplayName="7-day pass"
+				is7DayPassExperiment={true}
+			/>
+		);
+
+		it('renders renewal text that actually reflects how the 7-day pass is a fixed term subscription with a one-off payment made at the outset', () => {
+			expect(wrapper.find('.ncf__payment-term__renews-text').text()).toMatch(
+				/This subscription is for 7 days, charged at the outset./
+			);
+		});
+
+		it('renders offer name and omits payment term title', () => {
+			expect(wrapper.find('.ncf__payment-term__title').text()).toMatch(
+				'7-day pass'
+			);
+		});
+	});
+
 	describe('getDisplayName', () => {
 		const baseOptions = {
 			name: 'monthly',
@@ -196,6 +227,22 @@ describe('PaymentTerm', () => {
 				const wrapper = shallow(<PaymentTerm options={options} />);
 				expect(wrapper.find('.ncf__payment-term__label').text()).toMatch(
 					/^Trial: someDisplayName - Monthly .*/
+				);
+			});
+		});
+		describe('7-day pass experiment', () => {
+			const options = [
+				{
+					...baseOptions,
+					isTrial: false,
+				},
+			];
+			it('renders with time period only if trial.option == false', () => {
+				const wrapper = shallow(
+					<PaymentTerm options={options} is7DayPassExperiment={true} />
+				);
+				expect(wrapper.find('.ncf__payment-term__label').text().trim()).toMatch(
+					'£20.00 one-time paymentThis subscription is for 7 days, charged at the outset.'
 				);
 			});
 		});

--- a/components/payment-term.stories.js
+++ b/components/payment-term.stories.js
@@ -109,6 +109,26 @@ FixedTermOffer.args = {
 	offerDisplayName: 'Mix & Match',
 };
 
+export const SevenDayPassExperimentOffer = (args) => (
+	<div className="ncf">
+		<Fieldset>
+			<PaymentTerm {...args} />
+		</Fieldset>
+	</div>
+);
+SevenDayPassExperimentOffer.args = {
+	options: [
+		{
+			name: 'monthly',
+			price: '$5.00',
+			value: 5.0,
+		},
+	],
+	isFixedTermOffer: true,
+	is7DayPassExperiment: true,
+	offerDisplayName: '7-day pass',
+};
+
 export const RenewOffers = (args) => (
 	<div className="ncf">
 		<Fieldset>

--- a/components/seven-day-pass-experiment-confirmation.jsx
+++ b/components/seven-day-pass-experiment-confirmation.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const DetailsMobileView = ({ details }) => (
+	<dl className="ncf__list ncf__lite-sub__details ncf__lite-sub-confirmation--hidden-md ncf__lite-sub-confirmation--hidden-lg">
+		{details.map((detail, index) => (
+			<React.Fragment key={index}>
+				<dt className="ncf__list-title">{detail.title}</dt>
+				<dd className="ncf__list-data">{detail.data}</dd>
+			</React.Fragment>
+		))}
+	</dl>
+);
+
+export function SevenDayPassExperimentConfirmation({
+	offerName = '',
+	details = [],
+}) {
+	const detailElements = details && (
+		<React.Fragment>
+			<h2 className="ncf__header2--afterline">Your billing details</h2>
+			<dl className="ncf__list ncf__lite-sub-confirmation--hidden-sm">
+				{details.map((detail, index) => (
+					<React.Fragment key={index}>
+						<dt className="ncf__list-title">{detail.title}</dt>
+						<dd className="ncf__list-data">{detail.data}</dd>
+					</React.Fragment>
+				))}
+			</dl>
+			<DetailsMobileView details={details} />
+		</React.Fragment>
+	);
+
+	return (
+		<div className="ncf ncf__wrapper">
+			<div className="ncf__center">
+				<div className="ncf__icon ncf__icon--tick ncf__icon--large"></div>
+				<p className="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">
+					You are now subscribed to:
+				</p>
+				<h1 className="ncf__header ncf__header--confirmation">
+					{'Premium Digital'}
+				</h1>
+			</div>
+			<p className="ncf__paragraph">
+				Exciting news! You are one of the first to try a{' '}
+				<strong>{offerName}</strong>. As a thank you, we are pleased to extend
+				your subscription to one month at no additional cost.
+			</p>
+			<p className="ncf__center">
+				<a
+					href="/"
+					className="ncf__button ncf__button--submit ncf__button--margin ncf__lite-sub-confirmation--lite-sub-cta"
+				>
+					Go to FT.com
+				</a>
+			</p>
+			<p className="ncf__paragraph">
+				Please save or print this page for your records as your purchase
+				confirmation.
+			</p>
+
+			<p className="ncf__paragraph">
+				Here&apos;s a summary of your Premium Digital subscription:
+			</p>
+
+			{detailElements}
+
+			<div className="ncf__headed-paragraph">
+				<h3 className="ncf__header">Something not right?</h3>
+				<p className="ncf__paragraph">
+					Go to your{' '}
+					<a
+						className="ncf__link ncf__link--external"
+						href="https://www.ft.com/myaccount/personal-details"
+						target="_blank"
+						rel="noopener noreferrer"
+						data-trackable="yourAccount"
+					>
+						account settings
+					</a>{' '}
+					to view or edit your account. If you need to get in touch call us on{' '}
+					<a href="tel:+442077556248" className="ncf__link ncf__link--external">
+						+44 20 7755 6248
+					</a>
+					. Or{' '}
+					<a
+						className="ncf__link ncf__link--external"
+						href="https://help.ft.com/contact/"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						contact us
+					</a>{' '}
+					for additional support.
+				</p>
+			</div>
+		</div>
+	);
+}
+
+SevenDayPassExperimentConfirmation.propTypes = {
+	offerName: PropTypes.string.isRequired,
+	details: PropTypes.arrayOf(
+		PropTypes.shape({
+			title: PropTypes.string.isRequired,
+			data: PropTypes.string.isRequired,
+		})
+	),
+};

--- a/components/seven-day-pass-experiment-confirmation.stories.js
+++ b/components/seven-day-pass-experiment-confirmation.stories.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { SevenDayPassExperimentConfirmation } from './seven-day-pass-experiment-confirmation';
+
+export default {
+	title: '7-day pass experiment confirmation',
+	component: SevenDayPassExperimentConfirmation,
+	argTypes: {
+		details: { control: 'array' },
+		offerType: { control: 'string' },
+		offerName: { control: 'string' },
+	},
+};
+
+export const Basic = (args) => <SevenDayPassExperimentConfirmation {...args} />;
+Basic.args = {
+	offerType: 'Premium',
+	details: [
+		{
+			title: 'End Date',
+			data: 'September 18, 2023',
+		},
+		{
+			title: 'One-time payment',
+			data: '£1.99',
+		},
+		{
+			title: 'Payment method',
+			data: 'Credit / Debit Card',
+		},
+	],
+	offerName: '7-day pass',
+	subscriptionAmount: '£1.99',
+};


### PR DESCRIPTION
RS-310

### Description
This PR updates various parts of the n-conversion-forms and adds a new component to facilitate the subscribe journey for a 7-day pass.

The 7-day pass is an experiment to gauge user's propensity to pay for a single-term 7-day pass to FT content. However, it is currently not possible to create such an offer and corresponding subscription.

Therefore we will be presenting the offer as granting 7 days' access and upon payment will reveal to the user that they have actually been granted one month's access (lucky them!). In the background (in work done in next-subscribe), the subscription will be cancelled to prevent recurring payments, thereby creating the illusion of a single-term subscription. 

These changes are **short-term** — they will be reverted on/around 11 Sep 2023 because this offer cannot remain active after this date owing to the class it would cause with the H2 (second half of year) sale when the £1 trial offer is heavily promoted. Given these circumstances we hope that these admittedly dirty and somewhat hacky changes may be acceptable.

### Ticket
- [RS-310: Customisation of the payment terms component on the subscription form](https://financialtimes.atlassian.net/jira/software/c/projects/RS/boards/1547?modal=detail&selectedIssue=RS-310)

### Release version
This PR adds functionality in a backward compatible manner so I would propose releasing these changes as a minor release.

### Related PRs:
- https://github.com/Financial-Times/next-subscribe/pull/2617
- https://github.com/Financial-Times/n-membership-sdk/pull/640
- https://github.com/Financial-Times/next-profile/pull/1467

### Screenshots

These screenshots are taken from next-subscribe consuming these changes, as well as these n-membership-sdk [changes](https://github.com/Financial-Times/n-membership-sdk/pull/640).

N.B. The test environment offer ID is `ae49646a-087f-7af2-5896-4645bc6c1566`

#### Access:
- `/buy/offer/ae49646a-087f-7af2-5896-4645bc6c1566/access`

| Before | After |
| ----- | ----- |
|![Screenshot 2023-08-29 at 14 46 58](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/18d23716-5176-4180-9f5c-e9de2fa46d39)|![Screenshot 2023-08-29 at 09 39 56](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/41ebe541-835f-41a3-bd75-e4007a45d775)|

---

#### Account:
- `/buy/offer/ae49646a-087f-7af2-5896-4645bc6c1566/access` (for anonymous users)

| Before | After |
| ----- | ----- |
|![Screenshot 2023-08-29 at 14 47 58](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/51f94d0d-dbdb-495b-8a88-d498ea6cde54)|![Screenshot 2023-08-29 at 09 40 13](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/f2a83a7e-e9f7-44e0-af1b-d6fb8562ff00)|

---

#### Account:
- `/buy/offer/ae49646a-087f-7af2-5896-4645bc6c1566/registered` (for registered users)

| Before | After |
| ----- | ----- |
|![Screenshot 2023-08-29 at 14 50 58](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/9ec87254-4ce4-451e-9251-17392420096d)|![account](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/7026f21b-996c-48c1-b9cf-c896ed0195c6)|

---

#### Payment:
- `/buy/offer/ae49646a-087f-7af2-5896-4645bc6c1566/payment`
- top of component
- see changes in `PackageChange` and `PaymentTerm` components

| Before | After |
| ----- | ----- |
|![Screenshot 2023-08-29 at 14 52 01](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/5fc3faef-28fd-41cf-8b4f-7e6c83826abc)|![Screenshot 2023-08-29 at 09 17 09](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/923094a2-d95e-4ac2-bbe4-d9b4a4909d25)|

---

#### Payment:
- `/buy/offer/ae49646a-087f-7af2-5896-4645bc6c1566/registered`
- bottom of component
- see changes in Terms & Conditions in `AcceptTermsSubscription` component

| Before | After |
| ----- | ----- |
|![Screenshot 2023-08-29 at 14 52 32](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/fa853485-4a4d-4145-b626-0f24a8bfc214)|![Screenshot 2023-08-29 at 12 49 38](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/0d812c2f-3c27-4fa0-8f50-0f10816eef38)|

---

#### Confirmation:
- `/buy/offer/ae49646a-087f-7af2-5896-4645bc6c1566/confirmation?subscriptionNumber={subscriptionNumber}&paymentType=creditcard`
- top of component
- see new `SevenDayPassExperimentConfirmation` component

| Before (`LiteSubConfirmation`) | After (`SevenDayPassExperimentConfirmation`) |
| ----- | ----- |
|![Screenshot 2023-08-29 at 15 34 29](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/700ca7b6-5988-4559-9ebd-8ecbb30f5625)|![Screenshot 2023-08-29 at 12 51 36](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/97ca9b2c-59df-4970-ab87-4d6da02d8532)|

---

#### Confirmation:
- `/buy/offer/ae49646a-087f-7af2-5896-4645bc6c1566/confirmation?subscriptionNumber={subscriptionNumber}&paymentType=creditcard`
- bottom of component
- see new `SevenDayPassExperimentConfirmation` component

| Before (`LiteSubConfirmation`) | After (`SevenDayPassExperimentConfirmation`) |
| ----- | ----- |
|![Screenshot 2023-08-29 at 15 39 20](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/a782c774-2f10-4159-8f92-22c0e3c3bcdf)|![Screenshot 2023-08-29 at 09 20 07](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/20404eb6-7529-4516-bfd2-abc2525bb873)|

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [x] **Product Review** ran past the product owner
