### PR TITLE
Remove isFixedTermOffer

### DIFF
--- a/components/payment-term.jsx
+++ b/components/payment-term.jsx
@@ -9,8 +9,6 @@ export function PaymentTerm({
 	isPrintOrBundle = false,
 	isEpaper = false,
 	options = [],
-	isFixedTermOffer = false,
-	offerDisplayName,
 	showLegal = true,
 	largePrice = false,
 	optionsInARow = false,
@@ -133,15 +131,11 @@ export function PaymentTerm({
 				</React.Fragment>
 			),
 			monthlyPrice: () => {},
-			renewsText: (isFixedTermOffer) => {
-				const textToDisplay = isFixedTermOffer
-					? 'This subscription is for 3 months, charged monthly. You can cancel at anytime'
-					: 'Renews monthly unless cancelled';
-
-				return (
-					<p className="ncf__payment-term__renews-text">{textToDisplay}</p>
-				);
-			},
+			renewsText: () => (
+				<p className="ncf__payment-term__renews-text">
+					{'Renews monthly unless cancelled'}
+				</p>
+			),
 		},
 		custom: {
 			price: (price) => (
@@ -235,7 +229,7 @@ export function PaymentTerm({
 						<div className="ncf__payment-term__description">
 							{nameMap[option.name].price(option.price)}
 							{nameMap[option.name].monthlyPrice(option.monthlyPrice)}
-							{nameMap[option.name].renewsText(isFixedTermOffer)}
+							{nameMap[option.name].renewsText()}
 							{/* Remove this discount text temporarily in favour of monthly price */}
 							{/* <br />Save up to 25% when you pay annually */}
 						</div>
@@ -287,12 +281,8 @@ export function PaymentTerm({
 				return labelOverride;
 			}
 
-			const defaultTitle =
+			const title =
 				option.name && nameMap[option.name] ? nameMap[option.name].title : '';
-
-			const title = isFixedTermOffer
-				? `${offerDisplayName} - ${defaultTitle}`
-				: defaultTitle;
 
 			let termDisplayName = '';
 			if (showTrialCopyInTitle) {
@@ -363,7 +353,7 @@ export function PaymentTerm({
 
 			{showLegal && (
 				<div className="ncf__payment-term__legal">
-					{isTermedSubscriptionTermType || isFixedTermOffer ? (
+					{isTermedSubscriptionTermType ? (
 						<p>
 							Find out more about our cancellation policy in our{' '}
 							<a
@@ -434,9 +424,7 @@ PaymentTerm.propTypes = {
 			fulfilmentOption: PropTypes.string,
 		})
 	),
-	isFixedTermOffer: PropTypes.bool,
 	isTermedSubscriptionTermType: PropTypes.bool,
-	offerDisplayName: PropTypes.string,
 	showLegal: PropTypes.bool,
 	largePrice: PropTypes.bool,
 	optionsInARow: PropTypes.bool,

--- a/components/payment-term.spec.js
+++ b/components/payment-term.spec.js
@@ -117,42 +117,6 @@ describe('PaymentTerm', () => {
 		});
 	});
 
-	describe('given isFixedTermOffer prop is set to true', () => {
-		const options = [
-			{
-				name: 'monthly',
-				price: '$5.00',
-				value: 'monthly',
-				monthlyPrice: '$5.00',
-			},
-		];
-		const wrapper = shallow(
-			<PaymentTerm
-				isFixedTermOffer={true}
-				options={options}
-				offerDisplayName="Mix & Match"
-			/>
-		);
-
-		it('does not include renewal text', () => {
-			expect(
-				wrapper.find('.ncf__payment-term__renews-text').text()
-			).not.toMatch(/Renews (annually|monthly|quarterly) unless cancelled/);
-		});
-
-		it('renders fixed term renewal text in English', () => {
-			expect(wrapper.find('.ncf__payment-term__renews-text').text()).toMatch(
-				/This subscription is for 3 months, charged monthly. You can cancel at anytime/
-			);
-		});
-
-		it('renders offer name on payment term title', () => {
-			expect(wrapper.find('.ncf__payment-term__title').text()).toMatch(
-				'Mix & Match - Monthly'
-			);
-		});
-	});
-
 	describe('given isTermedSubscriptionTermType is true', () => {
 		describe('options include duration expressed in weeks', () => {
 			const options = [

--- a/components/payment-term.stories.js
+++ b/components/payment-term.stories.js
@@ -90,25 +90,6 @@ Basic.args = {
 	],
 };
 
-export const FixedTermOffer = (args) => (
-	<div className="ncf">
-		<Fieldset>
-			<PaymentTerm {...args} />
-		</Fieldset>
-	</div>
-);
-FixedTermOffer.args = {
-	options: [
-		{
-			name: 'monthly',
-			price: '$5.00',
-			value: 5.0,
-		},
-	],
-	isFixedTermOffer: true,
-	offerDisplayName: 'Mix & Match',
-};
-
 export const TermedSubscriptionTermType = (args) => (
 	<div className="ncf">
 		<Fieldset>


### PR DESCRIPTION
### Description
This is a follow-up to https://github.com/Financial-Times/n-conversion-forms/pull/780.

It transpires that `isFixedTermOffer` was tied to the usage of the Lite Subs (as introduced in this PR https://github.com/Financial-Times/n-conversion-forms/pull/482, and which the above-mentioned PR removed) and so should be removed along with it.

These changes should be released and then consumed by this [next-subscribe branch](https://github.com/Financial-Times/next-subscribe/compare/main...remove-usage-of-lite-subs-confirmation-is-fixed-term-offer) to remove usage of both LiteSubConfirmation and `isFixedTermOffer`.

It feels important to tidy up these unused terms because in next-subscribe there currently exists the following, which all sound similar and are hard to distinguish without sufficient institutional knowledge:
- `isFixedTermOffer` — tied to Lite Subs and removed by this PR
- `oneTimeCharge` — seemingly used for the £1 payment for trials
- `isTermedSubscriptionTermType` — this one is still active and is being used to facilitate subscriptions made via the Sort Your Financial Life Out newsletter series offer

### Ticket
N/A

### Screenshots
N/A

## Release:
I propose to release this as a **major** version. Even though I will be removing all consumption of this component (which is unused in production) it is still technically a breaking change by virtue of the fact that it removes the ability to provide certain arguments to the PaymentTerm component.

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
