### PR TITLE
Apply changes for email newsletter products

### DIFF
--- a/components/__snapshots__/confirmation.spec.js.snap
+++ b/components/__snapshots__/confirmation.spec.js.snap
@@ -111,6 +111,117 @@ exports[`Confirmation renders appropriately if is trial 1`] = `
 </div>
 `;
 
+exports[`Confirmation renders appropriately if newsletterScheduleExplainer is not supplied 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <p class="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">
+      You are now subscribed to:
+    </p>
+    <h1 class="ncf__header ncf__header--confirmation">
+      Offer text
+    </h1>
+  </div>
+  <p class="ncf__paragraph">
+    We’ve sent confirmation to your email. Make sure you check your spam folder if you don’t receive it.
+  </p>
+  <p class="ncf__paragraph">
+    Here’s a summary of your Offer text subscription:
+  </p>
+  <div class="ncf__headed-paragraph">
+    <h3 class="ncf__header">
+      Something not right?
+    </h3>
+    <p class="ncf__paragraph">
+      Go to your
+      <a class="ncf__link ncf__link--external"
+         href="https://www.ft.com/myaccount/personal-details"
+         target="_blank"
+         rel="noopener noreferrer"
+         data-trackable="yourAccount"
+      >
+        account settings
+      </a>
+      to view or edit your account. If you need to get in touch call us on
+      <a href="tel:+442077556248"
+         class="ncf__link ncf__link--external"
+      >
+        +44 (0) 207 755 6248
+      </a>
+      . Or contact us for additional support.
+    </p>
+  </div>
+  <p class="ncf__paragraph">
+    We will automatically renew your subscription using the payment method provided unless you cancel before your renewal date. See our
+    <a class="ncf__link ncf__link--external"
+       href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+       target="_top"
+       rel="noopener"
+    >
+      Terms &amp; Conditions
+    </a>
+    for details on how to cancel.
+  </p>
+</div>
+`;
+
+exports[`Confirmation renders appropriately if newsletterScheduleExplainer is supplied 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <p class="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">
+      You are now subscribed to:
+    </p>
+    <h1 class="ncf__header ncf__header--confirmation">
+      Offer text
+    </h1>
+  </div>
+  <p class="ncf__paragraph">
+    We’ve sent confirmation to your email. Make sure you check your spam folder if you don’t receive it.
+  </p>
+  You will receive your first newsletter on the next weekday to foo@bar.com
+  <p class="ncf__paragraph">
+    Here’s a summary of your Offer text subscription:
+  </p>
+  <div class="ncf__headed-paragraph">
+    <h3 class="ncf__header">
+      Something not right?
+    </h3>
+    <p class="ncf__paragraph">
+      Go to your
+      <a class="ncf__link ncf__link--external"
+         href="https://www.ft.com/myaccount/personal-details"
+         target="_blank"
+         rel="noopener noreferrer"
+         data-trackable="yourAccount"
+      >
+        account settings
+      </a>
+      to view or edit your account. If you need to get in touch call us on
+      <a href="tel:+442077556248"
+         class="ncf__link ncf__link--external"
+      >
+        +44 (0) 207 755 6248
+      </a>
+      . Or contact us for additional support.
+    </p>
+  </div>
+  <p class="ncf__paragraph">
+    We will automatically renew your subscription using the payment method provided unless you cancel before your renewal date. See our
+    <a class="ncf__link ncf__link--external"
+       href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+       target="_top"
+       rel="noopener"
+    >
+      Terms &amp; Conditions
+    </a>
+    for details on how to cancel.
+  </p>
+</div>
+`;
+
 exports[`Confirmation renders appropriately if nextActionBottom is not supplied 1`] = `
 <div class="ncf ncf__wrapper">
   <div class="ncf__center">

--- a/components/confirmation.jsx
+++ b/components/confirmation.jsx
@@ -14,6 +14,7 @@ export function Confirmation({
 	directDebitMandateUrl = null,
 	nextActionTop = null,
 	nextActionBottom = null,
+	newsletterScheduleExplainer = null,
 }) {
 	const containerDivProps = {
 		className: 'ncf ncf__wrapper',
@@ -83,6 +84,9 @@ export function Confirmation({
 			) : (
 				''
 			)}
+
+			{newsletterScheduleExplainer}
+
 			<p className="ncf__paragraph">
 				Here’s a summary of your {offer} subscription:
 			</p>
@@ -146,4 +150,5 @@ Confirmation.propTypes = {
 	directDebitMandateUrl: PropTypes.string,
 	nextActionTop: PropTypes.node,
 	nextActionBottom: PropTypes.node,
+	newsletterScheduleExplainer: PropTypes.node,
 };

--- a/components/confirmation.spec.js
+++ b/components/confirmation.spec.js
@@ -6,6 +6,9 @@ expect.extend(expectToRenderCorrectly);
 const OFFER_TEXT = 'Offer text';
 const nextActionTop = ['i might take you to tailor your experience'];
 const nextActionBottom = ['i might take you to the ePaper'];
+const newsletterScheduleExplainer = [
+	'You will receive your first newsletter on the next weekday to foo@bar.com',
+];
 
 describe('Confirmation', () => {
 	it('renders with default props', () => {
@@ -89,6 +92,18 @@ describe('Confirmation', () => {
 	});
 
 	it('renders appropriately if nextActionBottom is not supplied', () => {
+		const props = { offer: OFFER_TEXT };
+
+		expect(Confirmation).toRenderCorrectly(props);
+	});
+
+	it('renders appropriately if newsletterScheduleExplainer is supplied', () => {
+		const props = { offer: OFFER_TEXT, newsletterScheduleExplainer };
+
+		expect(Confirmation).toRenderCorrectly(props);
+	});
+
+	it('renders appropriately if newsletterScheduleExplainer is not supplied', () => {
 		const props = { offer: OFFER_TEXT };
 
 		expect(Confirmation).toRenderCorrectly(props);

--- a/components/confirmation.stories.js
+++ b/components/confirmation.stories.js
@@ -38,6 +38,13 @@ const nextActionBottom = (
 	</div>
 );
 
+const newsletterScheduleExplainer = (
+	<p className="ncf__paragraph">
+		You will receive your first newsletter on the next weekday to{' '}
+		<strong>foo@bar.com</strong>.
+	</p>
+);
+
 export const Basic = (args) => <Confirmation {...args} />;
 Basic.args = {
 	offer: 'Premium Digital',
@@ -55,4 +62,5 @@ Basic.args = {
 	],
 	nextActionTop,
 	nextActionBottom,
+	newsletterScheduleExplainer,
 };


### PR DESCRIPTION
RS-275

### Description
This PR allows the `Confirmation` component to receive a `newsletterScheduleExplainer` prop, which is a node that contains text like the below when the user subscribes to an email newsletter product:

> You will receive your first newsletter on the next weekday to n-conversion-forms@1694502556888@ftqa.org.

### Ticket
- [RS-275: Modifications to next-subscribe payment flow](https://financialtimes.atlassian.net/jira/software/c/projects/RS/boards/1547?modal=detail&selectedIssue=RS-275)

### Dependent PRs
- https://github.com/Financial-Times/next-subscribe/pull/2630

### Screenshots

N.B. The offer names will be changed upstream, meaning the text displayed will be subject to the following changes:
- "Niches Standard 1 - Inside Politics" -> "Inside Politics email newsletter"
- "Niches Premium 1 - Unhedged" -> "Unhedged email newsletter"

#### Inside Politics
| Before | After |
| ------ | ----- |
|![before-inside-politics-confirmation](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/6d64c40a-ac7a-4346-bd09-a92143c8fd44)|![after-inside-politics-confirmation](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/1646abb4-4a1a-4e3f-8e86-80796d0707e1)|

#### Unhedged
| Before | After |
| ------ | ----- |
|![before-unhedged-confirmation](https://github.com/Financial-Times/next-subscribe/assets/10484515/4806c578-c03e-410a-9cef-d509f9fbb57a)|![after-unhedged-confirmation](https://github.com/Financial-Times/next-subscribe/assets/10484515/ac9352d0-fd6e-459a-b299-942a0eb73b51)|

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [x] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
