### PR TITLE
ACQ-2528: synced n-static-common-data lists with FT Core

### DIFF
--- a/components/__snapshots__/industry.spec.js.snap
+++ b/components/__snapshots__/industry.spec.js.snap
@@ -27,6 +27,9 @@ exports[`Industry can render a disable select 1`] = `
       <option value="DEF">
         Aerospace &amp; defence
       </option>
+      <option value="APF">
+        Apparel and Fashion
+      </option>
       <option value="CAR">
         Automobiles
       </option>
@@ -36,23 +39,47 @@ exports[`Industry can render a disable select 1`] = `
       <option value="RES">
         Basic resources/mining
       </option>
+      <option value="BIO">
+        Biotechnology
+      </option>
+      <option value="CAP">
+        Capital Markets
+      </option>
       <option value="PHC">
         Chemicals
       </option>
       <option value="MAP">
         Comms/Publishing/Media
       </option>
+      <option value="GAM">
+        Computer Games
+      </option>
       <option value="BSE">
         Consulting/business services
       </option>
+      <option value="COS">
+        Cosmetics
+      </option>
+      <option value="DES">
+        Design
+      </option>
       <option value="EDU">
         Education/Academia
+      </option>
+      <option value="ELE">
+        Electrical/Electronic Manufacturing
       </option>
       <option value="ENU">
         Energy/utilities
       </option>
       <option value="ENC">
         Engineering/construction
+      </option>
+      <option value="ENV">
+        Environmental Services
+      </option>
+      <option value="EXE">
+        Executive Office
       </option>
       <option value="FSE">
         Financial services
@@ -69,11 +96,11 @@ exports[`Industry can render a disable select 1`] = `
       <option value="HEA">
         Health &amp; pharmaceuticals
       </option>
-      <option value="ITT">
-        IT/Tech/Telecoms
+      <option value="HOS">
+        Hospitality
       </option>
-      <option value="IT">
-        IT/computing
+      <option value="IAE">
+        Import and Export
       </option>
       <option value="MAN">
         Industrial goods &amp; services
@@ -81,8 +108,29 @@ exports[`Industry can render a disable select 1`] = `
       <option value="INS">
         Insurance
       </option>
+      <option value="INV">
+        Investment banking
+      </option>
+      <option value="IT">
+        IT/computing
+      </option>
+      <option value="ITT">
+        IT/Tech/Telecoms
+      </option>
       <option value="LAW">
         Legal services
+      </option>
+      <option value="LUX">
+        Luxury goods and jewelry
+      </option>
+      <option value="MNG">
+        Management consultancy
+      </option>
+      <option value="MEN">
+        Mental Healthcare
+      </option>
+      <option value="MET">
+        Mining and Metals
       </option>
       <option value="OTH">
         N/A
@@ -90,17 +138,53 @@ exports[`Industry can render a disable select 1`] = `
       <option value="OGM">
         Oil/gas/mining
       </option>
+      <option value="OUT">
+        Outsourcing/Offshoring
+      </option>
       <option value="RET">
         Personal &amp; household goods
+      </option>
+      <option value="PHL">
+        Philanthropy
+      </option>
+      <option value="PLA">
+        Plastics
+      </option>
+      <option value="POL">
+        Political organisation
       </option>
       <option value="REA">
         Property
       </option>
+      <option value="PUB">
+        Public Policy
+      </option>
+      <option value="REL">
+        Public Relations and communications
+      </option>
+      <option value="REN">
+        Renewables and environment
+      </option>
       <option value="RTL">
         Retail
       </option>
+      <option value="SHI">
+        Shipbuilding
+      </option>
+      <option value="SPG">
+        Sporting Goods
+      </option>
+      <option value="SPO">
+        Sports
+      </option>
+      <option value="STA">
+        Staffing and recruiting
+      </option>
       <option value="TEL">
         Telecommunications
+      </option>
+      <option value="TOB">
+        Tobacco
       </option>
       <option value="TIE">
         Trade/import/export
@@ -110,6 +194,9 @@ exports[`Industry can render a disable select 1`] = `
       </option>
       <option value="TRV">
         Travel &amp; leisure
+      </option>
+      <option value="VEN">
+        Venture capital and private equity
       </option>
     </select>
     <span class="o-forms-input__error">
@@ -145,6 +232,9 @@ exports[`Industry can render an error message 1`] = `
       <option value="DEF">
         Aerospace &amp; defence
       </option>
+      <option value="APF">
+        Apparel and Fashion
+      </option>
       <option value="CAR">
         Automobiles
       </option>
@@ -154,23 +244,47 @@ exports[`Industry can render an error message 1`] = `
       <option value="RES">
         Basic resources/mining
       </option>
+      <option value="BIO">
+        Biotechnology
+      </option>
+      <option value="CAP">
+        Capital Markets
+      </option>
       <option value="PHC">
         Chemicals
       </option>
       <option value="MAP">
         Comms/Publishing/Media
       </option>
+      <option value="GAM">
+        Computer Games
+      </option>
       <option value="BSE">
         Consulting/business services
       </option>
+      <option value="COS">
+        Cosmetics
+      </option>
+      <option value="DES">
+        Design
+      </option>
       <option value="EDU">
         Education/Academia
+      </option>
+      <option value="ELE">
+        Electrical/Electronic Manufacturing
       </option>
       <option value="ENU">
         Energy/utilities
       </option>
       <option value="ENC">
         Engineering/construction
+      </option>
+      <option value="ENV">
+        Environmental Services
+      </option>
+      <option value="EXE">
+        Executive Office
       </option>
       <option value="FSE">
         Financial services
@@ -187,11 +301,11 @@ exports[`Industry can render an error message 1`] = `
       <option value="HEA">
         Health &amp; pharmaceuticals
       </option>
-      <option value="ITT">
-        IT/Tech/Telecoms
+      <option value="HOS">
+        Hospitality
       </option>
-      <option value="IT">
-        IT/computing
+      <option value="IAE">
+        Import and Export
       </option>
       <option value="MAN">
         Industrial goods &amp; services
@@ -199,8 +313,29 @@ exports[`Industry can render an error message 1`] = `
       <option value="INS">
         Insurance
       </option>
+      <option value="INV">
+        Investment banking
+      </option>
+      <option value="IT">
+        IT/computing
+      </option>
+      <option value="ITT">
+        IT/Tech/Telecoms
+      </option>
       <option value="LAW">
         Legal services
+      </option>
+      <option value="LUX">
+        Luxury goods and jewelry
+      </option>
+      <option value="MNG">
+        Management consultancy
+      </option>
+      <option value="MEN">
+        Mental Healthcare
+      </option>
+      <option value="MET">
+        Mining and Metals
       </option>
       <option value="OTH">
         N/A
@@ -208,17 +343,53 @@ exports[`Industry can render an error message 1`] = `
       <option value="OGM">
         Oil/gas/mining
       </option>
+      <option value="OUT">
+        Outsourcing/Offshoring
+      </option>
       <option value="RET">
         Personal &amp; household goods
+      </option>
+      <option value="PHL">
+        Philanthropy
+      </option>
+      <option value="PLA">
+        Plastics
+      </option>
+      <option value="POL">
+        Political organisation
       </option>
       <option value="REA">
         Property
       </option>
+      <option value="PUB">
+        Public Policy
+      </option>
+      <option value="REL">
+        Public Relations and communications
+      </option>
+      <option value="REN">
+        Renewables and environment
+      </option>
       <option value="RTL">
         Retail
       </option>
+      <option value="SHI">
+        Shipbuilding
+      </option>
+      <option value="SPG">
+        Sporting Goods
+      </option>
+      <option value="SPO">
+        Sports
+      </option>
+      <option value="STA">
+        Staffing and recruiting
+      </option>
       <option value="TEL">
         Telecommunications
+      </option>
+      <option value="TOB">
+        Tobacco
       </option>
       <option value="TIE">
         Trade/import/export
@@ -228,6 +399,9 @@ exports[`Industry can render an error message 1`] = `
       </option>
       <option value="TRV">
         Travel &amp; leisure
+      </option>
+      <option value="VEN">
+        Venture capital and private equity
       </option>
     </select>
     <span class="o-forms-input__error">
@@ -265,6 +439,9 @@ exports[`Industry can render an initial selected value 1`] = `
       >
         Aerospace &amp; defence
       </option>
+      <option value="APF">
+        Apparel and Fashion
+      </option>
       <option value="CAR">
         Automobiles
       </option>
@@ -274,23 +451,47 @@ exports[`Industry can render an initial selected value 1`] = `
       <option value="RES">
         Basic resources/mining
       </option>
+      <option value="BIO">
+        Biotechnology
+      </option>
+      <option value="CAP">
+        Capital Markets
+      </option>
       <option value="PHC">
         Chemicals
       </option>
       <option value="MAP">
         Comms/Publishing/Media
       </option>
+      <option value="GAM">
+        Computer Games
+      </option>
       <option value="BSE">
         Consulting/business services
       </option>
+      <option value="COS">
+        Cosmetics
+      </option>
+      <option value="DES">
+        Design
+      </option>
       <option value="EDU">
         Education/Academia
+      </option>
+      <option value="ELE">
+        Electrical/Electronic Manufacturing
       </option>
       <option value="ENU">
         Energy/utilities
       </option>
       <option value="ENC">
         Engineering/construction
+      </option>
+      <option value="ENV">
+        Environmental Services
+      </option>
+      <option value="EXE">
+        Executive Office
       </option>
       <option value="FSE">
         Financial services
@@ -307,11 +508,11 @@ exports[`Industry can render an initial selected value 1`] = `
       <option value="HEA">
         Health &amp; pharmaceuticals
       </option>
-      <option value="ITT">
-        IT/Tech/Telecoms
+      <option value="HOS">
+        Hospitality
       </option>
-      <option value="IT">
-        IT/computing
+      <option value="IAE">
+        Import and Export
       </option>
       <option value="MAN">
         Industrial goods &amp; services
@@ -319,8 +520,29 @@ exports[`Industry can render an initial selected value 1`] = `
       <option value="INS">
         Insurance
       </option>
+      <option value="INV">
+        Investment banking
+      </option>
+      <option value="IT">
+        IT/computing
+      </option>
+      <option value="ITT">
+        IT/Tech/Telecoms
+      </option>
       <option value="LAW">
         Legal services
+      </option>
+      <option value="LUX">
+        Luxury goods and jewelry
+      </option>
+      <option value="MNG">
+        Management consultancy
+      </option>
+      <option value="MEN">
+        Mental Healthcare
+      </option>
+      <option value="MET">
+        Mining and Metals
       </option>
       <option value="OTH">
         N/A
@@ -328,17 +550,53 @@ exports[`Industry can render an initial selected value 1`] = `
       <option value="OGM">
         Oil/gas/mining
       </option>
+      <option value="OUT">
+        Outsourcing/Offshoring
+      </option>
       <option value="RET">
         Personal &amp; household goods
+      </option>
+      <option value="PHL">
+        Philanthropy
+      </option>
+      <option value="PLA">
+        Plastics
+      </option>
+      <option value="POL">
+        Political organisation
       </option>
       <option value="REA">
         Property
       </option>
+      <option value="PUB">
+        Public Policy
+      </option>
+      <option value="REL">
+        Public Relations and communications
+      </option>
+      <option value="REN">
+        Renewables and environment
+      </option>
       <option value="RTL">
         Retail
       </option>
+      <option value="SHI">
+        Shipbuilding
+      </option>
+      <option value="SPG">
+        Sporting Goods
+      </option>
+      <option value="SPO">
+        Sports
+      </option>
+      <option value="STA">
+        Staffing and recruiting
+      </option>
       <option value="TEL">
         Telecommunications
+      </option>
+      <option value="TOB">
+        Tobacco
       </option>
       <option value="TIE">
         Trade/import/export
@@ -348,6 +606,9 @@ exports[`Industry can render an initial selected value 1`] = `
       </option>
       <option value="TRV">
         Travel &amp; leisure
+      </option>
+      <option value="VEN">
+        Venture capital and private equity
       </option>
     </select>
     <span class="o-forms-input__error">
@@ -383,6 +644,9 @@ exports[`Industry render a select with a label 1`] = `
       <option value="DEF">
         Aerospace &amp; defence
       </option>
+      <option value="APF">
+        Apparel and Fashion
+      </option>
       <option value="CAR">
         Automobiles
       </option>
@@ -392,23 +656,47 @@ exports[`Industry render a select with a label 1`] = `
       <option value="RES">
         Basic resources/mining
       </option>
+      <option value="BIO">
+        Biotechnology
+      </option>
+      <option value="CAP">
+        Capital Markets
+      </option>
       <option value="PHC">
         Chemicals
       </option>
       <option value="MAP">
         Comms/Publishing/Media
       </option>
+      <option value="GAM">
+        Computer Games
+      </option>
       <option value="BSE">
         Consulting/business services
       </option>
+      <option value="COS">
+        Cosmetics
+      </option>
+      <option value="DES">
+        Design
+      </option>
       <option value="EDU">
         Education/Academia
+      </option>
+      <option value="ELE">
+        Electrical/Electronic Manufacturing
       </option>
       <option value="ENU">
         Energy/utilities
       </option>
       <option value="ENC">
         Engineering/construction
+      </option>
+      <option value="ENV">
+        Environmental Services
+      </option>
+      <option value="EXE">
+        Executive Office
       </option>
       <option value="FSE">
         Financial services
@@ -425,11 +713,11 @@ exports[`Industry render a select with a label 1`] = `
       <option value="HEA">
         Health &amp; pharmaceuticals
       </option>
-      <option value="ITT">
-        IT/Tech/Telecoms
+      <option value="HOS">
+        Hospitality
       </option>
-      <option value="IT">
-        IT/computing
+      <option value="IAE">
+        Import and Export
       </option>
       <option value="MAN">
         Industrial goods &amp; services
@@ -437,8 +725,29 @@ exports[`Industry render a select with a label 1`] = `
       <option value="INS">
         Insurance
       </option>
+      <option value="INV">
+        Investment banking
+      </option>
+      <option value="IT">
+        IT/computing
+      </option>
+      <option value="ITT">
+        IT/Tech/Telecoms
+      </option>
       <option value="LAW">
         Legal services
+      </option>
+      <option value="LUX">
+        Luxury goods and jewelry
+      </option>
+      <option value="MNG">
+        Management consultancy
+      </option>
+      <option value="MEN">
+        Mental Healthcare
+      </option>
+      <option value="MET">
+        Mining and Metals
       </option>
       <option value="OTH">
         N/A
@@ -446,17 +755,53 @@ exports[`Industry render a select with a label 1`] = `
       <option value="OGM">
         Oil/gas/mining
       </option>
+      <option value="OUT">
+        Outsourcing/Offshoring
+      </option>
       <option value="RET">
         Personal &amp; household goods
+      </option>
+      <option value="PHL">
+        Philanthropy
+      </option>
+      <option value="PLA">
+        Plastics
+      </option>
+      <option value="POL">
+        Political organisation
       </option>
       <option value="REA">
         Property
       </option>
+      <option value="PUB">
+        Public Policy
+      </option>
+      <option value="REL">
+        Public Relations and communications
+      </option>
+      <option value="REN">
+        Renewables and environment
+      </option>
       <option value="RTL">
         Retail
       </option>
+      <option value="SHI">
+        Shipbuilding
+      </option>
+      <option value="SPG">
+        Sporting Goods
+      </option>
+      <option value="SPO">
+        Sports
+      </option>
+      <option value="STA">
+        Staffing and recruiting
+      </option>
       <option value="TEL">
         Telecommunications
+      </option>
+      <option value="TOB">
+        Tobacco
       </option>
       <option value="TIE">
         Trade/import/export
@@ -466,6 +811,9 @@ exports[`Industry render a select with a label 1`] = `
       </option>
       <option value="TRV">
         Travel &amp; leisure
+      </option>
+      <option value="VEN">
+        Venture capital and private equity
       </option>
     </select>
     <span class="o-forms-input__error">

--- a/components/__snapshots__/position.spec.js.snap
+++ b/components/__snapshots__/position.spec.js.snap
@@ -28,26 +28,32 @@ exports[`Position can render a disable select 1`] = `
       <option value="AN">
         Analyst
       </option>
-      <option value="CS">
-        Consultant
-      </option>
       <option value="AS">
         Associate
       </option>
       <option value="BR">
         Broker/Trader/Advisor
       </option>
+      <option value="CL">
+        C-Suite
+      </option>
       <option value="CP">
         CEO/President/Chairperson
       </option>
-      <option value="CL">
-        C-Suite
+      <option value="CS">
+        Consultant
+      </option>
+      <option value="GI">
+        Diplomat/Sen Govt Officer
       </option>
       <option value="DR">
         Director
       </option>
-      <option value="GI">
-        Diplomat/Sen Govt Officer
+      <option value="OE">
+        Executive Management
+      </option>
+      <option value="OP">
+        Founder/Owner
       </option>
       <option value="IN">
         Intern/Trainee/Student
@@ -61,23 +67,17 @@ exports[`Position can render a disable select 1`] = `
       <option value="NW">
         Not working
       </option>
-      <option value="OE">
-        Executive Management
-      </option>
       <option value="OT">
         Other
-      </option>
-      <option value="OP">
-        Founder/Owner
       </option>
       <option value="PA">
         Partner/Principal
       </option>
-      <option value="PM">
-        Programme/Project Manager
-      </option>
       <option value="PO">
         Politician/Government Minister
+      </option>
+      <option value="PM">
+        Programme/Project Manager
       </option>
       <option value="SM">
         Senior Manager/Dept Head
@@ -123,26 +123,32 @@ exports[`Position can render an error message 1`] = `
       <option value="AN">
         Analyst
       </option>
-      <option value="CS">
-        Consultant
-      </option>
       <option value="AS">
         Associate
       </option>
       <option value="BR">
         Broker/Trader/Advisor
       </option>
+      <option value="CL">
+        C-Suite
+      </option>
       <option value="CP">
         CEO/President/Chairperson
       </option>
-      <option value="CL">
-        C-Suite
+      <option value="CS">
+        Consultant
+      </option>
+      <option value="GI">
+        Diplomat/Sen Govt Officer
       </option>
       <option value="DR">
         Director
       </option>
-      <option value="GI">
-        Diplomat/Sen Govt Officer
+      <option value="OE">
+        Executive Management
+      </option>
+      <option value="OP">
+        Founder/Owner
       </option>
       <option value="IN">
         Intern/Trainee/Student
@@ -156,23 +162,17 @@ exports[`Position can render an error message 1`] = `
       <option value="NW">
         Not working
       </option>
-      <option value="OE">
-        Executive Management
-      </option>
       <option value="OT">
         Other
-      </option>
-      <option value="OP">
-        Founder/Owner
       </option>
       <option value="PA">
         Partner/Principal
       </option>
-      <option value="PM">
-        Programme/Project Manager
-      </option>
       <option value="PO">
         Politician/Government Minister
+      </option>
+      <option value="PM">
+        Programme/Project Manager
       </option>
       <option value="SM">
         Senior Manager/Dept Head
@@ -218,28 +218,34 @@ exports[`Position can render an initial selected value 1`] = `
       <option value="AN">
         Analyst
       </option>
-      <option value="CS">
-        Consultant
-      </option>
       <option value="AS">
         Associate
       </option>
       <option value="BR">
         Broker/Trader/Advisor
       </option>
+      <option value="CL">
+        C-Suite
+      </option>
       <option selected
               value="CP"
       >
         CEO/President/Chairperson
       </option>
-      <option value="CL">
-        C-Suite
+      <option value="CS">
+        Consultant
+      </option>
+      <option value="GI">
+        Diplomat/Sen Govt Officer
       </option>
       <option value="DR">
         Director
       </option>
-      <option value="GI">
-        Diplomat/Sen Govt Officer
+      <option value="OE">
+        Executive Management
+      </option>
+      <option value="OP">
+        Founder/Owner
       </option>
       <option value="IN">
         Intern/Trainee/Student
@@ -253,23 +259,17 @@ exports[`Position can render an initial selected value 1`] = `
       <option value="NW">
         Not working
       </option>
-      <option value="OE">
-        Executive Management
-      </option>
       <option value="OT">
         Other
-      </option>
-      <option value="OP">
-        Founder/Owner
       </option>
       <option value="PA">
         Partner/Principal
       </option>
-      <option value="PM">
-        Programme/Project Manager
-      </option>
       <option value="PO">
         Politician/Government Minister
+      </option>
+      <option value="PM">
+        Programme/Project Manager
       </option>
       <option value="SM">
         Senior Manager/Dept Head
@@ -315,26 +315,32 @@ exports[`Position render a select with a label 1`] = `
       <option value="AN">
         Analyst
       </option>
-      <option value="CS">
-        Consultant
-      </option>
       <option value="AS">
         Associate
       </option>
       <option value="BR">
         Broker/Trader/Advisor
       </option>
+      <option value="CL">
+        C-Suite
+      </option>
       <option value="CP">
         CEO/President/Chairperson
       </option>
-      <option value="CL">
-        C-Suite
+      <option value="CS">
+        Consultant
+      </option>
+      <option value="GI">
+        Diplomat/Sen Govt Officer
       </option>
       <option value="DR">
         Director
       </option>
-      <option value="GI">
-        Diplomat/Sen Govt Officer
+      <option value="OE">
+        Executive Management
+      </option>
+      <option value="OP">
+        Founder/Owner
       </option>
       <option value="IN">
         Intern/Trainee/Student
@@ -348,23 +354,17 @@ exports[`Position render a select with a label 1`] = `
       <option value="NW">
         Not working
       </option>
-      <option value="OE">
-        Executive Management
-      </option>
       <option value="OT">
         Other
-      </option>
-      <option value="OP">
-        Founder/Owner
       </option>
       <option value="PA">
         Partner/Principal
       </option>
-      <option value="PM">
-        Programme/Project Manager
-      </option>
       <option value="PO">
         Politician/Government Minister
+      </option>
+      <option value="PM">
+        Programme/Project Manager
       </option>
       <option value="SM">
         Senior Manager/Dept Head

--- a/components/__snapshots__/responsibility.spec.js.snap
+++ b/components/__snapshots__/responsibility.spec.js.snap
@@ -22,32 +22,65 @@ exports[`Responsibility can render a disable select 1`] = `
       <option value>
         Please select a job responsibility
       </option>
-      <option value="FIN">
-        Accounting/finance
+      <option value="ACC">
+        Accounting
       </option>
       <option value="ADL">
         Administration
       </option>
+      <option value="ANL">
+        Analyst
+      </option>
+      <option value="ART">
+        Arts &amp; design
+      </option>
       <option value="RES">
         Broker/trader
       </option>
-      <option value="BUY">
-        Buying/procurement
+      <option value="COM">
+        Community &amp; social services
+      </option>
+      <option value="COS">
+        Consulting
+      </option>
+      <option value="RAD">
+        Data &amp; Analytics
+      </option>
+      <option value="ENG">
+        Engineering
+      </option>
+      <option value="ESG">
+        ESG (Env’tl, Social &amp; Corp. Governance)
       </option>
       <option value="EXP">
         Export/international sales
       </option>
+      <option value="FAC">
+        Facilities
+      </option>
+      <option value="FIN">
+        Finance
+      </option>
+      <option value="FNC">
+        Finance
+      </option>
+      <option value="IFA">
+        Financial Advisor
+      </option>
+      <option value="FUM">
+        Fund management
+      </option>
       <option value="CON">
         General management
       </option>
+      <option value="HEA">
+        Healthcare services
+      </option>
       <option value="PAT">
-        HR/Training
+        Human resources
       </option>
-      <option value="IFA">
-        IFA/financial adviser
-      </option>
-      <option value="ITC">
-        IT/computing
+      <option value="HUM">
+        Human resources
       </option>
       <option value="TEC">
         Information technology
@@ -55,17 +88,32 @@ exports[`Responsibility can render a disable select 1`] = `
       <option value="INS">
         Insurance
       </option>
+      <option value="PRI">
+        Investments
+      </option>
+      <option value="ITC">
+        IT/computing
+      </option>
       <option value="KNO">
-        Knowledge management
+        Knowledge &amp; information management
+      </option>
+      <option value="LEA">
+        Learning &amp; Development
       </option>
       <option value="LEG">
-        Legal/company secretarial
+        Legal
+      </option>
+      <option value="LGL">
+        Legal
       </option>
       <option value="MKT">
-        Marketing/communications/PR
+        Marketing
       </option>
-      <option value="MON">
-        Money/portfolio management
+      <option value="MAR">
+        Marketing
+      </option>
+      <option value="MED">
+        Media &amp; communication
       </option>
       <option value="OTH">
         N/A
@@ -76,29 +124,50 @@ exports[`Responsibility can render a disable select 1`] = `
       <option value="OPS">
         Operations
       </option>
-      <option value="PRI">
-        Private Investor
+      <option value="POL">
+        Policy making
+      </option>
+      <option value="MON">
+        Portfolio management
       </option>
       <option value="PRO">
-        Product mgmt/development
+        Product management
       </option>
-      <option value="RAD">
-        Research/analysis
+      <option value="PMN">
+        Program and project management
+      </option>
+      <option value="BUY">
+        Purchasing &amp; procurement
+      </option>
+      <option value="QUA">
+        Quantitative Analysis
+      </option>
+      <option value="REA">
+        Real Estate
+      </option>
+      <option value="RSR">
+        Research
       </option>
       <option value="RET">
         Retired
       </option>
       <option value="RSK">
-        Risk management/compliance
+        Risk &amp; compliance
       </option>
       <option value="SAL">
-        Sales/business development
+        Sales &amp; business development
       </option>
       <option value="CPL">
-        Strategy/planning
+        Strategy
       </option>
       <option value="STU">
         Student
+      </option>
+      <option value="SUP">
+        Support
+      </option>
+      <option value="TEA">
+        Teaching &amp; training
       </option>
       <option value="TEL">
         Telecommunications
@@ -132,32 +201,65 @@ exports[`Responsibility can render an error message 1`] = `
       <option value>
         Please select a job responsibility
       </option>
-      <option value="FIN">
-        Accounting/finance
+      <option value="ACC">
+        Accounting
       </option>
       <option value="ADL">
         Administration
       </option>
+      <option value="ANL">
+        Analyst
+      </option>
+      <option value="ART">
+        Arts &amp; design
+      </option>
       <option value="RES">
         Broker/trader
       </option>
-      <option value="BUY">
-        Buying/procurement
+      <option value="COM">
+        Community &amp; social services
+      </option>
+      <option value="COS">
+        Consulting
+      </option>
+      <option value="RAD">
+        Data &amp; Analytics
+      </option>
+      <option value="ENG">
+        Engineering
+      </option>
+      <option value="ESG">
+        ESG (Env’tl, Social &amp; Corp. Governance)
       </option>
       <option value="EXP">
         Export/international sales
       </option>
+      <option value="FAC">
+        Facilities
+      </option>
+      <option value="FIN">
+        Finance
+      </option>
+      <option value="FNC">
+        Finance
+      </option>
+      <option value="IFA">
+        Financial Advisor
+      </option>
+      <option value="FUM">
+        Fund management
+      </option>
       <option value="CON">
         General management
       </option>
+      <option value="HEA">
+        Healthcare services
+      </option>
       <option value="PAT">
-        HR/Training
+        Human resources
       </option>
-      <option value="IFA">
-        IFA/financial adviser
-      </option>
-      <option value="ITC">
-        IT/computing
+      <option value="HUM">
+        Human resources
       </option>
       <option value="TEC">
         Information technology
@@ -165,17 +267,32 @@ exports[`Responsibility can render an error message 1`] = `
       <option value="INS">
         Insurance
       </option>
+      <option value="PRI">
+        Investments
+      </option>
+      <option value="ITC">
+        IT/computing
+      </option>
       <option value="KNO">
-        Knowledge management
+        Knowledge &amp; information management
+      </option>
+      <option value="LEA">
+        Learning &amp; Development
       </option>
       <option value="LEG">
-        Legal/company secretarial
+        Legal
+      </option>
+      <option value="LGL">
+        Legal
       </option>
       <option value="MKT">
-        Marketing/communications/PR
+        Marketing
       </option>
-      <option value="MON">
-        Money/portfolio management
+      <option value="MAR">
+        Marketing
+      </option>
+      <option value="MED">
+        Media &amp; communication
       </option>
       <option value="OTH">
         N/A
@@ -186,29 +303,50 @@ exports[`Responsibility can render an error message 1`] = `
       <option value="OPS">
         Operations
       </option>
-      <option value="PRI">
-        Private Investor
+      <option value="POL">
+        Policy making
+      </option>
+      <option value="MON">
+        Portfolio management
       </option>
       <option value="PRO">
-        Product mgmt/development
+        Product management
       </option>
-      <option value="RAD">
-        Research/analysis
+      <option value="PMN">
+        Program and project management
+      </option>
+      <option value="BUY">
+        Purchasing &amp; procurement
+      </option>
+      <option value="QUA">
+        Quantitative Analysis
+      </option>
+      <option value="REA">
+        Real Estate
+      </option>
+      <option value="RSR">
+        Research
       </option>
       <option value="RET">
         Retired
       </option>
       <option value="RSK">
-        Risk management/compliance
+        Risk &amp; compliance
       </option>
       <option value="SAL">
-        Sales/business development
+        Sales &amp; business development
       </option>
       <option value="CPL">
-        Strategy/planning
+        Strategy
       </option>
       <option value="STU">
         Student
+      </option>
+      <option value="SUP">
+        Support
+      </option>
+      <option value="TEA">
+        Teaching &amp; training
       </option>
       <option value="TEL">
         Telecommunications
@@ -242,34 +380,67 @@ exports[`Responsibility can render an initial selected value 1`] = `
       <option value>
         Please select a job responsibility
       </option>
-      <option selected
-              value="FIN"
-      >
-        Accounting/finance
+      <option value="ACC">
+        Accounting
       </option>
       <option value="ADL">
         Administration
       </option>
+      <option value="ANL">
+        Analyst
+      </option>
+      <option value="ART">
+        Arts &amp; design
+      </option>
       <option value="RES">
         Broker/trader
       </option>
-      <option value="BUY">
-        Buying/procurement
+      <option value="COM">
+        Community &amp; social services
+      </option>
+      <option value="COS">
+        Consulting
+      </option>
+      <option value="RAD">
+        Data &amp; Analytics
+      </option>
+      <option value="ENG">
+        Engineering
+      </option>
+      <option value="ESG">
+        ESG (Env’tl, Social &amp; Corp. Governance)
       </option>
       <option value="EXP">
         Export/international sales
       </option>
+      <option value="FAC">
+        Facilities
+      </option>
+      <option selected
+              value="FIN"
+      >
+        Finance
+      </option>
+      <option value="FNC">
+        Finance
+      </option>
+      <option value="IFA">
+        Financial Advisor
+      </option>
+      <option value="FUM">
+        Fund management
+      </option>
       <option value="CON">
         General management
       </option>
+      <option value="HEA">
+        Healthcare services
+      </option>
       <option value="PAT">
-        HR/Training
+        Human resources
       </option>
-      <option value="IFA">
-        IFA/financial adviser
-      </option>
-      <option value="ITC">
-        IT/computing
+      <option value="HUM">
+        Human resources
       </option>
       <option value="TEC">
         Information technology
@@ -277,17 +448,32 @@ exports[`Responsibility can render an initial selected value 1`] = `
       <option value="INS">
         Insurance
       </option>
+      <option value="PRI">
+        Investments
+      </option>
+      <option value="ITC">
+        IT/computing
+      </option>
       <option value="KNO">
-        Knowledge management
+        Knowledge &amp; information management
+      </option>
+      <option value="LEA">
+        Learning &amp; Development
       </option>
       <option value="LEG">
-        Legal/company secretarial
+        Legal
+      </option>
+      <option value="LGL">
+        Legal
       </option>
       <option value="MKT">
-        Marketing/communications/PR
+        Marketing
       </option>
-      <option value="MON">
-        Money/portfolio management
+      <option value="MAR">
+        Marketing
+      </option>
+      <option value="MED">
+        Media &amp; communication
       </option>
       <option value="OTH">
         N/A
@@ -298,29 +484,50 @@ exports[`Responsibility can render an initial selected value 1`] = `
       <option value="OPS">
         Operations
       </option>
-      <option value="PRI">
-        Private Investor
+      <option value="POL">
+        Policy making
+      </option>
+      <option value="MON">
+        Portfolio management
       </option>
       <option value="PRO">
-        Product mgmt/development
+        Product management
       </option>
-      <option value="RAD">
-        Research/analysis
+      <option value="PMN">
+        Program and project management
+      </option>
+      <option value="BUY">
+        Purchasing &amp; procurement
+      </option>
+      <option value="QUA">
+        Quantitative Analysis
+      </option>
+      <option value="REA">
+        Real Estate
+      </option>
+      <option value="RSR">
+        Research
       </option>
       <option value="RET">
         Retired
       </option>
       <option value="RSK">
-        Risk management/compliance
+        Risk &amp; compliance
       </option>
       <option value="SAL">
-        Sales/business development
+        Sales &amp; business development
       </option>
       <option value="CPL">
-        Strategy/planning
+        Strategy
       </option>
       <option value="STU">
         Student
+      </option>
+      <option value="SUP">
+        Support
+      </option>
+      <option value="TEA">
+        Teaching &amp; training
       </option>
       <option value="TEL">
         Telecommunications
@@ -354,32 +561,65 @@ exports[`Responsibility render a select with a label 1`] = `
       <option value>
         Please select a job responsibility
       </option>
-      <option value="FIN">
-        Accounting/finance
+      <option value="ACC">
+        Accounting
       </option>
       <option value="ADL">
         Administration
       </option>
+      <option value="ANL">
+        Analyst
+      </option>
+      <option value="ART">
+        Arts &amp; design
+      </option>
       <option value="RES">
         Broker/trader
       </option>
-      <option value="BUY">
-        Buying/procurement
+      <option value="COM">
+        Community &amp; social services
+      </option>
+      <option value="COS">
+        Consulting
+      </option>
+      <option value="RAD">
+        Data &amp; Analytics
+      </option>
+      <option value="ENG">
+        Engineering
+      </option>
+      <option value="ESG">
+        ESG (Env’tl, Social &amp; Corp. Governance)
       </option>
       <option value="EXP">
         Export/international sales
       </option>
+      <option value="FAC">
+        Facilities
+      </option>
+      <option value="FIN">
+        Finance
+      </option>
+      <option value="FNC">
+        Finance
+      </option>
+      <option value="IFA">
+        Financial Advisor
+      </option>
+      <option value="FUM">
+        Fund management
+      </option>
       <option value="CON">
         General management
       </option>
+      <option value="HEA">
+        Healthcare services
+      </option>
       <option value="PAT">
-        HR/Training
+        Human resources
       </option>
-      <option value="IFA">
-        IFA/financial adviser
-      </option>
-      <option value="ITC">
-        IT/computing
+      <option value="HUM">
+        Human resources
       </option>
       <option value="TEC">
         Information technology
@@ -387,17 +627,32 @@ exports[`Responsibility render a select with a label 1`] = `
       <option value="INS">
         Insurance
       </option>
+      <option value="PRI">
+        Investments
+      </option>
+      <option value="ITC">
+        IT/computing
+      </option>
       <option value="KNO">
-        Knowledge management
+        Knowledge &amp; information management
+      </option>
+      <option value="LEA">
+        Learning &amp; Development
       </option>
       <option value="LEG">
-        Legal/company secretarial
+        Legal
+      </option>
+      <option value="LGL">
+        Legal
       </option>
       <option value="MKT">
-        Marketing/communications/PR
+        Marketing
       </option>
-      <option value="MON">
-        Money/portfolio management
+      <option value="MAR">
+        Marketing
+      </option>
+      <option value="MED">
+        Media &amp; communication
       </option>
       <option value="OTH">
         N/A
@@ -408,29 +663,50 @@ exports[`Responsibility render a select with a label 1`] = `
       <option value="OPS">
         Operations
       </option>
-      <option value="PRI">
-        Private Investor
+      <option value="POL">
+        Policy making
+      </option>
+      <option value="MON">
+        Portfolio management
       </option>
       <option value="PRO">
-        Product mgmt/development
+        Product management
       </option>
-      <option value="RAD">
-        Research/analysis
+      <option value="PMN">
+        Program and project management
+      </option>
+      <option value="BUY">
+        Purchasing &amp; procurement
+      </option>
+      <option value="QUA">
+        Quantitative Analysis
+      </option>
+      <option value="REA">
+        Real Estate
+      </option>
+      <option value="RSR">
+        Research
       </option>
       <option value="RET">
         Retired
       </option>
       <option value="RSK">
-        Risk management/compliance
+        Risk &amp; compliance
       </option>
       <option value="SAL">
-        Sales/business development
+        Sales &amp; business development
       </option>
       <option value="CPL">
-        Strategy/planning
+        Strategy
       </option>
       <option value="STU">
         Student
+      </option>
+      <option value="SUP">
+        Support
+      </option>
+      <option value="TEA">
+        Teaching &amp; training
       </option>
       <option value="TEL">
         Telecommunications

--- a/components/__snapshots__/responsibility.spec.js.snap
+++ b/components/__snapshots__/responsibility.spec.js.snap
@@ -28,14 +28,8 @@ exports[`Responsibility can render a disable select 1`] = `
       <option value="ADL">
         Administration
       </option>
-      <option value="ANL">
-        Analyst
-      </option>
       <option value="ART">
         Arts &amp; design
-      </option>
-      <option value="RES">
-        Broker/trader
       </option>
       <option value="COM">
         Community &amp; social services
@@ -52,16 +46,10 @@ exports[`Responsibility can render a disable select 1`] = `
       <option value="ESG">
         ESG (Env’tl, Social &amp; Corp. Governance)
       </option>
-      <option value="EXP">
-        Export/international sales
-      </option>
       <option value="FAC">
         Facilities
       </option>
       <option value="FIN">
-        Finance
-      </option>
-      <option value="FNC">
         Finance
       </option>
       <option value="IFA">
@@ -70,29 +58,17 @@ exports[`Responsibility can render a disable select 1`] = `
       <option value="FUM">
         Fund management
       </option>
-      <option value="CON">
-        General management
-      </option>
       <option value="HEA">
         Healthcare services
       </option>
       <option value="PAT">
         Human resources
       </option>
-      <option value="HUM">
-        Human resources
-      </option>
       <option value="TEC">
         Information technology
       </option>
-      <option value="INS">
-        Insurance
-      </option>
       <option value="PRI">
         Investments
-      </option>
-      <option value="ITC">
-        IT/computing
       </option>
       <option value="KNO">
         Knowledge &amp; information management
@@ -103,20 +79,11 @@ exports[`Responsibility can render a disable select 1`] = `
       <option value="LEG">
         Legal
       </option>
-      <option value="LGL">
-        Legal
-      </option>
       <option value="MKT">
-        Marketing
-      </option>
-      <option value="MAR">
         Marketing
       </option>
       <option value="MED">
         Media &amp; communication
-      </option>
-      <option value="OTH">
-        N/A
       </option>
       <option value="NOT">
         Not working
@@ -148,9 +115,6 @@ exports[`Responsibility can render a disable select 1`] = `
       <option value="RSR">
         Research
       </option>
-      <option value="RET">
-        Retired
-      </option>
       <option value="RSK">
         Risk &amp; compliance
       </option>
@@ -168,9 +132,6 @@ exports[`Responsibility can render a disable select 1`] = `
       </option>
       <option value="TEA">
         Teaching &amp; training
-      </option>
-      <option value="TEL">
-        Telecommunications
       </option>
     </select>
     <span class="o-forms-input__error">
@@ -207,14 +168,8 @@ exports[`Responsibility can render an error message 1`] = `
       <option value="ADL">
         Administration
       </option>
-      <option value="ANL">
-        Analyst
-      </option>
       <option value="ART">
         Arts &amp; design
-      </option>
-      <option value="RES">
-        Broker/trader
       </option>
       <option value="COM">
         Community &amp; social services
@@ -231,16 +186,10 @@ exports[`Responsibility can render an error message 1`] = `
       <option value="ESG">
         ESG (Env’tl, Social &amp; Corp. Governance)
       </option>
-      <option value="EXP">
-        Export/international sales
-      </option>
       <option value="FAC">
         Facilities
       </option>
       <option value="FIN">
-        Finance
-      </option>
-      <option value="FNC">
         Finance
       </option>
       <option value="IFA">
@@ -249,29 +198,17 @@ exports[`Responsibility can render an error message 1`] = `
       <option value="FUM">
         Fund management
       </option>
-      <option value="CON">
-        General management
-      </option>
       <option value="HEA">
         Healthcare services
       </option>
       <option value="PAT">
         Human resources
       </option>
-      <option value="HUM">
-        Human resources
-      </option>
       <option value="TEC">
         Information technology
       </option>
-      <option value="INS">
-        Insurance
-      </option>
       <option value="PRI">
         Investments
-      </option>
-      <option value="ITC">
-        IT/computing
       </option>
       <option value="KNO">
         Knowledge &amp; information management
@@ -282,20 +219,11 @@ exports[`Responsibility can render an error message 1`] = `
       <option value="LEG">
         Legal
       </option>
-      <option value="LGL">
-        Legal
-      </option>
       <option value="MKT">
-        Marketing
-      </option>
-      <option value="MAR">
         Marketing
       </option>
       <option value="MED">
         Media &amp; communication
-      </option>
-      <option value="OTH">
-        N/A
       </option>
       <option value="NOT">
         Not working
@@ -327,9 +255,6 @@ exports[`Responsibility can render an error message 1`] = `
       <option value="RSR">
         Research
       </option>
-      <option value="RET">
-        Retired
-      </option>
       <option value="RSK">
         Risk &amp; compliance
       </option>
@@ -347,9 +272,6 @@ exports[`Responsibility can render an error message 1`] = `
       </option>
       <option value="TEA">
         Teaching &amp; training
-      </option>
-      <option value="TEL">
-        Telecommunications
       </option>
     </select>
     <span class="o-forms-input__error">
@@ -386,14 +308,8 @@ exports[`Responsibility can render an initial selected value 1`] = `
       <option value="ADL">
         Administration
       </option>
-      <option value="ANL">
-        Analyst
-      </option>
       <option value="ART">
         Arts &amp; design
-      </option>
-      <option value="RES">
-        Broker/trader
       </option>
       <option value="COM">
         Community &amp; social services
@@ -410,9 +326,6 @@ exports[`Responsibility can render an initial selected value 1`] = `
       <option value="ESG">
         ESG (Env’tl, Social &amp; Corp. Governance)
       </option>
-      <option value="EXP">
-        Export/international sales
-      </option>
       <option value="FAC">
         Facilities
       </option>
@@ -421,17 +334,11 @@ exports[`Responsibility can render an initial selected value 1`] = `
       >
         Finance
       </option>
-      <option value="FNC">
-        Finance
-      </option>
       <option value="IFA">
         Financial Advisor
       </option>
       <option value="FUM">
         Fund management
-      </option>
-      <option value="CON">
-        General management
       </option>
       <option value="HEA">
         Healthcare services
@@ -439,20 +346,11 @@ exports[`Responsibility can render an initial selected value 1`] = `
       <option value="PAT">
         Human resources
       </option>
-      <option value="HUM">
-        Human resources
-      </option>
       <option value="TEC">
         Information technology
       </option>
-      <option value="INS">
-        Insurance
-      </option>
       <option value="PRI">
         Investments
-      </option>
-      <option value="ITC">
-        IT/computing
       </option>
       <option value="KNO">
         Knowledge &amp; information management
@@ -463,20 +361,11 @@ exports[`Responsibility can render an initial selected value 1`] = `
       <option value="LEG">
         Legal
       </option>
-      <option value="LGL">
-        Legal
-      </option>
       <option value="MKT">
-        Marketing
-      </option>
-      <option value="MAR">
         Marketing
       </option>
       <option value="MED">
         Media &amp; communication
-      </option>
-      <option value="OTH">
-        N/A
       </option>
       <option value="NOT">
         Not working
@@ -508,9 +397,6 @@ exports[`Responsibility can render an initial selected value 1`] = `
       <option value="RSR">
         Research
       </option>
-      <option value="RET">
-        Retired
-      </option>
       <option value="RSK">
         Risk &amp; compliance
       </option>
@@ -528,9 +414,6 @@ exports[`Responsibility can render an initial selected value 1`] = `
       </option>
       <option value="TEA">
         Teaching &amp; training
-      </option>
-      <option value="TEL">
-        Telecommunications
       </option>
     </select>
     <span class="o-forms-input__error">
@@ -567,14 +450,8 @@ exports[`Responsibility render a select with a label 1`] = `
       <option value="ADL">
         Administration
       </option>
-      <option value="ANL">
-        Analyst
-      </option>
       <option value="ART">
         Arts &amp; design
-      </option>
-      <option value="RES">
-        Broker/trader
       </option>
       <option value="COM">
         Community &amp; social services
@@ -591,16 +468,10 @@ exports[`Responsibility render a select with a label 1`] = `
       <option value="ESG">
         ESG (Env’tl, Social &amp; Corp. Governance)
       </option>
-      <option value="EXP">
-        Export/international sales
-      </option>
       <option value="FAC">
         Facilities
       </option>
       <option value="FIN">
-        Finance
-      </option>
-      <option value="FNC">
         Finance
       </option>
       <option value="IFA">
@@ -609,29 +480,17 @@ exports[`Responsibility render a select with a label 1`] = `
       <option value="FUM">
         Fund management
       </option>
-      <option value="CON">
-        General management
-      </option>
       <option value="HEA">
         Healthcare services
       </option>
       <option value="PAT">
         Human resources
       </option>
-      <option value="HUM">
-        Human resources
-      </option>
       <option value="TEC">
         Information technology
       </option>
-      <option value="INS">
-        Insurance
-      </option>
       <option value="PRI">
         Investments
-      </option>
-      <option value="ITC">
-        IT/computing
       </option>
       <option value="KNO">
         Knowledge &amp; information management
@@ -642,20 +501,11 @@ exports[`Responsibility render a select with a label 1`] = `
       <option value="LEG">
         Legal
       </option>
-      <option value="LGL">
-        Legal
-      </option>
       <option value="MKT">
-        Marketing
-      </option>
-      <option value="MAR">
         Marketing
       </option>
       <option value="MED">
         Media &amp; communication
-      </option>
-      <option value="OTH">
-        N/A
       </option>
       <option value="NOT">
         Not working
@@ -687,9 +537,6 @@ exports[`Responsibility render a select with a label 1`] = `
       <option value="RSR">
         Research
       </option>
-      <option value="RET">
-        Retired
-      </option>
       <option value="RSK">
         Risk &amp; compliance
       </option>
@@ -707,9 +554,6 @@ exports[`Responsibility render a select with a label 1`] = `
       </option>
       <option value="TEA">
         Teaching &amp; training
-      </option>
-      <option value="TEL">
-        Telecommunications
       </option>
     </select>
     <span class="o-forms-input__error">

--- a/components/industry.jsx
+++ b/components/industry.jsx
@@ -26,6 +26,8 @@ export function Industry({
 		{ 'o-forms-field--optional': !isRequired },
 	]);
 
+	options.sort((a, b) => a.description.localeCompare(b.description));
+
 	return (
 		<label
 			id={fieldId}

--- a/components/industry.stories.js
+++ b/components/industry.stories.js
@@ -13,3 +13,6 @@ Basic.args = {
 		{ code: 'COM', description: 'Computing' },
 	],
 };
+
+export const Default = (args) => <Industry {...args} />;
+Default.args = {};

--- a/components/position.jsx
+++ b/components/position.jsx
@@ -28,6 +28,8 @@ export function Position({
 		{ 'o-forms-field--optional': !isRequired },
 	]);
 
+	options.sort((a, b) => a.description.localeCompare(b.description));
+
 	return (
 		<label
 			id={fieldId}

--- a/components/position.stories.js
+++ b/components/position.stories.js
@@ -21,3 +21,6 @@ Basic.args = {
 		},
 	],
 };
+
+export const Default = (args) => <Position {...args} />;
+Default.args = {};

--- a/components/responsibility.jsx
+++ b/components/responsibility.jsx
@@ -28,6 +28,8 @@ export function Responsibility({
 		{ 'o-forms-field--optional': !isRequired },
 	]);
 
+	options.sort((a, b) => a.description.localeCompare(b.description));
+
 	return (
 		<label
 			id={fieldId}

--- a/components/responsibility.stories.js
+++ b/components/responsibility.stories.js
@@ -26,3 +26,6 @@ Basic.args = {
 		},
 	],
 };
+
+export const Default = (args) => <Responsibility {...args} />;
+Default.args = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "classnames": "2.3.2",
         "fetchres": "1.7.2",
         "lodash.get": "4.4.2",
-        "n-common-static-data": "github:Financial-Times/n-common-static-data#v2.3.0"
+        "n-common-static-data": "github:Financial-Times/n-common-static-data#v2.3.1"
       },
       "devDependencies": {
         "@babel/core": "^7.22.15",
@@ -20542,7 +20542,7 @@
     },
     "node_modules/n-common-static-data": {
       "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/Financial-Times/n-common-static-data.git#05c71455db73fe5e3cddd197afc2f0954c365c16",
+      "resolved": "git+ssh://git@github.com/Financial-Times/n-common-static-data.git#952e64ea106df44506389fd53c022c697919b822",
       "engines": {
         "node": "16.x || 18.x",
         "npm": "7.x || 8.x || 9.x"
@@ -39902,8 +39902,8 @@
       }
     },
     "n-common-static-data": {
-      "version": "git+ssh://git@github.com/Financial-Times/n-common-static-data.git#05c71455db73fe5e3cddd197afc2f0954c365c16",
-      "from": "n-common-static-data@github:Financial-Times/n-common-static-data#v2.3.0"
+      "version": "git+ssh://git@github.com/Financial-Times/n-common-static-data.git#952e64ea106df44506389fd53c022c697919b822",
+      "from": "n-common-static-data@github:Financial-Times/n-common-static-data#v2.3.1"
     },
     "nanoid": {
       "version": "3.3.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "classnames": "2.3.2",
         "fetchres": "1.7.2",
         "lodash.get": "4.4.2",
-        "n-common-static-data": "github:Financial-Times/n-common-static-data#v2.2.0"
+        "n-common-static-data": "github:Financial-Times/n-common-static-data#v2.3.0"
       },
       "devDependencies": {
         "@babel/core": "^7.22.15",
@@ -20542,7 +20542,7 @@
     },
     "node_modules/n-common-static-data": {
       "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/Financial-Times/n-common-static-data.git#d79d2d88af2356c0034bcc35a0468645e5ff2d8e",
+      "resolved": "git+ssh://git@github.com/Financial-Times/n-common-static-data.git#05c71455db73fe5e3cddd197afc2f0954c365c16",
       "engines": {
         "node": "16.x || 18.x",
         "npm": "7.x || 8.x || 9.x"
@@ -39902,8 +39902,8 @@
       }
     },
     "n-common-static-data": {
-      "version": "git+ssh://git@github.com/Financial-Times/n-common-static-data.git#d79d2d88af2356c0034bcc35a0468645e5ff2d8e",
-      "from": "n-common-static-data@github:Financial-Times/n-common-static-data#v2.2.0"
+      "version": "git+ssh://git@github.com/Financial-Times/n-common-static-data.git#05c71455db73fe5e3cddd197afc2f0954c365c16",
+      "from": "n-common-static-data@github:Financial-Times/n-common-static-data#v2.3.0"
     },
     "nanoid": {
       "version": "3.3.7",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "classnames": "2.3.2",
     "fetchres": "1.7.2",
     "lodash.get": "4.4.2",
-    "n-common-static-data": "github:Financial-Times/n-common-static-data#v2.3.0"
+    "n-common-static-data": "github:Financial-Times/n-common-static-data#v2.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.22.15",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "test": "dotcom-tool-kit test:local",
+    "test:update-snapshots": "NODE_ENV=test jest --updateSnapshot",
     "prepare": "snyk-protect || snyk-protect -d || true",
     "build": "npm run clean && dotcom-tool-kit build:local",
     "start": "dotcom-tool-kit run:local",
@@ -29,7 +30,7 @@
     "classnames": "2.3.2",
     "fetchres": "1.7.2",
     "lodash.get": "4.4.2",
-    "n-common-static-data": "github:Financial-Times/n-common-static-data#v2.2.0"
+    "n-common-static-data": "github:Financial-Times/n-common-static-data#v2.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.15",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
This ticket focuses on syncing `n-common-static-data` lists with FT Core.

The following actions were taken:
- sorted `industry`, `position` and `responsibility` lists for better UI display
- created `Default` stories for `industry`, `position` and `responsibility` in Storybook
- updated `n-common-static-data` dependency (v2.3.1 tag)
- update test snapshots

### Ticket
<!-- Add link to the corresponding ticket -->
[ACQ-2528](https://financialtimes.atlassian.net/browse/ACQ-2528)

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [x] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [x] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner


[ACQ-2528]: https://financialtimes.atlassian.net/browse/ACQ-2528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ