### PR TITLE
ACQ-2523: adding .toolkitstate to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ npm-debug.log
 .stylelintrc
 dist
 docs
+/.toolkitstate/


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
The folder `.toolkitstate` created by `dotcom-tool-kit` is added to gitignore

### Ticket
<!-- Add link to the corresponding ticket -->
[ACQ-2523](https://financialtimes.atlassian.net/browse/ACQ-2523)

[ACQ-2523]: https://financialtimes.atlassian.net/browse/ACQ-2523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ