### PR TITLE
Accommodate 'Termed' subscriptionTermType

### DIFF
--- a/components/accept-terms-subscription.jsx
+++ b/components/accept-terms-subscription.jsx
@@ -10,6 +10,7 @@ export function AcceptTermsSubscription({
 	isPrintProduct = false,
 	isSingleTerm = false,
 	is7DayPassExperiment = false,
+	isTermedSubscriptionTermType = false,
 	isTransition = false,
 	transitionType = null,
 	isDeferredBilling = false,
@@ -58,6 +59,52 @@ export function AcceptTermsSubscription({
 							collected at the time of checkout, and cancelling at any point
 							(whether before or after the 14-day period) will not entitle you
 							to a refund.
+						</span>
+					</li>
+					<li>
+						<span className="terms-transition">
+							Please see here for the complete{' '}
+							<a
+								className="ncf__link--external"
+								href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								Terms &amp; Conditions
+							</a>
+							.
+						</span>
+					</li>
+				</ul>
+				<label className={labelClassName} htmlFor="termsAcceptance">
+					<input {...inputProps} />
+					<span className="o-forms-input__label">
+						I agree to the above terms &amp; conditions.
+					</span>
+					<p className="o-forms-input__error">
+						Please accept our terms &amp; conditions
+					</p>
+				</label>
+			</div>
+		);
+	}
+
+	if (isTermedSubscriptionTermType) {
+		return (
+			<div {...divProps}>
+				<ul className="o-typography-list ncf__accept-terms-list">
+					<li>
+						<span className="terms-transition terms-transition--immediate">
+							I give consent for the chosen payment method to be charged automatically.
+						</span>
+					</li>
+					<li>
+						<span className="terms-transition terms-transition--immediate">
+							By placing your order subject to the Terms & Conditions (save for section 2) referred to
+							below, you are waiving your statutory right to cancel our contract within 14 days of
+							payment. Your payment is a one-time payment collected at the time of checkout, and
+							unsubscribing or cancelling at any point (whether before or after the 14-day period)
+							will not entitle you to a refund.
 						</span>
 					</li>
 					<li>
@@ -261,6 +308,7 @@ AcceptTermsSubscription.propTypes = {
 	isPrintProduct: PropTypes.bool,
 	isSingleTerm: PropTypes.bool,
 	is7DayPassExperiment: PropTypes.bool,
+	isTermedSubscriptionTermType: PropTypes.bool,
 	isTransition: PropTypes.bool,
 	transitionType: PropTypes.string,
 	isDeferredBilling: PropTypes.bool,

--- a/components/accept-terms-subscription.spec.js
+++ b/components/accept-terms-subscription.spec.js
@@ -70,6 +70,17 @@ describe('AcceptTermsSubscription', () => {
 		expect(transitionTerms.exists()).toBe(true);
 	});
 
+	it('renders the transition terms when isTermedSubscriptionTermType prop is true', () => {
+		const props = {
+			isTermedSubscriptionTermType: true,
+		};
+
+		const component = mount(<AcceptTermsSubscription {...props} />);
+
+		const transitionTerms = component.find('.terms-transition');
+		expect(transitionTerms.exists()).toBe(true);
+	});
+
 	it('does not render the transition terms when transitionType prop is null', () => {
 		const props = {
 			transitionType: null,

--- a/components/accept-terms-subscription.stories.js
+++ b/components/accept-terms-subscription.stories.js
@@ -30,6 +30,14 @@ IsSingleTerm.args = {
 	isSingleTerm: true,
 };
 
+export const TermedSubscriptionTermType = (args) => (
+	<AcceptTermsSubscription {...args} />
+);
+
+TermedSubscriptionTermType.args = {
+	isTermedSubscriptionTermType: true,
+};
+
 export const IsTransition = (args) => <AcceptTermsSubscription {...args} />;
 
 IsTransition.args = {

--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -16,12 +16,13 @@ export function PaymentTerm({
 	optionsInARow = false,
 	billingCountry = '',
 	is7DayPassExperiment = false,
+	isTermedSubscriptionTermType = false,
 }) {
 	/**
 	 * Compute monthly price for given term name
 	 * @param {number} amount price in number format
 	 * @param {string} currency country id of the currency
-	 * @param {string} period PxY (yearly) or PxM (montly) where x is the amount of years/months
+	 * @param {string} period (expressed in IS0 8601 duration format): PxY (yearly) or PxM (montly) where x is the amount of years/months
 	 * @returns {string}
 	 */
 	const getMontlyPriceFromPeriod = (amount, currency, period) => {
@@ -33,13 +34,22 @@ export function PaymentTerm({
 	/**
 	 * returns period converted to time if found
 	 * otherwise returns empty string to avoid show information not mapped
-	 * @param {string} period PxY (yearly) or PxM (montly) where x is the amount of years/months
+	 * @param {string} period (expressed in IS0 8601 duration format): PxY (yearly), PxM (montly), or PxW, where x is the amount of years/months/weeks
 	 * @returns {string}
 	 */
 	const getTimeFromPeriod = (period) => {
-		const freq =
-			period.substring(period.length - 1) === 'Y' ? 'years' : 'months';
+		const periodUnitCodeToWordMap = {
+			Y: 'years',
+			M: 'months',
+			W: 'weeks',
+		};
+
+		const periodUnitCode = period.substring(period.length - 1);
+
+		const freq = periodUnitCodeToWordMap[periodUnitCode] || '';
+
 		const amount = period.substring(1, period.length - 1);
+
 		return period ? `${amount} ${freq}` : '';
 	};
 
@@ -177,6 +187,7 @@ export function PaymentTerm({
 					</span>
 				),
 			renewsText: (renewalPeriod) =>
+				!isTermedSubscriptionTermType &&
 				Boolean(renewalPeriod) && (
 					<p className="ncf__payment-term__renews-text">
 						Renews every {renewalPeriod} unless cancelled
@@ -371,7 +382,7 @@ export function PaymentTerm({
 
 			{showLegal && (
 				<div className="ncf__payment-term__legal">
-					{isFixedTermOffer ? (
+					{isTermedSubscriptionTermType || isFixedTermOffer ? (
 						<p>
 							Find out more about our cancellation policy in our{' '}
 							<a
@@ -443,6 +454,7 @@ PaymentTerm.propTypes = {
 		})
 	),
 	isFixedTermOffer: PropTypes.bool,
+	isTermedSubscriptionTermType: PropTypes.bool,
 	offerDisplayName: PropTypes.string,
 	showLegal: PropTypes.bool,
 	largePrice: PropTypes.bool,

--- a/components/payment-term.spec.js
+++ b/components/payment-term.spec.js
@@ -184,6 +184,32 @@ describe('PaymentTerm', () => {
 		});
 	});
 
+	describe('given isTermedSubscriptionTermType is true', () => {
+		const options = [
+			{
+				name: '8 weeks',
+				price: '£19.00',
+				amount: '19.00',
+				value: 'P8W',
+			},
+		];
+		const wrapper = shallow(
+			<PaymentTerm options={options} isTermedSubscriptionTermType={true} />
+		);
+
+		it('renders subscription term as title', () => {
+			expect(wrapper.find('.ncf__payment-term__title').text()).toMatch(
+				'8 weeks'
+			);
+		});
+
+		it('renders description text that reflects that the termed subscription requires a single payment that expresses the per duration cost for shorter durations', () => {
+			expect(wrapper.find('.ncf__payment-term__description').text()).toContain(
+				'Single £19.00 paymentThat’s equivalent to GBP9.50 per month'
+			);
+		});
+	});
+
 	describe('getDisplayName', () => {
 		const baseOptions = {
 			name: 'monthly',

--- a/components/payment-term.stories.js
+++ b/components/payment-term.stories.js
@@ -129,6 +129,25 @@ SevenDayPassExperimentOffer.args = {
 	offerDisplayName: '7-day pass',
 };
 
+export const TermedSubscriptionTermType = (args) => (
+	<div className="ncf">
+		<Fieldset>
+			<PaymentTerm {...args} />
+		</Fieldset>
+	</div>
+);
+TermedSubscriptionTermType.args = {
+	options: [
+		{
+			name: '8 weeks',
+			price: '£19.00',
+			amount: '19.00',
+			value: 'P8W',
+		},
+	],
+	isTermedSubscriptionTermType: true,
+};
+
 export const RenewOffers = (args) => (
 	<div className="ncf">
 		<Fieldset>


### PR DESCRIPTION
### Description
This PR accommodates the introduction of single-term (i.e. non-recurring) subscriptions.

- **Single-term** subscriptions have a term type value of **'Termed'**
- **Recurring** subscriptions have a term type value of **'Evergreen'**

The first offer to use this 'Termed' subscription type is Sort Your Financial Life Out by Claer Barrett, a weekly 8-part newsletter course. The newsletter will be freely available to existing standard and premium FT.com subscribers, and is offered to non-subscribers as an eight-week standard FT.com subscription which will auto-subscribe them to the newsletter upon purchase at the cost of £19.

This PR does not address the specifics of the above offer (which will be covered in separate PRs), only the requirements to facilitate subscriptions to single-term subscriptions, regardless of the offer being purchased.

### Ticket
- [RS-510: Finance course user sign-up journey](https://financialtimes.atlassian.net/jira/software/c/projects/RS/boards/1547?selectedIssue=RS-510)

### Dependent PRs
- https://github.com/Financial-Times/next-subscribe/pull/2695

### Related PRs
- https://github.com/Financial-Times/n-membership-sdk/pull/663

### Screenshots
N.B.
- The below screenshots show the combined effect of the changes made in this PR as well as the corresponding ones in next-subscribe and n-membership-sdk
- Where a repository name is given in one of the bullet points, it is to describe where the key changes were (or would need to be) made

#### Access
No changes, i.e. 'Before' and 'After' shots are the same

| Before | After |
| ------ | ------ |
|![access-before-and-after](https://github.com/Financial-Times/next-subscribe/assets/10484515/0592ba9f-d9d8-40ff-8184-67d56b426050)|![access-before-and-after](https://github.com/Financial-Times/next-subscribe/assets/10484515/0592ba9f-d9d8-40ff-8184-67d56b426050)|

#### Account
No changes, i.e. 'Before' and 'After' shots are the same

| Before | After |
| ------ | ------ |
|![account-before-and-after](https://github.com/Financial-Times/next-subscribe/assets/10484515/ef8a18f6-7bd3-429c-9326-8ee09f3589da)|![account-before-and-after](https://github.com/Financial-Times/next-subscribe/assets/10484515/ef8a18f6-7bd3-429c-9326-8ee09f3589da)|

#### Payment (top half of page)
- n-conversion-forms: "8 months" has been changed to "8 weeks", which was a modification to enable the display logic to handle durations expressed in weeks (because weeks-long terms are likely single-term subscription durations); currently it only handles years and months by looking for a duration expressed in years else defaulting to months
- n-conversion-forms: Admittedly, the "That's equivalent to **GBP5.00** per month" text seems redundant when the calculation is so simple, but this is circumstantial because of the offer; other single-term subscription offers may be for a longer duration where this text becomes useful, and so the basis for displaying it should be the subscription duration rather than whether it is single-term or recurring (this PR is only concerned with the latter)
- n-conversion-forms: "Renews every {duration} unless cancelled" has been removed because it does not apply to single-term subscriptions
- n-conversion-forms: The default text about cancellation relates to recurring subscriptions which does not apply to single-term subscriptions, and so different text is required here

N.B. The information about whether the offer is 'Termed' or 'Evergreen' appears nested in the offer's `charges` data (in the `subscriptionTerm`), so the data is pulled from the `PaymentViewModel` instance's `paymentTerms`'s `subscriptionTermType` value and applied at the instance's root level as a property called `isTermedSubscriptionTermType`. This provides the basis for display logic for e.g. the text about cancellation, which applies to the overall offer rather than one of its specific charges.

| Before | After |
| ------ | ------ |
|![payment-top-before](https://github.com/Financial-Times/next-subscribe/assets/10484515/bfeba460-739f-4ee6-9903-6afa29412ef2)|![payment-top-after](https://github.com/Financial-Times/next-subscribe/assets/10484515/2a29675d-3d27-4a97-a41c-918122d23b1a)|

#### Payment (bottom half of page)
- n-conversion-forms: The default Terms & Conditions text relates to recurring subscriptions which does not apply to single-term subscriptions, and so different text is required here that relates to single-term subscriptions

| Before | After |
| ------ | ------ |
|![payment-bottom-before](https://github.com/Financial-Times/next-subscribe/assets/10484515/c9b80400-0fa1-45ad-b3db-024e46bd4542)|![payment-bottom-after](https://github.com/Financial-Times/next-subscribe/assets/10484515/84f34001-3beb-4bd7-89cc-2de74991b463)|

#### Confirmation
- next-subscribe: "Renewal date" has been changed to "End date" so that it is relevant to a single-term subscription rather than a recurring subscription
- next-subscribe: "You will be billed from this date" has been removed as it applies to recurring subscriptions but not single-term subscriptions
- next-subscribe: "Payment" has been changed to "One-time payment" to assure users that they will not incur any automatic subsequent charges

N.B. The display logic for this page relies on the `type` value of the rate plan charge from the subscription data object returned by the [Subscription Service](https://biz-ops.in.ft.com/System/subscription-svc), which for recurring subscriptions is 'Recurring'. Counter-logically, for single-term subscriptions, this value is also 'Recurring' 🙃 This is caused by a Salesforce limitation of only being able to apply single-term charges to trials (Slack conversations [here](https://financialtimes.slack.com/archives/C05307V13PT/p1700840985895489?thread_ts=1700467920.984909&cid=C05307V13PT) and [here](https://financialtimes.slack.com/archives/C05307V13PT/p1700468257399159?thread_ts=1700468074.431789&cid=C05307V13PT)), and a explanatory comment has been added to the code that accommodates this anomaly.

| Before | After |
| ------ | ------ |
|![confirmation-before](https://github.com/Financial-Times/next-subscribe/assets/10484515/afa74a03-eba6-42ca-8bb3-3c37813b526e)|![confirmation-after](https://github.com/Financial-Times/next-subscribe/assets/10484515/33dd4676-0c32-418c-940e-730070b8d1ea)|

### TODO (pre-merge)
- [ ] Address whether the default text on the payment page (top) about cancellation needs to have the below changes applied; the former statement becomes untrue with the introduction of single-term subscriptions which are not automatically renewed
  - From: "With **all** subscription types, we will automatically renew your subscription…"
  - To: "With **recurring** subscription types, we will automatically renew your subscription…"

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [ ] **Accessibility** checked for screen readers and contrast
- [x] **Design Review** ran past the designer
- [x] **Product Review** ran past the product owner