### PR TITLE
fix + style: correct styling for confirmation page of the /register route and add styling tweaks for  confirmation page of the /ft-edit-registration route

### DIFF
--- a/components/__snapshots__/ft-edit-registration-confirmation.spec.js.snap
+++ b/components/__snapshots__/ft-edit-registration-confirmation.spec.js.snap
@@ -8,116 +8,29 @@ exports[`RegistrationConfirmation renders a continue reading button when an arti
     <h1 class="ncf__header ncf__header--confirmation">
       Success
     </h1>
-    <p class="ncf__FT_Edit_confirmation--message">
+    <p class="ncf_confirmation--message">
       Thank you for registering for FT Edit.
     </p>
-    <p class="ncf__FT_Edit_confirmation--message margin-top-x4 ">
-      Enjoy 30 days of great journalism. We’ve sent confirmation to test@example.com.
-    </p>
-  </div>
-  <div class="ncf__divider-horizontal">
-  </div>
-  <div class="ncf__FT_Edit_confirmation--links ncf__margin">
-    <div class="ncf__FT_Edit_confirmation--socials">
-      <b>
-        Breaking news alerts, direct to your lock screen
-      </b>
-      <p class="ncf__FT_Edit_confirmation--mobile">
-        Download our apps or follow us on our socials
-      </p>
-      <p class="ncf__FT_Edit_confirmation--desktop">
-        Find us in the app stores or follow us on our socials
-      </p>
-      <div class="ncf__FT_Edit_confirmation--badges">
-        <div class="o-social-follow"
-             aria-label="Follow on social media"
-        >
-          <a href="https://www.instagram.com/financialtimes"
-             class="o-social-follow-icon o-social-follow-icon--instagram"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-social-instagram"
-          >
-            <span class="o-social-follow-icon__label">
-              on instagram
-            </span>
-          </a>
-          <a href="https://www.linkedin.com/company/financial-times"
-             class="o-social-follow-icon o-social-follow-icon--linkedin"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-social-linkedin"
-          >
-            <span class="o-social-follow-icon__label">
-              on linkedin
-            </span>
-          </a>
-          <a href="https://twitter.com/FT"
-             class="o-social-follow-icon o-social-follow-icon--twitter"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-social-twitter"
-          >
-            <span class="o-social-follow-icon__label">
-              on twitter
-            </span>
-          </a>
-          <a href="https://www.facebook.com/financialtimes"
-             class="o-social-follow-icon o-social-follow-icon--facebook"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-social-facebook"
-          >
-            <span class="o-social-follow-icon__label">
-              on facebook
-            </span>
-          </a>
-        </div>
-        <div class="ncf__FT_Edit_confirmation--mobile ncf__FT_Edit_confirmation--app-badges"
-             aria-label="Download the app"
-        >
-          <a href="https://apps.apple.com/gb/app/ft-edit-by-the-financial-times/id1574510369"
-             class="ncf-icon ncf-icon--apple"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-app-apple-ft-edit"
-          >
-            <span class="o-social-follow-icon__label">
-              on apple
-            </span>
-          </a>
-        </div>
+    <p class="ncf__confirmation--message margin-top-x4 ">
+      Enjoy 30 days of great journalism. We’ve sent confirmation to
+      <div>
+        <strong>
+          test@example.com
+        </strong>
+        .
       </div>
-    </div>
-    <div class="ncf__FT_Edit_confirmation--alerts">
-      <b>
-        Set up email alerts in
-        <span aria-label="myFT"
-              class="ncf-icon ncf-icon--myft"
-        >
-        </span>
-      </b>
-      <p>
-        Choose the content you want to follow by personalising your alerts for the most important topics and additional newsletters
-      </p>
-      <a href="/myft"
-         class="margin-top-x4 ncf__button ncf__button--secondary"
-         data-trackable="register-personalise-my-alerts"
-      >
-        Personalise my alerts
-      </a>
-    </div>
+    </p>
   </div>
   <a href="/"
      target="_parent"
-     class=" ncf__FT_Edit_confirmation--finish ncf__button ncf__button--submit"
+     class=" ncf__confirmation--finish ncf__button ncf__button--submit"
      data-trackable="register-finish-head-to-ft-edit-hub"
   >
     Explore our FT Edit hub
   </a>
   <a href="https://www.ft.com/content/9141eee7-825a-41d7-913d-49e8c12e76db"
      target="_parent"
-     class=" ncf__FT_Edit_confirmation--finish-article-read ncf__button ncf__button--secondary reduce-bottom-spacing"
+     class=" ncf__confirmation--finish-article-read ncf__button ncf__button--secondary reduce-bottom-spacing"
      data-trackable="register-finish-head-to-article"
   >
     Continue reading
@@ -133,109 +46,22 @@ exports[`RegistrationConfirmation renders an explore hub button always 1`] = `
     <h1 class="ncf__header ncf__header--confirmation">
       Success
     </h1>
-    <p class="ncf__FT_Edit_confirmation--message">
+    <p class="ncf_confirmation--message">
       Thank you for registering for FT Edit.
     </p>
-    <p class="ncf__FT_Edit_confirmation--message margin-top-x4 ">
-      Enjoy 30 days of great journalism. We’ve sent confirmation to test@example.com.
-    </p>
-  </div>
-  <div class="ncf__divider-horizontal">
-  </div>
-  <div class="ncf__FT_Edit_confirmation--links ncf__margin">
-    <div class="ncf__FT_Edit_confirmation--socials">
-      <b>
-        Breaking news alerts, direct to your lock screen
-      </b>
-      <p class="ncf__FT_Edit_confirmation--mobile">
-        Download our apps or follow us on our socials
-      </p>
-      <p class="ncf__FT_Edit_confirmation--desktop">
-        Find us in the app stores or follow us on our socials
-      </p>
-      <div class="ncf__FT_Edit_confirmation--badges">
-        <div class="o-social-follow"
-             aria-label="Follow on social media"
-        >
-          <a href="https://www.instagram.com/financialtimes"
-             class="o-social-follow-icon o-social-follow-icon--instagram"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-social-instagram"
-          >
-            <span class="o-social-follow-icon__label">
-              on instagram
-            </span>
-          </a>
-          <a href="https://www.linkedin.com/company/financial-times"
-             class="o-social-follow-icon o-social-follow-icon--linkedin"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-social-linkedin"
-          >
-            <span class="o-social-follow-icon__label">
-              on linkedin
-            </span>
-          </a>
-          <a href="https://twitter.com/FT"
-             class="o-social-follow-icon o-social-follow-icon--twitter"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-social-twitter"
-          >
-            <span class="o-social-follow-icon__label">
-              on twitter
-            </span>
-          </a>
-          <a href="https://www.facebook.com/financialtimes"
-             class="o-social-follow-icon o-social-follow-icon--facebook"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-social-facebook"
-          >
-            <span class="o-social-follow-icon__label">
-              on facebook
-            </span>
-          </a>
-        </div>
-        <div class="ncf__FT_Edit_confirmation--mobile ncf__FT_Edit_confirmation--app-badges"
-             aria-label="Download the app"
-        >
-          <a href="https://apps.apple.com/gb/app/ft-edit-by-the-financial-times/id1574510369"
-             class="ncf-icon ncf-icon--apple"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-app-apple-ft-edit"
-          >
-            <span class="o-social-follow-icon__label">
-              on apple
-            </span>
-          </a>
-        </div>
+    <p class="ncf__confirmation--message margin-top-x4 ">
+      Enjoy 30 days of great journalism. We’ve sent confirmation to
+      <div>
+        <strong>
+          test@example.com
+        </strong>
+        .
       </div>
-    </div>
-    <div class="ncf__FT_Edit_confirmation--alerts">
-      <b>
-        Set up email alerts in
-        <span aria-label="myFT"
-              class="ncf-icon ncf-icon--myft"
-        >
-        </span>
-      </b>
-      <p>
-        Choose the content you want to follow by personalising your alerts for the most important topics and additional newsletters
-      </p>
-      <a href="/myft"
-         class="margin-top-x4 ncf__button ncf__button--secondary"
-         data-trackable="register-personalise-my-alerts"
-      >
-        Personalise my alerts
-      </a>
-    </div>
+    </p>
   </div>
   <a href="http://thing-hub"
      target="_parent"
-     class=" ncf__FT_Edit_confirmation--finish ncf__button ncf__button--submit"
+     class=" ncf__confirmation--finish ncf__button ncf__button--submit"
      data-trackable="register-finish-head-to-ft-edit-hub"
   >
     Explore our FT Edit hub
@@ -251,109 +77,22 @@ exports[`RegistrationConfirmation renders with a custom email 1`] = `
     <h1 class="ncf__header ncf__header--confirmation">
       Success
     </h1>
-    <p class="ncf__FT_Edit_confirmation--message">
+    <p class="ncf_confirmation--message">
       Thank you for registering for FT Edit.
     </p>
-    <p class="ncf__FT_Edit_confirmation--message margin-top-x4 ">
-      Enjoy 30 days of great journalism. We’ve sent confirmation to test@example.com.
-    </p>
-  </div>
-  <div class="ncf__divider-horizontal">
-  </div>
-  <div class="ncf__FT_Edit_confirmation--links ncf__margin">
-    <div class="ncf__FT_Edit_confirmation--socials">
-      <b>
-        Breaking news alerts, direct to your lock screen
-      </b>
-      <p class="ncf__FT_Edit_confirmation--mobile">
-        Download our apps or follow us on our socials
-      </p>
-      <p class="ncf__FT_Edit_confirmation--desktop">
-        Find us in the app stores or follow us on our socials
-      </p>
-      <div class="ncf__FT_Edit_confirmation--badges">
-        <div class="o-social-follow"
-             aria-label="Follow on social media"
-        >
-          <a href="https://www.instagram.com/financialtimes"
-             class="o-social-follow-icon o-social-follow-icon--instagram"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-social-instagram"
-          >
-            <span class="o-social-follow-icon__label">
-              on instagram
-            </span>
-          </a>
-          <a href="https://www.linkedin.com/company/financial-times"
-             class="o-social-follow-icon o-social-follow-icon--linkedin"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-social-linkedin"
-          >
-            <span class="o-social-follow-icon__label">
-              on linkedin
-            </span>
-          </a>
-          <a href="https://twitter.com/FT"
-             class="o-social-follow-icon o-social-follow-icon--twitter"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-social-twitter"
-          >
-            <span class="o-social-follow-icon__label">
-              on twitter
-            </span>
-          </a>
-          <a href="https://www.facebook.com/financialtimes"
-             class="o-social-follow-icon o-social-follow-icon--facebook"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-social-facebook"
-          >
-            <span class="o-social-follow-icon__label">
-              on facebook
-            </span>
-          </a>
-        </div>
-        <div class="ncf__FT_Edit_confirmation--mobile ncf__FT_Edit_confirmation--app-badges"
-             aria-label="Download the app"
-        >
-          <a href="https://apps.apple.com/gb/app/ft-edit-by-the-financial-times/id1574510369"
-             class="ncf-icon ncf-icon--apple"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-app-apple-ft-edit"
-          >
-            <span class="o-social-follow-icon__label">
-              on apple
-            </span>
-          </a>
-        </div>
+    <p class="ncf__confirmation--message margin-top-x4 ">
+      Enjoy 30 days of great journalism. We’ve sent confirmation to
+      <div>
+        <strong>
+          test@example.com
+        </strong>
+        .
       </div>
-    </div>
-    <div class="ncf__FT_Edit_confirmation--alerts">
-      <b>
-        Set up email alerts in
-        <span aria-label="myFT"
-              class="ncf-icon ncf-icon--myft"
-        >
-        </span>
-      </b>
-      <p>
-        Choose the content you want to follow by personalising your alerts for the most important topics and additional newsletters
-      </p>
-      <a href="/myft"
-         class="margin-top-x4 ncf__button ncf__button--secondary"
-         data-trackable="register-personalise-my-alerts"
-      >
-        Personalise my alerts
-      </a>
-    </div>
+    </p>
   </div>
   <a href="/"
      target="_parent"
-     class=" ncf__FT_Edit_confirmation--finish ncf__button ncf__button--submit"
+     class=" ncf__confirmation--finish ncf__button ncf__button--submit"
      data-trackable="register-finish-head-to-ft-edit-hub"
   >
     Explore our FT Edit hub
@@ -369,109 +108,22 @@ exports[`RegistrationConfirmation renders with default props 1`] = `
     <h1 class="ncf__header ncf__header--confirmation">
       Success
     </h1>
-    <p class="ncf__FT_Edit_confirmation--message">
+    <p class="ncf_confirmation--message">
       Thank you for registering for FT Edit.
     </p>
-    <p class="ncf__FT_Edit_confirmation--message margin-top-x4 ">
-      Enjoy 30 days of great journalism. We’ve sent confirmation to your email.
-    </p>
-  </div>
-  <div class="ncf__divider-horizontal">
-  </div>
-  <div class="ncf__FT_Edit_confirmation--links ncf__margin">
-    <div class="ncf__FT_Edit_confirmation--socials">
-      <b>
-        Breaking news alerts, direct to your lock screen
-      </b>
-      <p class="ncf__FT_Edit_confirmation--mobile">
-        Download our apps or follow us on our socials
-      </p>
-      <p class="ncf__FT_Edit_confirmation--desktop">
-        Find us in the app stores or follow us on our socials
-      </p>
-      <div class="ncf__FT_Edit_confirmation--badges">
-        <div class="o-social-follow"
-             aria-label="Follow on social media"
-        >
-          <a href="https://www.instagram.com/financialtimes"
-             class="o-social-follow-icon o-social-follow-icon--instagram"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-social-instagram"
-          >
-            <span class="o-social-follow-icon__label">
-              on instagram
-            </span>
-          </a>
-          <a href="https://www.linkedin.com/company/financial-times"
-             class="o-social-follow-icon o-social-follow-icon--linkedin"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-social-linkedin"
-          >
-            <span class="o-social-follow-icon__label">
-              on linkedin
-            </span>
-          </a>
-          <a href="https://twitter.com/FT"
-             class="o-social-follow-icon o-social-follow-icon--twitter"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-social-twitter"
-          >
-            <span class="o-social-follow-icon__label">
-              on twitter
-            </span>
-          </a>
-          <a href="https://www.facebook.com/financialtimes"
-             class="o-social-follow-icon o-social-follow-icon--facebook"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-social-facebook"
-          >
-            <span class="o-social-follow-icon__label">
-              on facebook
-            </span>
-          </a>
-        </div>
-        <div class="ncf__FT_Edit_confirmation--mobile ncf__FT_Edit_confirmation--app-badges"
-             aria-label="Download the app"
-        >
-          <a href="https://apps.apple.com/gb/app/ft-edit-by-the-financial-times/id1574510369"
-             class="ncf-icon ncf-icon--apple"
-             target="_blank"
-             rel="noopener noreferrer"
-             data-trackable="register-app-apple-ft-edit"
-          >
-            <span class="o-social-follow-icon__label">
-              on apple
-            </span>
-          </a>
-        </div>
+    <p class="ncf__confirmation--message margin-top-x4 ">
+      Enjoy 30 days of great journalism. We’ve sent confirmation to
+      <div>
+        <strong>
+          bob@gmail.com
+        </strong>
+        .
       </div>
-    </div>
-    <div class="ncf__FT_Edit_confirmation--alerts">
-      <b>
-        Set up email alerts in
-        <span aria-label="myFT"
-              class="ncf-icon ncf-icon--myft"
-        >
-        </span>
-      </b>
-      <p>
-        Choose the content you want to follow by personalising your alerts for the most important topics and additional newsletters
-      </p>
-      <a href="/myft"
-         class="margin-top-x4 ncf__button ncf__button--secondary"
-         data-trackable="register-personalise-my-alerts"
-      >
-        Personalise my alerts
-      </a>
-    </div>
+    </p>
   </div>
   <a href="/"
      target="_parent"
-     class=" ncf__FT_Edit_confirmation--finish ncf__button ncf__button--submit"
+     class=" ncf__confirmation--finish ncf__button ncf__button--submit"
      data-trackable="register-finish-head-to-ft-edit-hub"
   >
     Explore our FT Edit hub

--- a/components/ft-edit-registration-confirmation.jsx
+++ b/components/ft-edit-registration-confirmation.jsx
@@ -6,26 +6,7 @@ import PropTypes from 'prop-types';
  * next-subscribe. This can be removed after the trial. The trial is beginning May 2024, please
  * reach out to light-apps channel if we dont reach out first, as to when this can be deleted.
  */
-const EMAIL_DEFAULT_TEXT = 'your email';
-
-const SOCIALS = [
-	{
-		name: 'instagram',
-		link: 'https://www.instagram.com/financialtimes',
-	},
-	{
-		name: 'linkedin',
-		link: 'https://www.linkedin.com/company/financial-times',
-	},
-	{
-		name: 'twitter',
-		link: 'https://twitter.com/FT',
-	},
-	{
-		name: 'facebook',
-		link: 'https://www.facebook.com/financialtimes',
-	},
-];
+const EMAIL_DEFAULT_TEXT = 'bob@gmail.com';
 
 export function FTEditRegistrationConfirmation({
 	email = EMAIL_DEFAULT_TEXT,
@@ -37,84 +18,21 @@ export function FTEditRegistrationConfirmation({
 			<div className="ncf__center ncf__margin">
 				<div className="ncf__icon ncf__icon--tick ncf__icon--large"></div>
 				<h1 className="ncf__header ncf__header--confirmation">Success</h1>
-				<p className="ncf__FT_Edit_confirmation--message">
+				<p className="ncf_confirmation--message">
 					Thank you for registering for FT Edit.
 				</p>
-				<p className="ncf__FT_Edit_confirmation--message margin-top-x4 ">
-					Enjoy 30 days of great journalism. We’ve sent confirmation to {email}.
-				</p>
-			</div>
-
-			<div className="ncf__divider-horizontal" />
-
-			<div className="ncf__FT_Edit_confirmation--links ncf__margin">
-				<div className="ncf__FT_Edit_confirmation--socials">
-					<b>Breaking news alerts, direct to your lock screen</b>
-					<p className="ncf__FT_Edit_confirmation--mobile">
-						Download our apps or follow us on our socials
-					</p>
-					<p className="ncf__FT_Edit_confirmation--desktop">
-						Find us in the app stores or follow us on our socials
-					</p>
-					<div className="ncf__FT_Edit_confirmation--badges">
-						<div
-							className="o-social-follow"
-							aria-label="Follow on social media"
-						>
-							{SOCIALS.map(({ name, link }) => (
-								<a
-									key={name}
-									href={link}
-									className={`o-social-follow-icon o-social-follow-icon--${name}`}
-									target="_blank"
-									rel="noopener noreferrer"
-									data-trackable={`register-social-${name}`}
-								>
-									<span className="o-social-follow-icon__label">on {name}</span>
-								</a>
-							))}
-						</div>
-						<div
-							className="ncf__FT_Edit_confirmation--mobile ncf__FT_Edit_confirmation--app-badges"
-							aria-label="Download the app"
-						>
-							<a
-								key="apple-ft-edit"
-								href="https://apps.apple.com/gb/app/ft-edit-by-the-financial-times/id1574510369"
-								className={`ncf-icon ncf-icon--apple`}
-								target="_blank"
-								rel="noopener noreferrer"
-								data-trackable={`register-app-apple-ft-edit`}
-							>
-								<span className="o-social-follow-icon__label">on apple</span>
-							</a>
-						</div>
+				<p className="ncf__confirmation--message margin-top-x4 ">
+					Enjoy 30 days of great journalism. We’ve sent confirmation to
+					<div>
+						<strong>{email}</strong>.
 					</div>
-				</div>
-				<div className="ncf__FT_Edit_confirmation--alerts">
-					<b>
-						Set up email alerts in
-						<span aria-label="myFT" className="ncf-icon ncf-icon--myft" />
-					</b>
-
-					<p>
-						Choose the content you want to follow by personalising your alerts
-						for the most important topics and additional newsletters
-					</p>
-					<a
-						href="/myft"
-						className="margin-top-x4 ncf__button ncf__button--secondary"
-						data-trackable="register-personalise-my-alerts"
-					>
-						Personalise my alerts
-					</a>
-				</div>
+				</p>
 			</div>
 
 			<a
 				href={hubUrl}
 				target="_parent"
-				className=" ncf__FT_Edit_confirmation--finish ncf__button ncf__button--submit"
+				className=" ncf__confirmation--finish ncf__button ncf__button--submit"
 				data-trackable="register-finish-head-to-ft-edit-hub"
 			>
 				Explore our FT Edit hub
@@ -124,7 +42,7 @@ export function FTEditRegistrationConfirmation({
 				<a
 					href={articleUrl}
 					target="_parent"
-					className=" ncf__FT_Edit_confirmation--finish-article-read ncf__button ncf__button--secondary reduce-bottom-spacing"
+					className=" ncf__confirmation--finish-article-read ncf__button ncf__button--secondary reduce-bottom-spacing"
 					data-trackable="register-finish-head-to-article"
 				>
 					Continue reading

--- a/styles/ft-edit-registration-confirmation.scss
+++ b/styles/ft-edit-registration-confirmation.scss
@@ -19,7 +19,7 @@
 );
 
 @mixin ncfConfirmation() {
-	&__FT_Edit_confirmation {
+	&__confirmation {
 		&--message {
 			max-width: 304px;
 			margin: auto;


### PR DESCRIPTION
### Description
An earlier change for the ft edit registration flow had inadvertently broken the main /register flow, this was due to the build and nature of scss compiling and styles overwriting. 

I was also asked post launch to tweak the designs of the confirmation page of the /ft-edit-register flow so have done this here

### Ticket
[<!-- Add link to the corresponding ticket -->](https://financialtimes.atlassian.net/browse/LAT-1438)

### Screenshots
before: broken /register path
![screenshot_2024-05-10_at_10 15 15_720](https://github.com/Financial-Times/n-conversion-forms/assets/138028929/f5d59e35-1af4-47fe-8156-6fe5d98c37f4)


fixed /register
<img width="1440" alt="Screenshot 2024-05-10 at 11 04 08" src="https://github.com/Financial-Times/n-conversion-forms/assets/138028929/c452b470-36e3-4424-bdfd-2c16628a1e62">


/ tweaks to ft edit registration

<img width="1440" alt="Screenshot 2024-05-10 at 11 03 55" src="https://github.com/Financial-Times/n-conversion-forms/assets/138028929/c6ffcca7-f516-4f60-8ccc-42c63d21365f">

### Reminder
- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
