### PR TITLE
ACQ-2398: Change: Home delivery to Hand delivery 

### DIFF
--- a/components/__snapshots__/delivery-option.spec.js.snap
+++ b/components/__snapshots__/delivery-option.spec.js.snap
@@ -85,7 +85,7 @@ exports[`DeliveryOption renders with a context of being single 1`] = `
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
         <span class="ncf__delivery-option__title o-forms-title__main">
-          Home delivery
+          Hand delivery
         </span>
         <div class="ncf__delivery-option__description">
           Free delivery to your home or office before 7am.
@@ -181,7 +181,7 @@ exports[`DeliveryOption renders with minimum mandatory props 1`] = `
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
         <span class="ncf__delivery-option__title o-forms-title__main">
-          Home delivery
+          Hand delivery
         </span>
         <div class="ncf__delivery-option__description">
           Free delivery to your home or office before 7am.
@@ -247,7 +247,7 @@ exports[`DeliveryOption renders without unrecognised delivery options 1`] = `
       >
       <span class="o-forms-input__label ncf__delivery-option__label">
         <span class="ncf__delivery-option__title o-forms-title__main">
-          Home delivery
+          Hand delivery
         </span>
         <div class="ncf__delivery-option__description">
           Free delivery to your home or office before 7am.

--- a/utils/delivery-option-messages.js
+++ b/utils/delivery-option-messages.js
@@ -114,7 +114,7 @@ const deliveryOptionMessages = [
 		deliveryOnPublicationDate: false,
 		flightMarket: true,
 		country: [printRegions.cemeaV1, printRegions.cemeaV2, printRegions.apac],
-		title: 'Hand Delivery',
+		title: 'Hand delivery',
 		description:
 			'Enjoy the delivery of the newspaper to your home or office address. Please note we fly the newspaper to your location which means delivery is subject to flight delays/cancellations outside of the FT’s control. In those circumstances, your newspaper will be delivered the next delivery day. Please also be aware that your FT weekend will be delivered on Sunday.',
 	},
@@ -127,7 +127,7 @@ const deliveryOptionMessages = [
 		distributorType: HAND_DELIVERY,
 		deliveryOnPublicationDate: true,
 		flightMarket: true,
-		title: 'Hand Delivery',
+		title: 'Hand delivery',
 		country: [printRegions.cemeaV1, printRegions.cemeaV2, printRegions.apac],
 		description:
 			'Enjoy delivery of the newspaper to your home or office address. FT Weekend will be delivered on Sunday or Monday.',
@@ -142,7 +142,7 @@ const deliveryOptionMessages = [
 		deliveryOnPublicationDate: true,
 		flightMarket: false,
 		country: [printRegions.cemeaV1, printRegions.cemeaV2, printRegions.apac],
-		title: 'Hand Delivery',
+		title: 'Hand delivery',
 		description:
 			'Enjoy delivery of the newspaper daily to your home or office address on the day of publication.',
 	},

--- a/utils/delivery-option-messages.js
+++ b/utils/delivery-option-messages.js
@@ -31,7 +31,7 @@ const UKDeliveryOptions = {
 			'13-week voucher pack delivered quarterly and redeemable at retailers nationwide. COVID-19 - make sure your preferred newsagent or retailer is open and/or delivering before you select this option.',
 	},
 	HD: {
-		title: 'Hand Delivery',
+		title: 'Hand delivery',
 		description: 'Free delivery to your home or office before 7am.',
 	},
 	EV: {

--- a/utils/delivery-option-messages.js
+++ b/utils/delivery-option-messages.js
@@ -31,7 +31,7 @@ const UKDeliveryOptions = {
 			'13-week voucher pack delivered quarterly and redeemable at retailers nationwide. COVID-19 - make sure your preferred newsagent or retailer is open and/or delivering before you select this option.',
 	},
 	HD: {
-		title: 'Home delivery',
+		title: 'Hand Delivery',
 		description: 'Free delivery to your home or office before 7am.',
 	},
 	EV: {

--- a/utils/delivery-option-messages.spec.js
+++ b/utils/delivery-option-messages.spec.js
@@ -140,7 +140,7 @@ describe('Find Custom Delivery Option', () => {
 			stubOption.deliveryOnPublicationDate = false;
 			stubOption.mailDelivery = false;
 			const expected = {
-				title: 'Hand Delivery',
+				title: 'Hand delivery',
 				description:
 					'Enjoy the delivery of the newspaper to your home or office address. Please note we fly the newspaper to your location which means delivery is subject to flight delays/cancellations outside of the FT’s control. In those circumstances, your newspaper will be delivered the next delivery day. Please also be aware that your FT weekend will be delivered on Sunday.',
 			};


### PR DESCRIPTION
### Description
Hello, could someone confirm whether the displayName field value is used for anything on the MMA (perhaps in the Delivery Address tab) from the following endpoint:
https://api.ft.com/newspaper/fulfilment/options

We have a request to change the value from "displayName": "Home Delivery" to "displayName": "Hand Delivery"

As a result on the acq side => print flow - delivery step - the “Home delivery” option will now be called “Hand delivery”. 
https://financialtimes.slack.com/archives/CSVRXFV6F/p1694762784250909
### Ticket
(https://financialtimes.atlassian.net/browse/ACQ-2398)
### Screenshots

![Uploading Screenshot 2023-09-18 at 17.13.10.png…]()



### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
