### PR TITLE
Upgrading the version of n-common-static-data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "classnames": "2.3.2",
         "fetchres": "1.7.2",
         "lodash.get": "4.4.2",
-        "n-common-static-data": "github:Financial-Times/n-common-static-data#v2.0.0"
+        "n-common-static-data": "github:Financial-Times/n-common-static-data#v2.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.22.15",
@@ -43416,7 +43416,7 @@
     },
     "n-common-static-data": {
       "version": "git+ssh://git@github.com/Financial-Times/n-common-static-data.git#1f1834268907a29c69ad6d22db0e68dd33809dc9",
-      "from": "n-common-static-data@github:Financial-Times/n-common-static-data#v2.0.0"
+      "from": "n-common-static-data@github:Financial-Times/n-common-static-data#v2.1.0"
     },
     "nanoid": {
       "version": "3.3.6",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "classnames": "2.3.2",
     "fetchres": "1.7.2",
     "lodash.get": "4.4.2",
-    "n-common-static-data": "github:Financial-Times/n-common-static-data#v2.0.0"
+    "n-common-static-data": "github:Financial-Times/n-common-static-data#v2.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.15",


### PR DESCRIPTION
### Description
There is a change in n-common-static-data to update demographics positions list. 
New release is here - https://github.com/Financial-Times/n-common-static-data/releases/tag/v2.1.0
This PR uses the new version in n-conversion-forms

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-2495

### Screenshots

| Before | After |
| ------ | ----- |
|        |       |

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
