### PR TITLE
Fix deployment of Storybook in CI workflow

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -19,6 +19,7 @@ jobs:
           persist-credentials: false
       - run: git config --global url."https://${{ secrets.NEXT_USER_PAT }}@github.com/".insteadOf ssh://git@github.com/
       - run: npm install -g npm@7.24.2
+      - run: npm install
       - run: npm run build-storybook
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -19,7 +19,6 @@ jobs:
           persist-credentials: false
       - run: git config --global url."https://${{ secrets.NEXT_USER_PAT }}@github.com/".insteadOf ssh://git@github.com/
       - run: npm install -g npm@7.24.2
-      - run: make install
       - run: npm run build-storybook
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
### Description
This PR fixes the failing deployment of Storybook owing to its usage of `make install` — see: https://github.com/Financial-Times/n-conversion-forms/actions/runs/6049500710/job/16420507328

```
Run make install
make: *** No rule to make target 'install'.  Stop.
Error: Process completed with exit code 2.
```

The `make` commands were removed in the previous PR, which migration this app to dotcom-tool-kit: https://github.com/Financial-Times/n-conversion-forms/pull/752

### Ticket
N/A

### Screenshots
N/A

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
