### PR TITLE
Upate GitHub Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,9 @@
 | ------ | ----- |
 |        |       |
 
+### Semantic versioning
+<!-- What is the proposed release type (i.e. major, minor, path) for these changes and the rationale? -->
+
 ### Reminder
 Have you completed these common tasks (remove those that don't apply)?
 


### PR DESCRIPTION
### Description
This PR adds an additional field to the PR template so that the contributor is prompted to say which release type they propose for their changes.

This can sometimes be a discussion point and so is worth bringing it to these conversation starters rather than it being an afterthought once the changes and code itself has been approved (as has happened here: https://github.com/Financial-Times/n-conversion-forms/pull/799#issuecomment-2205777590).

### Ticket
N/A

### Screenshots
N/A

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
