### PR TITLE
Upgrade Node.js version used in Storybook deployment

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -13,12 +13,12 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18.x
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
       - run: git config --global url."https://${{ secrets.NEXT_USER_PAT }}@github.com/".insteadOf ssh://git@github.com/
-      - run: npm install -g npm@7.24.2
+      - run: npm install -g npm@9.6.7
       - run: npm install
       - run: npm run build-storybook
       - name: Deploy


### PR DESCRIPTION
### Description
This PR https://github.com/Financial-Times/n-conversion-forms/pull/753 attempted to fix the deployment of Storybook, though it did not fail owing to this error: https://github.com/Financial-Times/n-conversion-forms/actions/runs/6071085286/job/16468398553.

This [Stack Overflow question](https://stackoverflow.com/questions/72866798/node-openssl-legacy-provider-is-not-allowed-in-node-options) indicates that upgrading to Node.js v18 with npm v9 and retaining `NODE_OPTIONS=--openssl-legacy-provider` in the command worked for them so I figure it is worth a try.

### Ticket
N/A

### Screenshots
N/A

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
