### PR TITLE
ACQ-2592: add an isTrialOfferAsNonTrialOverride property to display a trial off…

### DIFF
--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -17,6 +17,7 @@ export function PaymentTerm({
 	billingCountry = '',
 	is7DayPassExperiment = false,
 	isTermedSubscriptionTermType = false,
+	isTrialOfferAsNonTrialOverride = false,
 }) {
 	/**
 	 * Compute monthly price for given term name
@@ -319,7 +320,18 @@ export function PaymentTerm({
 				const termName = option.displayName
 					? option.displayName
 					: 'Premium Digital';
-				termDisplayName = `Trial: ${termName} - `;
+
+				// https://financialtimes.atlassian.net/browse/ACQ-2592
+				// We need to have one specific trial offer to have terms displayed as non-trial.
+				// The offer is a trial offer and should use trial mechanics but should show as non-trial.
+				// There is nothing in the offer payload to identify when this should happen, we need to rely on the offer id.
+				// This is a TEMPORARY hack and will be removed once the campaign is over.
+				// A ticket as been raised already to deal with the clean up: https://financialtimes.atlassian.net/browse/ACQ-2593.
+				const trialPrefix = isTrialOfferAsNonTrialOverride ? '' : 'Trial: ';
+				termDisplayName = `${trialPrefix}${termName} - `;
+
+				// the original line of code being
+				// termDisplayName = `Trial: ${termName} - `;
 			}
 
 			const getTermPeriod = () => {
@@ -461,4 +473,5 @@ PaymentTerm.propTypes = {
 	largePrice: PropTypes.bool,
 	optionsInARow: PropTypes.bool,
 	billingCountry: PropTypes.string,
+	isTrialOfferAsNonTrialOverride: PropTypes.bool,
 };

--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -18,6 +18,7 @@ export function PaymentTerm({
 	is7DayPassExperiment = false,
 	isTermedSubscriptionTermType = false,
 	isTrialOfferAsNonTrialOverride = false,
+	labelOverride = '', // this is a temporary hack for the February 2024 campaign
 }) {
 	/**
 	 * Compute monthly price for given term name
@@ -26,7 +27,7 @@ export function PaymentTerm({
 	 * @param {string} period (expressed in IS0 8601 duration format): e.g. PxY (yearly) or PxM (montly) where x is the amount of years/months
 	 * @returns {string}
 	 */
-	const getMontlyPriceFromPeriod = (amount, currency, period) => {
+	const getMonthlyPriceFromPeriod = (amount, currency, period) => {
 		const periodObj = new Period(period);
 		const monthlyPrice = periodObj.calculatePrice('P1M', amount);
 		return new Monthly({ value: monthlyPrice, currency }).getAmount('monthly');
@@ -269,7 +270,7 @@ export function PaymentTerm({
 							{nameMap['custom'].monthlyPrice(
 								option.monthlyPrice && option.monthlyPrice !== '0'
 									? Number(option.monthlyPrice)
-									: getMontlyPriceFromPeriod(
+									: getMonthlyPriceFromPeriod(
 											option.amount,
 											option.currency,
 											option.value
@@ -299,6 +300,16 @@ export function PaymentTerm({
 			const showTrialCopyInTitle =
 				option.isTrial && !isPrintOrBundle && !isEpaper;
 
+			// https://financialtimes.atlassian.net/browse/ACQ-2592
+			// We need to have one specific trial offer to have terms displayed as non-trial.
+			// The offer is a trial offer and should use trial mechanics but should show as non-trial.
+			// There is nothing in the offer payload to identify when this should happen, we need to rely on the offer id.
+			// This is a TEMPORARY hack and will be removed once the campaign is over.
+			// A ticket as been raised already to deal with the clean up: https://financialtimes.atlassian.net/browse/ACQ-2593.
+			if (isTrialOfferAsNonTrialOverride && labelOverride) {
+				return labelOverride;
+			}
+
 			const defaultTitle = (() => {
 				if (is7DayPassExperiment) {
 					return '';
@@ -320,18 +331,7 @@ export function PaymentTerm({
 				const termName = option.displayName
 					? option.displayName
 					: 'Premium Digital';
-
-				// https://financialtimes.atlassian.net/browse/ACQ-2592
-				// We need to have one specific trial offer to have terms displayed as non-trial.
-				// The offer is a trial offer and should use trial mechanics but should show as non-trial.
-				// There is nothing in the offer payload to identify when this should happen, we need to rely on the offer id.
-				// This is a TEMPORARY hack and will be removed once the campaign is over.
-				// A ticket as been raised already to deal with the clean up: https://financialtimes.atlassian.net/browse/ACQ-2593.
-				const trialPrefix = isTrialOfferAsNonTrialOverride ? '' : 'Trial: ';
-				termDisplayName = `${trialPrefix}${termName} - `;
-
-				// the original line of code being
-				// termDisplayName = `Trial: ${termName} - `;
+				termDisplayName = `Trial: ${termName} - `;
 			}
 
 			const getTermPeriod = () => {

--- a/components/payment-term.spec.js
+++ b/components/payment-term.spec.js
@@ -261,7 +261,7 @@ describe('PaymentTerm', () => {
 				);
 			});
 		});
-		describe('getDisplayName', () => {
+		describe('getDisplayName trial', () => {
 			const trialOptions = {
 				...baseOptions,
 				isTrial: true,
@@ -275,10 +275,15 @@ describe('PaymentTerm', () => {
 			});
 			it('handles trial to non-trial payment term display name', () => {
 				const options = [trialOptions];
-				options.isTrialOfferAsNonTrialOverride = true;
-				const wrapper = shallow(<PaymentTerm options={options} />);
+				const wrapper = shallow(
+					<PaymentTerm
+						options={options}
+						labelOverride={'some term label'}
+						isTrialOfferAsNonTrialOverride={true}
+					/>
+				);
 				expect(wrapper.find('.ncf__payment-term__label').text()).toMatch(
-					/^Trial: Premium Digital - Monthly .*$/
+					/^some term label.*$/
 				);
 			});
 			it('renders using displayName if available', () => {

--- a/components/payment-term.spec.js
+++ b/components/payment-term.spec.js
@@ -273,6 +273,14 @@ describe('PaymentTerm', () => {
 					/^Trial: Premium Digital - Monthly .*$/
 				);
 			});
+			it('handles trial to non-trial payment term display name', () => {
+				const options = [trialOptions];
+				options.isTrialOfferAsNonTrialOverride = true;
+				const wrapper = shallow(<PaymentTerm options={options} />);
+				expect(wrapper.find('.ncf__payment-term__label').text()).toMatch(
+					/^Trial: Premium Digital - Monthly .*$/
+				);
+			});
 			it('renders using displayName if available', () => {
 				const options = [
 					{

--- a/components/payment-term.stories.js
+++ b/components/payment-term.stories.js
@@ -183,3 +183,38 @@ RenewOffers.args = {
 	],
 	optionsInARow: true,
 };
+
+// https://financialtimes.atlassian.net/browse/ACQ-2592
+// We need to have one specific trial offer to have terms displayed as non-trial.
+// The offer is a trial offer and should use trial mechanics but should show as non-trial.
+// There is nothing in the offer payload to identify when this should happen, we need to rely on the offer id.
+// This is a TEMPORARY hack and will be removed once the campaign is over.
+// A ticket as been raised already to deal with the clean up: https://financialtimes.atlassian.net/browse/ACQ-2593.
+export const PaymentTermLabelOverride = (args) => (
+	<div className="ncf">
+		<Fieldset>
+			<PaymentTerm {...args} />
+		</Fieldset>
+	</div>
+);
+
+PaymentTermLabelOverride.args = {
+	isTrialOfferAsNonTrialOverride: true,
+	labelOverride: 'some fancy payment term',
+	options: [
+		{
+			name: '6 monthly',
+			isTrial: false,
+			discount: '',
+			selected: false,
+			price: '$229.00',
+			trialPrice: '$0.00',
+			trialDuration: '',
+			monthlyPrice: '0',
+			amount: '229.00',
+			trialAmount: null,
+			value: 'P6M',
+			currency: 'USD',
+		},
+	],
+};


### PR DESCRIPTION
…er as non-trial

### Description
	// https://financialtimes.atlassian.net/browse/ACQ-2592
	// We need to have one specific trial offer to have terms displayed as non-trial.
	// The offer is a trial offer and should use trial mechanics but should show as non-trial.
	// There is nothing in the offer payload to identify when this should happen, we need to rely on the offer id.
	// This is a TEMPORARY hack and will be removed once the campaign is over.
	// A ticket as been raised already to deal with the clean up: https://financialtimes.atlassian.net/browse/ACQ-2593.

Note:
So my PR will **ONLY deal with the main label**. of the term
If they want further changes, they'll go to our product team with complete requirements.
I suspect there are other places where it will mention the trial things, like the confirmation page.
But as an emergency patch, I'm not willing to change to many things in one go.
I have asked in the thread already and let them know about it here: https://financialtimes.slack.com/archives/CSVRXFV6F/p1707302278097599?thread_ts=1707153263.283689&cid=CSVRXFV6F

Matching change in next-subscribe:
https://github.com/Financial-Times/next-subscribe/pull/2759

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-2592

### Screenshots
isTrialOfferAsNonTrialOverride = false (current, default behaviour)
![image](https://github.com/Financial-Times/n-conversion-forms/assets/6513313/c54808b0-28e1-46dd-815b-411bbad67dd6)

isTrialOfferAsNonTrialOverride = true (remove the "trial: " prefix)
![image](https://github.com/Financial-Times/n-conversion-forms/assets/6513313/8954a782-fce3-423e-993c-77c9a9d770da)

If an override string is provided, the whole payment term title will be overridden.
![image](https://github.com/Financial-Times/n-conversion-forms/assets/6513313/6ee5716d-f843-4244-bfc5-34cc3d8fd131)



### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
