### PR TITLE
ACQ-2495: bump n-common-static-data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "classnames": "2.3.2",
         "fetchres": "1.7.2",
         "lodash.get": "4.4.2",
-        "n-common-static-data": "github:Financial-Times/n-common-static-data#v2.1.0"
+        "n-common-static-data": "github:Financial-Times/n-common-static-data#v2.2.0"
       },
       "devDependencies": {
         "@babel/core": "^7.22.15",
@@ -43416,7 +43416,7 @@
     },
     "n-common-static-data": {
       "version": "git+ssh://git@github.com/Financial-Times/n-common-static-data.git#1f1834268907a29c69ad6d22db0e68dd33809dc9",
-      "from": "n-common-static-data@github:Financial-Times/n-common-static-data#v2.1.0"
+      "from": "n-common-static-data@github:Financial-Times/n-common-static-data#v2.2.0"
     },
     "nanoid": {
       "version": "3.3.6",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "classnames": "2.3.2",
     "fetchres": "1.7.2",
     "lodash.get": "4.4.2",
-    "n-common-static-data": "github:Financial-Times/n-common-static-data#v2.1.0"
+    "n-common-static-data": "github:Financial-Times/n-common-static-data#v2.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.15",


### PR DESCRIPTION
### Description
Bump n-common-static-data to include the following changes:
https://github.com/Financial-Times/n-common-static-data/releases/tag/v2.2.0

- positions lists should replicate what FT Core uses: https://github.com/Financial-Times/memb-common-value-types/blob/master/src/main/resources/demographics/position.json
- removed legacy code used by swg (disabled years ago)

This change is needed to fix a production issue: https://financialtimes.slack.com/archives/CSVRXFV6F/p1701691948640919

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-2495

### Screenshots

| Before | After |
| ------ | ----- |
|        |       |

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
