### PR TITLE
ACQ-2876: changed delivery message for Japan

### DIFF
--- a/components/delivery-option.jsx
+++ b/components/delivery-option.jsx
@@ -35,7 +35,8 @@ export function DeliveryOption({
 					const deliveryOptionValue = getDeliveryOption(
 						productCode,
 						option,
-						FTShippingZone
+						FTShippingZone,
+						country
 					);
 
 					if (!isValidDeliveryOption || !deliveryOptionValue) {

--- a/components/delivery-option.stories.js
+++ b/components/delivery-option.stories.js
@@ -89,3 +89,18 @@ USWeekendOnlyDeliveryOptions.args = {
 	country: 'USA',
 	productCode: 'NWE',
 };
+
+export const JapanDeliveryOptions = (args) => (
+	<div className="ncf">
+		<DeliveryOption {...args} />
+	</div>
+);
+JapanDeliveryOptions.args = {
+	country: 'JPN',
+	options: [
+		{
+			value: 'HD',
+			isValidDeliveryOption: true,
+		},
+	],
+};

--- a/utils/delivery-option-messages.js
+++ b/utils/delivery-option-messages.js
@@ -25,28 +25,35 @@ const UK_COUNTRY_CODE = 'GBR';
 const JPN_COUNTRY_CODE = 'JPN';
 const USA_COUNTRY_CODE = 'USA';
 
-const UKDeliveryOptions = {
-	PV: {
-		title: 'Paper vouchers',
-		description:
-			'13-week voucher pack delivered quarterly and redeemable at retailers nationwide.',
+const customCountries = [UK_COUNTRY_CODE, JPN_COUNTRY_CODE];
+const customCountriesDeliveryOptions = {
+	GBR: {
+		PV: {
+			title: 'Paper vouchers',
+			description:
+				'13-week voucher pack delivered quarterly and redeemable at retailers nationwide.',
+		},
+		HD: {
+			title: 'Hand delivery',
+			description: 'Free delivery to your home or office before 7am.',
+		},
+		EV: {
+			title: 'Electronic vouchers',
+			description:
+				'Delivered via email and card, redeemable at retailers nationwide.',
+		},
 	},
-	HD: {
-		title: 'Hand delivery',
-		description: 'Free delivery to your home or office before 7am.',
-	},
-	EV: {
-		title: 'Electronic vouchers',
-		description:
-			'Delivered via email and card, redeemable at retailers nationwide.',
-	},
-};
-
-const JapanDeliveryOptions = {
-	HD: {
-		title: 'Hand delivery',
-		description:
-			'Enjoy delivery of the newspaper to your home or office address.',
+	JPN: {
+		HD: {
+			title: 'Hand delivery',
+			description:
+				'Enjoy delivery of the newspaper to your home or office address.',
+		},
+		ML: {
+			title: 'Mail Delivery',
+			description:
+				'Enjoy delivery of the newspaper to your home or office address.',
+		},
 	},
 };
 
@@ -297,14 +304,9 @@ function findCustomDeliveryOption(productCode, option, FTShippingZone) {
 }
 
 function getDeliveryOption(productCode, option, FTShippingZone, country) {
-	if (FTShippingZone === UK_COUNTRY_CODE) {
-		return UKDeliveryOptions[option.value];
-	}
-
-	// A specific delivery message should be displayed for Japan
-	// More info: https://financialtimes.atlassian.net/browse/ACQ-2876
-	if (country === JPN_COUNTRY_CODE) {
-		return JapanDeliveryOptions[option.value];
+	// Custom delivery messages are displayed for certain countries
+	if (customCountries.includes(country)) {
+		return customCountriesDeliveryOptions[country][option.value];
 	}
 
 	return findCustomDeliveryOption(productCode, option, FTShippingZone);

--- a/utils/delivery-option-messages.js
+++ b/utils/delivery-option-messages.js
@@ -20,9 +20,10 @@ const HAND_DELIVERY = 'HD';
 const MAIL = 'ML';
 
 // Country codes
-const UK_COUNTRY_CODE = 'GBR';
-const USA_COUNTRY_CODE = 'USA';
 const CAN_COUNTRY_CODE = 'CAN';
+const UK_COUNTRY_CODE = 'GBR';
+const JPN_COUNTRY_CODE = 'JPN';
+const USA_COUNTRY_CODE = 'USA';
 
 const UKDeliveryOptions = {
 	PV: {
@@ -38,6 +39,14 @@ const UKDeliveryOptions = {
 		title: 'Electronic vouchers',
 		description:
 			'Delivered via email and card, redeemable at retailers nationwide.',
+	},
+};
+
+const JapanDeliveryOptions = {
+	HD: {
+		title: 'Hand delivery',
+		description:
+			'Enjoy delivery of the newspaper to your home or office address.',
 	},
 };
 
@@ -287,10 +296,18 @@ function findCustomDeliveryOption(productCode, option, FTShippingZone) {
 	return deliveryOption;
 }
 
-function getDeliveryOption(productCode, option, FTShippingZone) {
-	return FTShippingZone === UK_COUNTRY_CODE
-		? UKDeliveryOptions[option.value]
-		: findCustomDeliveryOption(productCode, option, FTShippingZone);
+function getDeliveryOption(productCode, option, FTShippingZone, country) {
+	if (FTShippingZone === UK_COUNTRY_CODE) {
+		return UKDeliveryOptions[option.value];
+	}
+
+	// A specific delivery message should be displayed for Japan
+	// More info: https://financialtimes.atlassian.net/browse/ACQ-2876
+	if (country === JPN_COUNTRY_CODE) {
+		return JapanDeliveryOptions[option.value];
+	}
+
+	return findCustomDeliveryOption(productCode, option, FTShippingZone);
 }
 
 module.exports = {

--- a/utils/delivery-option-messages.js
+++ b/utils/delivery-option-messages.js
@@ -20,14 +20,25 @@ const HAND_DELIVERY = 'HD';
 const MAIL = 'ML';
 
 // Country codes
-const CAN_COUNTRY_CODE = 'CAN';
+const CANADA_COUNTRY_CODE = 'CAN';
+const JAPAN_COUNTRY_CODE = 'JPN';
 const UK_COUNTRY_CODE = 'GBR';
-const JPN_COUNTRY_CODE = 'JPN';
 const USA_COUNTRY_CODE = 'USA';
 
-const customCountries = [UK_COUNTRY_CODE, JPN_COUNTRY_CODE];
-const customCountriesDeliveryOptions = {
-	GBR: {
+const countryCodeToCustomDeliveryOptionsMap = {
+	[JAPAN_COUNTRY_CODE]: {
+		HD: {
+			title: 'Hand delivery',
+			description:
+				'Enjoy delivery of the newspaper to your home or office address.',
+		},
+		ML: {
+			title: 'Mail Delivery',
+			description:
+				'Enjoy delivery of the newspaper to your home or office address.',
+		},
+	},
+	[UK_COUNTRY_CODE]: {
 		PV: {
 			title: 'Paper vouchers',
 			description:
@@ -41,18 +52,6 @@ const customCountriesDeliveryOptions = {
 			title: 'Electronic vouchers',
 			description:
 				'Delivered via email and card, redeemable at retailers nationwide.',
-		},
-	},
-	JPN: {
-		HD: {
-			title: 'Hand delivery',
-			description:
-				'Enjoy delivery of the newspaper to your home or office address.',
-		},
-		ML: {
-			title: 'Mail Delivery',
-			description:
-				'Enjoy delivery of the newspaper to your home or office address.',
 		},
 	},
 };
@@ -77,7 +76,7 @@ const deliveryOptionMessages = [
 		distributorType: HAND_DELIVERY,
 		deliveryOnPublicationDate: true,
 		flightMarket: true,
-		country: [USA_COUNTRY_CODE, CAN_COUNTRY_CODE],
+		country: [USA_COUNTRY_CODE, CANADA_COUNTRY_CODE],
 		title: 'Hand delivery',
 		description:
 			"Enjoy delivery of the newspaper daily to your home or office address. \nPlease note: We fly the newspaper to your location which means delivery is subject to flight delays/cancellations outside of the FT's control. In those circumstances, your newspaper will be delivered on the next delivery day.",
@@ -90,7 +89,7 @@ const deliveryOptionMessages = [
 		distributorType: HAND_DELIVERY,
 		deliveryOnPublicationDate: true,
 		flightMarket: false,
-		country: [USA_COUNTRY_CODE, CAN_COUNTRY_CODE],
+		country: [USA_COUNTRY_CODE, CANADA_COUNTRY_CODE],
 		title: 'Hand delivery',
 		description:
 			'Enjoy delivery of the newspaper daily to your home or office address.',
@@ -103,7 +102,7 @@ const deliveryOptionMessages = [
 		distributorType: HAND_DELIVERY,
 		deliveryOnPublicationDate: false,
 		flightMarket: true,
-		country: [USA_COUNTRY_CODE, CAN_COUNTRY_CODE],
+		country: [USA_COUNTRY_CODE, CANADA_COUNTRY_CODE],
 		title: 'Hand delivery',
 		description:
 			"Enjoy delivery of the newspaper daily to your home or office address. \nPlease note: We fly the newspaper to your location which means delivery is subject to flight delays/cancellations outside of the FT's control. In those circumstances, your newspaper will be delivered on the next delivery day. Please also be aware that your FT Weekend will be delivered on Sunday.",
@@ -116,7 +115,7 @@ const deliveryOptionMessages = [
 		distributorType: HAND_DELIVERY,
 		deliveryOnPublicationDate: false,
 		flightMarket: false,
-		country: [USA_COUNTRY_CODE, CAN_COUNTRY_CODE],
+		country: [USA_COUNTRY_CODE, CANADA_COUNTRY_CODE],
 		title: 'Hand delivery',
 		description:
 			'Enjoy delivery of the newspaper daily to your home or office address. \nPlease note: Your FT Weekend will be delivered on Sunday or Monday.',
@@ -196,7 +195,7 @@ const deliveryOptionMessages = [
 			SIX_DAYS_WEEK_DELIVERY_FREQ,
 		],
 		distributorType: MAIL,
-		country: [USA_COUNTRY_CODE, CAN_COUNTRY_CODE],
+		country: [USA_COUNTRY_CODE, CANADA_COUNTRY_CODE],
 		title: 'Mail',
 		customId: 'ML',
 		description:
@@ -207,7 +206,7 @@ const deliveryOptionMessages = [
 		distributorType: HAND_DELIVERY,
 		deliveryOnPublicationDate: true,
 		flightMarket: true,
-		country: [USA_COUNTRY_CODE, CAN_COUNTRY_CODE],
+		country: [USA_COUNTRY_CODE, CANADA_COUNTRY_CODE],
 		title: 'Hand delivery',
 		description:
 			"Enjoy delivery of the newspaper daily to your home or office address. \nPlease note: We fly the newspapers to your location which means delivery is subject to flight delays/cancellations outside of the FT's control. In those circumstances, your newspaper will be delivered the next delivery day.",
@@ -217,7 +216,7 @@ const deliveryOptionMessages = [
 		distributorType: HAND_DELIVERY,
 		deliveryOnPublicationDate: true,
 		flightMarket: false,
-		country: [USA_COUNTRY_CODE, CAN_COUNTRY_CODE],
+		country: [USA_COUNTRY_CODE, CANADA_COUNTRY_CODE],
 		title: 'Hand delivery',
 		description:
 			'Enjoy delivery of the newspaper daily to your home or office address.',
@@ -227,7 +226,7 @@ const deliveryOptionMessages = [
 		distributorType: HAND_DELIVERY,
 		deliveryOnPublicationDate: false,
 		flightMarket: true,
-		country: [USA_COUNTRY_CODE, CAN_COUNTRY_CODE],
+		country: [USA_COUNTRY_CODE, CANADA_COUNTRY_CODE],
 		title: 'Hand delivery',
 		description:
 			"Enjoy delivery of the newspaper daily to your home or office address. \nPlease note we fly the newspaper to your location which means delivery is subject to flight delays/cancellations outside of the FT's control. In those circumstances, your newspaper will be delivered on the next delivery day. Please also be aware that your FT Weekend will be delivered on Sunday.",
@@ -237,7 +236,7 @@ const deliveryOptionMessages = [
 		distributorType: HAND_DELIVERY,
 		deliveryOnPublicationDate: false,
 		flightMarket: false,
-		country: [USA_COUNTRY_CODE, CAN_COUNTRY_CODE],
+		country: [USA_COUNTRY_CODE, CANADA_COUNTRY_CODE],
 		title: 'Hand delivery',
 		description:
 			'Enjoy delivery of the newspaper daily to your home or office address. \nPlease note: Your FT Weekend will be delivered on Sunday.',
@@ -245,7 +244,7 @@ const deliveryOptionMessages = [
 	{
 		deliveryFrequency: [ONLY_WEEKEND_DELIVERY_FREQ],
 		distributorType: MAIL,
-		country: [USA_COUNTRY_CODE, CAN_COUNTRY_CODE],
+		country: [USA_COUNTRY_CODE, CANADA_COUNTRY_CODE],
 		title: 'Mail',
 		customId: 'ML',
 		description:
@@ -305,8 +304,8 @@ function findCustomDeliveryOption(productCode, option, FTShippingZone) {
 
 function getDeliveryOption(productCode, option, FTShippingZone, country) {
 	// Custom delivery messages are displayed for certain countries
-	if (customCountries.includes(country)) {
-		return customCountriesDeliveryOptions[country][option.value];
+	if (Object.keys(countryCodeToCustomDeliveryOptionsMap).includes(country)) {
+		return countryCodeToCustomDeliveryOptionsMap[country][option.value];
 	}
 
 	return findCustomDeliveryOption(productCode, option, FTShippingZone);

--- a/utils/delivery-option-messages.spec.js
+++ b/utils/delivery-option-messages.spec.js
@@ -14,14 +14,14 @@ describe('Find Custom Delivery Option', () => {
 
 		it('returns undefined when other country than custom messages', () => {
 			expect(
-				getDeliveryOption(sixDaysProductCode, stubOption, 'AAA')
+				getDeliveryOption(sixDaysProductCode, stubOption, 'AAA', 'AAA')
 			).toBeUndefined();
 		});
 
 		it('returns undefined when invalid distributor type code', () => {
 			const option = { ...stubOption, value: 'ZZ' };
 			expect(
-				getDeliveryOption(sixDaysProductCode, option, 'USA')
+				getDeliveryOption(sixDaysProductCode, option, 'USA', 'USA')
 			).toBeUndefined();
 		});
 
@@ -29,7 +29,7 @@ describe('Find Custom Delivery Option', () => {
 			stubOption.deliveryOnPublicationDate = undefined;
 			stubOption.flightMarket = undefined;
 			expect(
-				getDeliveryOption(sixDaysProductCode, stubOption, 'AAA')
+				getDeliveryOption(sixDaysProductCode, stubOption, 'AAA', 'AAA')
 			).toBeUndefined();
 		});
 	});
@@ -51,6 +51,7 @@ describe('Find Custom Delivery Option', () => {
 			const deliveryOption = getDeliveryOption(
 				sixDaysProductCode,
 				stubOption,
+				'USA',
 				'USA'
 			);
 
@@ -69,6 +70,7 @@ describe('Find Custom Delivery Option', () => {
 			const deliveryOption = getDeliveryOption(
 				weekendProductCode,
 				stubOption,
+				'USA',
 				'USA'
 			);
 
@@ -92,6 +94,7 @@ describe('Find Custom Delivery Option', () => {
 			const deliveryOption = getDeliveryOption(
 				sixDaysProductCode,
 				stubOption,
+				'USA',
 				'USA'
 			);
 
@@ -109,6 +112,7 @@ describe('Find Custom Delivery Option', () => {
 			const deliveryOption = getDeliveryOption(
 				weekendProductCode,
 				stubOption,
+				'CAN',
 				'CAN'
 			);
 
@@ -127,6 +131,7 @@ describe('Find Custom Delivery Option', () => {
 			const deliveryOption = getDeliveryOption(
 				sixDaysProductCode,
 				{ value: 'EV' },
+				'GBR',
 				'GBR'
 			);
 
@@ -164,7 +169,12 @@ describe('Find Custom Delivery Option', () => {
 					'Enjoy the delivery of the newspaper to your home or office address. Please note we fly the newspaper to your location which means delivery is subject to flight delays/cancellations outside of the FT’s control. In those circumstances, your newspaper will be delivered the next delivery day. Please also be aware that your FT weekend will be delivered on Sunday.',
 			};
 
-			const deliveryOption = getDeliveryOption('N6D', stubOption, 'CEMEA_V1');
+			const deliveryOption = getDeliveryOption(
+				'N6D',
+				stubOption,
+				'CEMEA_V1',
+				'BGR'
+			);
 
 			expect(deliveryOption).toEqual(expected);
 		});
@@ -179,7 +189,12 @@ describe('Find Custom Delivery Option', () => {
 					'Enjoy delivery of the newspaper to your home or office address. Note this is a postal delivery - expect delivery after the day of publication. If you would prefer to read the newspaper on the day of publication, purchase an FT ePaper subscription, our digital replica of the each daily edition.',
 			};
 
-			const deliveryOption = getDeliveryOption('N6D', stubOption, 'APAC');
+			const deliveryOption = getDeliveryOption(
+				'N6D',
+				stubOption,
+				'APAC',
+				'HKG'
+			);
 
 			expect(deliveryOption).toEqual(expected);
 		});

--- a/utils/delivery-option-messages.spec.js
+++ b/utils/delivery-option-messages.spec.js
@@ -134,6 +134,25 @@ describe('Find Custom Delivery Option', () => {
 		});
 	});
 
+	describe('Find Japan Delivery Option', () => {
+		it('returns Japan HD delivery option', () => {
+			const expected = {
+				title: 'Hand delivery',
+				description:
+					'Enjoy delivery of the newspaper to your home or office address.',
+			};
+
+			const deliveryOption = getDeliveryOption(
+				sixDaysProductCode,
+				stubOption,
+				'APAC',
+				'JPN'
+			);
+
+			expect(deliveryOption).toEqual(expected);
+		});
+	});
+
 	describe('Find CEMEA/APAC Delivery Option', () => {
 		it('returns CEMEA/APAC HD delivery option', () => {
 			stubOption.flightMarket = true;


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
This PR changes the delivery message displayed for Japan.

### Ticket
<!-- Add link to the corresponding ticket -->
[ACQ-2876](https://financialtimes.atlassian.net/browse/ACQ-2876)

### Screenshots

| Before | After |
| ------ | ----- |
|![old](https://github.com/Financial-Times/n-conversion-forms/assets/25990506/75024813-66b2-4839-944b-483bd62fba62)|![new](https://github.com/Financial-Times/n-conversion-forms/assets/25990506/fe1ef763-1aaa-484d-a884-9dcb402025b5)|

### Semantic versioning
<!-- What is the proposed release type (i.e. major, minor, path) for these changes and the rationale? -->

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [x] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner


[ACQ-2876]: https://financialtimes.atlassian.net/browse/ACQ-2876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ