### PR TITLE
ACQ-2503: removed n-common-static-data b2b demographics reference

### DIFF
--- a/components/position.jsx
+++ b/components/position.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { b2b, demographics } from 'n-common-static-data';
-const B2CPositions = demographics.positions.positions;
-const B2BPositions = b2b.demographics.positions.positions;
+import { demographics } from 'n-common-static-data';
 
 export function Position({
 	value,
@@ -12,8 +10,7 @@ export function Position({
 	fieldId = 'positionField',
 	selectId = 'position',
 	selectName = 'position',
-	isB2B = false,
-	options = isB2B ? B2BPositions : B2CPositions,
+	options = demographics.positions.positions,
 	isRequired = true,
 	fieldLabel = 'What’s your job position?',
 }) {

--- a/components/responsibility.jsx
+++ b/components/responsibility.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { b2b, demographics } from 'n-common-static-data';
-const B2CResponsibilities = demographics.responsibilities.responsibilities;
-const B2BResponsibilities = b2b.demographics.responsibilities.responsibilities;
+import { demographics } from 'n-common-static-data';
 
 export function Responsibility({
 	value,
@@ -13,8 +11,7 @@ export function Responsibility({
 	fieldId = 'responsibilityField',
 	selectId = 'responsibility',
 	selectName = 'responsibility',
-	isB2B = false,
-	options = isB2B ? B2BResponsibilities : B2CResponsibilities,
+	options = demographics.responsibilities.responsibilities,
 	fieldLabel = 'Which best describes your job responsibility?',
 }) {
 	const inputWrapperClassName = classNames([


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
This PR will remove the reference to the `b2b/demographics` object in `n-common-static-data` since `b2b` and `b2c` were using the same lists (duplicate references).

There were no other references to `b2b/demographics` found in other repos.

### Ticket
<!-- Add link to the corresponding ticket -->
[ACQ-2503](https://financialtimes.atlassian.net/browse/ACQ-2503)