### PR TITLE
Accommodate 'Termed' subscriptionTermType (II)

### DIFF
--- a/components/__snapshots__/confirmation.spec.js.snap
+++ b/components/__snapshots__/confirmation.spec.js.snap
@@ -1,5 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Confirmation renders appropriately if is 'Termed' subscription term type 1`] = `
+<div class="ncf ncf__wrapper">
+  <div class="ncf__center">
+    <div class="ncf__icon ncf__icon--tick ncf__icon--large">
+    </div>
+    <p class="ncf__paragraph--reduced-padding ncf__paragraph--subscription-confirmation">
+      You are now subscribed to:
+    </p>
+    <h1 class="ncf__header ncf__header--confirmation">
+    </h1>
+  </div>
+  <p class="ncf__paragraph">
+    We’ve sent confirmation to your email. Make sure you check your spam folder if you don’t receive it.
+  </p>
+  <p class="ncf__paragraph">
+    Here’s a summary of your  subscription:
+  </p>
+  <div class="ncf__headed-paragraph">
+    <h3 class="ncf__header">
+      Something not right?
+    </h3>
+    <p class="ncf__paragraph">
+      Go to your
+      <a class="ncf__link ncf__link--external"
+         href="https://www.ft.com/myaccount/personal-details"
+         target="_blank"
+         rel="noopener noreferrer"
+         data-trackable="yourAccount"
+      >
+        account settings
+      </a>
+      to view or edit your account. If you need to get in touch call us on
+      <a href="tel:+442077556248"
+         class="ncf__link ncf__link--external"
+      >
+        +44 (0) 207 755 6248
+      </a>
+      . Or contact us for additional support.
+    </p>
+  </div>
+  <p class="ncf__paragraph">
+    See our
+    <a class="ncf__link ncf__link--external"
+       href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+       target="_top"
+       rel="noopener"
+    >
+      Terms &amp; Conditions
+    </a>
+    for details on how to cancel.
+  </p>
+</div>
+`;
+
 exports[`Confirmation renders appropriately if is B2C Partnership 1`] = `
 <div class="ncf ncf__wrapper">
   <div class="ncf__center">

--- a/components/confirmation.jsx
+++ b/components/confirmation.jsx
@@ -8,6 +8,7 @@ export function Confirmation({
 	isTrial = false,
 	isB2cPartnership = false,
 	b2cPartnershipCopy = [],
+	isTermedSubscriptionTermType = false,
 	offer = '',
 	email = EMAIL_DEFAULT_TEXT,
 	details = null,
@@ -116,8 +117,12 @@ export function Confirmation({
 				</p>
 			</div>
 			<p className="ncf__paragraph">
-				We will automatically renew your subscription using the payment method
-				provided unless you cancel before your renewal date. See our{' '}
+				{
+					!isTermedSubscriptionTermType
+						? 'We will automatically renew your subscription using the payment method provided unless you cancel before your renewal date. '
+						: ''
+				}
+				{'See our '}
 				<a
 					className="ncf__link ncf__link--external"
 					href="http://help.ft.com/help/legal-privacy/terms-conditions/"
@@ -125,10 +130,9 @@ export function Confirmation({
 					rel="noopener"
 				>
 					Terms &amp; Conditions
-				</a>{' '}
-				for details on how to cancel.
+				</a>
+				{' for details on how to cancel.'}
 			</p>
-
 			{nextActionBottom}
 		</div>
 	);
@@ -138,6 +142,7 @@ Confirmation.propTypes = {
 	isTrial: PropTypes.bool,
 	isB2cPartnership: PropTypes.bool,
 	b2cPartnershipCopy: PropTypes.array,
+	isTermedSubscriptionTermType: PropTypes.bool,
 	offer: PropTypes.string.isRequired,
 	email: PropTypes.string,
 	details: PropTypes.arrayOf(

--- a/components/confirmation.spec.js
+++ b/components/confirmation.spec.js
@@ -29,6 +29,12 @@ describe('Confirmation', () => {
 		expect(Confirmation).toRenderCorrectly(props);
 	});
 
+	it("renders appropriately if is 'Termed' subscription term type", () => {
+		const props = { isTermedSubscriptionTermType: true };
+
+		expect(Confirmation).toRenderCorrectly(props);
+	});
+
 	it('renders with custom email', () => {
 		const props = { offer: OFFER_TEXT, email: 'test@example.com' };
 

--- a/components/confirmation.stories.js
+++ b/components/confirmation.stories.js
@@ -64,3 +64,21 @@ Basic.args = {
 	nextActionBottom,
 	newsletterScheduleExplainer,
 };
+
+export const TermedSubscriptionTermType = (args) => <Confirmation {...args} />;
+TermedSubscriptionTermType.args = {
+	isTermedSubscriptionTermType: true,
+	offer: 'Single-term subscription',
+	details: [
+		{
+			title: 'End date',
+			data: 'February 2, 2024',
+		},
+		{
+			title: 'One-time payment',
+			data: 'GBP 19.00',
+		},
+	],
+	nextActionTop,
+	nextActionBottom,
+};


### PR DESCRIPTION
### Description
This PR is an extension of https://github.com/Financial-Times/n-conversion-forms/pull/771 after it was noticed there are some aspects of the confirmation page that requires the text amended to reflect single-term subscriptions.

### Ticket
- [RS-510: Finance course user sign-up journey](https://financialtimes.atlassian.net/jira/software/c/projects/RS/boards/1547?selectedIssue=RS-510)

### Dependent PRs
- https://github.com/Financial-Times/next-subscribe/pull/2723

### Screenshots

Compare the last paragraph.

| Before | After |
| ------ | ----- |
|![before](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/77a25aa0-4aa5-4d3b-90c8-65d53c88a146)|![after](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/a4db9081-86d2-44a1-be09-208635468f77)|

### Screenshots: Storybook

#### `Confirmation` component
![Screenshot 2023-12-08 at 16 21 17](https://github.com/Financial-Times/n-conversion-forms/assets/10484515/e86bcc31-0a46-4605-86fb-931fe47ea03a)

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [x] **Stories** updated to use this change — no ex
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner