### PR TITLE
ACQ-2416: Remove Covid information on the Paper Vouchers

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,5 @@
 /dist
 /.eslintrc.js
 /public
+secret-squirrel.js
+secret-squirrel.cjs

--- a/components/__snapshots__/delivery-option.spec.js.snap
+++ b/components/__snapshots__/delivery-option.spec.js.snap
@@ -70,7 +70,7 @@ exports[`DeliveryOption renders with a context of being single 1`] = `
           Paper vouchers
         </span>
         <div class="ncf__delivery-option__description">
-          13-week voucher pack delivered quarterly and redeemable at retailers nationwide. COVID-19 - make sure your preferred newsagent or retailer is open and/or delivering before you select this option.
+          13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
         </div>
       </span>
     </label>
@@ -166,7 +166,7 @@ exports[`DeliveryOption renders with minimum mandatory props 1`] = `
           Paper vouchers
         </span>
         <div class="ncf__delivery-option__description">
-          13-week voucher pack delivered quarterly and redeemable at retailers nationwide. COVID-19 - make sure your preferred newsagent or retailer is open and/or delivering before you select this option.
+          13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
         </div>
       </span>
     </label>
@@ -232,7 +232,7 @@ exports[`DeliveryOption renders without unrecognised delivery options 1`] = `
           Paper vouchers
         </span>
         <div class="ncf__delivery-option__description">
-          13-week voucher pack delivered quarterly and redeemable at retailers nationwide. COVID-19 - make sure your preferred newsagent or retailer is open and/or delivering before you select this option.
+          13-week voucher pack delivered quarterly and redeemable at retailers nationwide.
         </div>
       </span>
     </label>

--- a/components/accept-terms-subscription.stories.js
+++ b/components/accept-terms-subscription.stories.js
@@ -24,28 +24,28 @@ PrintProductTrial.args = {
 	isTrial: true,
 };
 
-export const isSingleTerm = (args) => <AcceptTermsSubscription {...args} />;
+export const IsSingleTerm = (args) => <AcceptTermsSubscription {...args} />;
 
-isSingleTerm.args = {
+IsSingleTerm.args = {
 	isSingleTerm: true,
 };
 
-export const isTransition = (args) => <AcceptTermsSubscription {...args} />;
+export const IsTransition = (args) => <AcceptTermsSubscription {...args} />;
 
-isTransition.args = {
+IsTransition.args = {
 	isTransition: true,
 };
 
-export const transitionType = (args) => <AcceptTermsSubscription {...args} />;
+export const TransitionType = (args) => <AcceptTermsSubscription {...args} />;
 
-transitionType.args = {
+TransitionType.args = {
 	transitionType: true,
 };
 
-export const isDeferredBilling = (args) => (
+export const IsDeferredBilling = (args) => (
 	<AcceptTermsSubscription {...args} />
 );
 
-isDeferredBilling.args = {
+IsDeferredBilling.args = {
 	isDeferredBilling: true,
 };

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -1,15 +1,16 @@
 module.exports = {
 	files: {
 		allow: [],
-		allowOverrides: [],
+		allowOverrides: []
 	},
 	strings: {
 		deny: [],
 		denyOverrides: [
-			'createB2cDiscountCopy',
-			'test@example\\.com', // components/__snapshots__/confirmation.spec.js.snap:544|606, components/__snapshots__/email.spec.js.snap:154|186, components/__snapshots__/registration-confirmation.spec.js.snap:15|62, components/confirmation.spec.js:29, components/email.spec.js:30, components/registration-confirmation.spec.js:21, docs/PARTIALS.md:106|357, test/partials/confirmation.spec.js:12, test/partials/registration-confirmation.spec.js:12, test/utils/email.spec.js:148|159|168|178|188
-			'd19dc7a6-c33b-4931-9a7e-4a74674da29a', // components/__snapshots__/licence-confirmation.spec.js.snap:28|62, components/licence-confirmation.spec.js:44
-			'addressLine3MaxLength', // components/delivery-address-map.jsx:63|138|198|132
-		],
-	},
+			'foo@bar\\.com', // components/__snapshots__/confirmation.spec.js.snap:184, components/confirmation.spec.js:10, components/confirmation.stories.js:44
+			'test@example\\.com', // components/__snapshots__/confirmation.spec.js.snap:529, components/__snapshots__/email.spec.js.snap:90, components/__snapshots__/registration-confirmation.spec.js.snap:12, components/confirmation.spec.js:33, components/email.spec.js:23, components/registration-confirmation.spec.js:14, utils/email.spec.js:153|165|176|190|204
+			'd19dc7a6\\x2dc33b\\x2d4931\\x2d9a7e\\x2d4a74674da29a', // components/__snapshots__/licence-confirmation.spec.js.snap:28, components/licence-confirmation.spec.js:37
+			'addressLine3MaxLength', // components/delivery-address-map.jsx:63|138|198, components/delivery-address.jsx:132
+			'createB2cDiscountCopy' // components/payment-term.jsx:196|308
+		]
+	}
 };

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -1,7 +1,7 @@
 module.exports = {
 	files: {
 		allow: [],
-		allowOverrides: []
+		allowOverrides: [],
 	},
 	strings: {
 		deny: [],
@@ -10,7 +10,7 @@ module.exports = {
 			'test@example\\.com', // components/__snapshots__/confirmation.spec.js.snap:529, components/__snapshots__/email.spec.js.snap:90, components/__snapshots__/registration-confirmation.spec.js.snap:12, components/confirmation.spec.js:33, components/email.spec.js:23, components/registration-confirmation.spec.js:14, utils/email.spec.js:153|165|176|190|204
 			'd19dc7a6\\x2dc33b\\x2d4931\\x2d9a7e\\x2d4a74674da29a', // components/__snapshots__/licence-confirmation.spec.js.snap:28, components/licence-confirmation.spec.js:37
 			'addressLine3MaxLength', // components/delivery-address-map.jsx:63|138|198, components/delivery-address.jsx:132
-			'createB2cDiscountCopy' // components/payment-term.jsx:196|308
-		]
-	}
+			'createB2cDiscountCopy', // components/payment-term.jsx:196|308
+		],
+	},
 };

--- a/utils/delivery-option-messages.js
+++ b/utils/delivery-option-messages.js
@@ -28,7 +28,7 @@ const UKDeliveryOptions = {
 	PV: {
 		title: 'Paper vouchers',
 		description:
-			'13-week voucher pack delivered quarterly and redeemable at retailers nationwide. COVID-19 - make sure your preferred newsagent or retailer is open and/or delivering before you select this option.',
+			'13-week voucher pack delivered quarterly and redeemable at retailers nationwide.',
 	},
 	HD: {
 		title: 'Hand delivery',


### PR DESCRIPTION
### Description
Remove Covid information on the Paper Vouchers

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-2416

### Screenshots

| Before | After |
| ------ | ----- |
|        |       |

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
