### PR TITLE
ACQ-2876: delivery option title not displayed if property not provided and test updates

### DIFF
--- a/components/__snapshots__/delivery-option.spec.js.snap
+++ b/components/__snapshots__/delivery-option.spec.js.snap
@@ -17,7 +17,7 @@ exports[`DeliveryOption renders with USA print offer 1`] = `
              class="ncf__delivery-option__input"
              checked
       >
-      <span class="o-forms-input__label ncf__delivery-option__label ">
+      <span class="o-forms-input__label ncf__delivery-option__label">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Hand delivery
         </span>
@@ -35,7 +35,7 @@ exports[`DeliveryOption renders with USA print offer 1`] = `
              value="HD"
              class="ncf__delivery-option__input"
       >
-      <span class="o-forms-input__label ncf__delivery-option__label ">
+      <span class="o-forms-input__label ncf__delivery-option__label">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Mail
         </span>
@@ -65,7 +65,7 @@ exports[`DeliveryOption renders with a context of being single 1`] = `
              class="ncf__delivery-option__input"
              checked
       >
-      <span class="o-forms-input__label ncf__delivery-option__label ">
+      <span class="o-forms-input__label ncf__delivery-option__label">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Paper vouchers
         </span>
@@ -83,7 +83,7 @@ exports[`DeliveryOption renders with a context of being single 1`] = `
              value="HD"
              class="ncf__delivery-option__input"
       >
-      <span class="o-forms-input__label ncf__delivery-option__label ">
+      <span class="o-forms-input__label ncf__delivery-option__label">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Hand delivery
         </span>
@@ -101,7 +101,7 @@ exports[`DeliveryOption renders with a context of being single 1`] = `
              value="EV"
              class="ncf__delivery-option__input"
       >
-      <span class="o-forms-input__label ncf__delivery-option__label ">
+      <span class="o-forms-input__label ncf__delivery-option__label">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Electronic vouchers
         </span>
@@ -131,7 +131,7 @@ exports[`DeliveryOption renders with country CAN print offer HD and mailDelivery
              class="ncf__delivery-option__input"
              checked
       >
-      <span class="o-forms-input__label ncf__delivery-option__label ">
+      <span class="o-forms-input__label ncf__delivery-option__label">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Hand delivery
         </span>
@@ -161,7 +161,7 @@ exports[`DeliveryOption renders with minimum mandatory props 1`] = `
              class="ncf__delivery-option__input"
              checked
       >
-      <span class="o-forms-input__label ncf__delivery-option__label ">
+      <span class="o-forms-input__label ncf__delivery-option__label">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Paper vouchers
         </span>
@@ -179,7 +179,7 @@ exports[`DeliveryOption renders with minimum mandatory props 1`] = `
              value="HD"
              class="ncf__delivery-option__input"
       >
-      <span class="o-forms-input__label ncf__delivery-option__label ">
+      <span class="o-forms-input__label ncf__delivery-option__label">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Hand delivery
         </span>
@@ -197,7 +197,7 @@ exports[`DeliveryOption renders with minimum mandatory props 1`] = `
              value="EV"
              class="ncf__delivery-option__input"
       >
-      <span class="o-forms-input__label ncf__delivery-option__label ">
+      <span class="o-forms-input__label ncf__delivery-option__label">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Electronic vouchers
         </span>
@@ -227,7 +227,7 @@ exports[`DeliveryOption renders without unrecognised delivery options 1`] = `
              class="ncf__delivery-option__input"
              checked
       >
-      <span class="o-forms-input__label ncf__delivery-option__label ">
+      <span class="o-forms-input__label ncf__delivery-option__label">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Paper vouchers
         </span>
@@ -245,7 +245,7 @@ exports[`DeliveryOption renders without unrecognised delivery options 1`] = `
              value="HD"
              class="ncf__delivery-option__input"
       >
-      <span class="o-forms-input__label ncf__delivery-option__label ">
+      <span class="o-forms-input__label ncf__delivery-option__label">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Hand delivery
         </span>
@@ -263,7 +263,7 @@ exports[`DeliveryOption renders without unrecognised delivery options 1`] = `
              value="EV"
              class="ncf__delivery-option__input"
       >
-      <span class="o-forms-input__label ncf__delivery-option__label ">
+      <span class="o-forms-input__label ncf__delivery-option__label">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Electronic vouchers
         </span>

--- a/components/__snapshots__/delivery-option.spec.js.snap
+++ b/components/__snapshots__/delivery-option.spec.js.snap
@@ -17,7 +17,7 @@ exports[`DeliveryOption renders with USA print offer 1`] = `
              class="ncf__delivery-option__input"
              checked
       >
-      <span class="o-forms-input__label ncf__delivery-option__label">
+      <span class="o-forms-input__label ncf__delivery-option__label ">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Hand delivery
         </span>
@@ -35,7 +35,7 @@ exports[`DeliveryOption renders with USA print offer 1`] = `
              value="HD"
              class="ncf__delivery-option__input"
       >
-      <span class="o-forms-input__label ncf__delivery-option__label">
+      <span class="o-forms-input__label ncf__delivery-option__label ">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Mail
         </span>
@@ -65,7 +65,7 @@ exports[`DeliveryOption renders with a context of being single 1`] = `
              class="ncf__delivery-option__input"
              checked
       >
-      <span class="o-forms-input__label ncf__delivery-option__label">
+      <span class="o-forms-input__label ncf__delivery-option__label ">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Paper vouchers
         </span>
@@ -83,7 +83,7 @@ exports[`DeliveryOption renders with a context of being single 1`] = `
              value="HD"
              class="ncf__delivery-option__input"
       >
-      <span class="o-forms-input__label ncf__delivery-option__label">
+      <span class="o-forms-input__label ncf__delivery-option__label ">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Hand delivery
         </span>
@@ -101,7 +101,7 @@ exports[`DeliveryOption renders with a context of being single 1`] = `
              value="EV"
              class="ncf__delivery-option__input"
       >
-      <span class="o-forms-input__label ncf__delivery-option__label">
+      <span class="o-forms-input__label ncf__delivery-option__label ">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Electronic vouchers
         </span>
@@ -131,7 +131,7 @@ exports[`DeliveryOption renders with country CAN print offer HD and mailDelivery
              class="ncf__delivery-option__input"
              checked
       >
-      <span class="o-forms-input__label ncf__delivery-option__label">
+      <span class="o-forms-input__label ncf__delivery-option__label ">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Hand delivery
         </span>
@@ -161,7 +161,7 @@ exports[`DeliveryOption renders with minimum mandatory props 1`] = `
              class="ncf__delivery-option__input"
              checked
       >
-      <span class="o-forms-input__label ncf__delivery-option__label">
+      <span class="o-forms-input__label ncf__delivery-option__label ">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Paper vouchers
         </span>
@@ -179,7 +179,7 @@ exports[`DeliveryOption renders with minimum mandatory props 1`] = `
              value="HD"
              class="ncf__delivery-option__input"
       >
-      <span class="o-forms-input__label ncf__delivery-option__label">
+      <span class="o-forms-input__label ncf__delivery-option__label ">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Hand delivery
         </span>
@@ -197,7 +197,7 @@ exports[`DeliveryOption renders with minimum mandatory props 1`] = `
              value="EV"
              class="ncf__delivery-option__input"
       >
-      <span class="o-forms-input__label ncf__delivery-option__label">
+      <span class="o-forms-input__label ncf__delivery-option__label ">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Electronic vouchers
         </span>
@@ -227,7 +227,7 @@ exports[`DeliveryOption renders without unrecognised delivery options 1`] = `
              class="ncf__delivery-option__input"
              checked
       >
-      <span class="o-forms-input__label ncf__delivery-option__label">
+      <span class="o-forms-input__label ncf__delivery-option__label ">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Paper vouchers
         </span>
@@ -245,7 +245,7 @@ exports[`DeliveryOption renders without unrecognised delivery options 1`] = `
              value="HD"
              class="ncf__delivery-option__input"
       >
-      <span class="o-forms-input__label ncf__delivery-option__label">
+      <span class="o-forms-input__label ncf__delivery-option__label ">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Hand delivery
         </span>
@@ -263,7 +263,7 @@ exports[`DeliveryOption renders without unrecognised delivery options 1`] = `
              value="EV"
              class="ncf__delivery-option__input"
       >
-      <span class="o-forms-input__label ncf__delivery-option__label">
+      <span class="o-forms-input__label ncf__delivery-option__label ">
         <span class="ncf__delivery-option__title o-forms-title__main">
           Electronic vouchers
         </span>

--- a/components/delivery-option.jsx
+++ b/components/delivery-option.jsx
@@ -62,7 +62,13 @@ export function DeliveryOption({
 							htmlFor={id}
 						>
 							<input {...inputProps} />
-							<span className="o-forms-input__label ncf__delivery-option__label">
+							<span
+								className={`o-forms-input__label ncf__delivery-option__label ${
+									deliveryOptionValue.title
+										? ''
+										: 'no-title__delivery-option__box'
+								}`}
+							>
 								{deliveryOptionValue.title && (
 									<span className="ncf__delivery-option__title o-forms-title__main">
 										{deliveryOptionValue.title}

--- a/components/delivery-option.jsx
+++ b/components/delivery-option.jsx
@@ -63,9 +63,11 @@ export function DeliveryOption({
 						>
 							<input {...inputProps} />
 							<span className="o-forms-input__label ncf__delivery-option__label">
-								<span className="ncf__delivery-option__title o-forms-title__main">
-									{deliveryOptionValue.title}
-								</span>
+								{deliveryOptionValue.title && (
+									<span className="ncf__delivery-option__title o-forms-title__main">
+										{deliveryOptionValue.title}
+									</span>
+								)}
 								<div className="ncf__delivery-option__description">
 									{deliveryOptionValue.description}
 								</div>

--- a/components/delivery-option.jsx
+++ b/components/delivery-option.jsx
@@ -55,6 +55,12 @@ export function DeliveryOption({
 						defaultChecked: isSelected,
 					};
 
+					const deliveryOptionBoxClassNames = classNames([
+						'o-forms-input__label',
+						'ncf__delivery-option__label',
+						{ 'no-title__delivery-option__box': !deliveryOptionValue.title },
+					]);
+
 					return (
 						<label
 							key={value}
@@ -62,13 +68,7 @@ export function DeliveryOption({
 							htmlFor={id}
 						>
 							<input {...inputProps} />
-							<span
-								className={`o-forms-input__label ncf__delivery-option__label ${
-									deliveryOptionValue.title
-										? ''
-										: 'no-title__delivery-option__box'
-								}`}
-							>
+							<span className={deliveryOptionBoxClassNames}>
 								{deliveryOptionValue.title && (
 									<span className="ncf__delivery-option__title o-forms-title__main">
 										{deliveryOptionValue.title}

--- a/styles/_shared.scss
+++ b/styles/_shared.scss
@@ -28,6 +28,9 @@
 			background-color: oColorsByName('white');
 			color: oColorsByName('black-80');;
 		}
+		.no-title__delivery-option__box {
+			min-height: 80px;
+		}
 		.o-forms-input__address-type__label {
 			padding: 2px 2px 2px 35px;
 			min-height: 0;

--- a/utils/delivery-option-messages.js
+++ b/utils/delivery-option-messages.js
@@ -25,12 +25,17 @@ const JAPAN_COUNTRY_CODE = 'JPN';
 const UK_COUNTRY_CODE = 'GBR';
 const USA_COUNTRY_CODE = 'USA';
 
-const japanDeliveryOption = {
-	description:
-		'Enjoy delivery of the newspaper to your home or office address.',
-};
-
 const countryCodeToCustomDeliveryOptionsMap = {
+	[JAPAN_COUNTRY_CODE]: {
+		HD: {
+			description:
+				'Enjoy delivery of the newspaper to your home or office address.',
+		},
+		ML: {
+			description:
+				'Enjoy delivery of the newspaper to your home or office address.',
+		},
+	},
 	[UK_COUNTRY_CODE]: {
 		PV: {
 			title: 'Paper vouchers',
@@ -299,11 +304,6 @@ function getDeliveryOption(productCode, option, FTShippingZone, country) {
 	// Custom delivery messages are displayed for certain countries
 	if (Object.keys(countryCodeToCustomDeliveryOptionsMap).includes(country)) {
 		return countryCodeToCustomDeliveryOptionsMap[country][option.value];
-	}
-
-	// Specific delivery message for Japan (no title)
-	if (country === JAPAN_COUNTRY_CODE) {
-		return japanDeliveryOption;
 	}
 
 	return findCustomDeliveryOption(productCode, option, FTShippingZone);

--- a/utils/delivery-option-messages.js
+++ b/utils/delivery-option-messages.js
@@ -25,19 +25,12 @@ const JAPAN_COUNTRY_CODE = 'JPN';
 const UK_COUNTRY_CODE = 'GBR';
 const USA_COUNTRY_CODE = 'USA';
 
+const japanDeliveryOption = {
+	description:
+		'Enjoy delivery of the newspaper to your home or office address.',
+};
+
 const countryCodeToCustomDeliveryOptionsMap = {
-	[JAPAN_COUNTRY_CODE]: {
-		HD: {
-			title: 'Hand delivery',
-			description:
-				'Enjoy delivery of the newspaper to your home or office address.',
-		},
-		ML: {
-			title: 'Mail Delivery',
-			description:
-				'Enjoy delivery of the newspaper to your home or office address.',
-		},
-	},
 	[UK_COUNTRY_CODE]: {
 		PV: {
 			title: 'Paper vouchers',
@@ -306,6 +299,11 @@ function getDeliveryOption(productCode, option, FTShippingZone, country) {
 	// Custom delivery messages are displayed for certain countries
 	if (Object.keys(countryCodeToCustomDeliveryOptionsMap).includes(country)) {
 		return countryCodeToCustomDeliveryOptionsMap[country][option.value];
+	}
+
+	// Specific delivery message for Japan (no title)
+	if (country === JAPAN_COUNTRY_CODE) {
+		return japanDeliveryOption;
 	}
 
 	return findCustomDeliveryOption(productCode, option, FTShippingZone);

--- a/utils/delivery-option-messages.spec.js
+++ b/utils/delivery-option-messages.spec.js
@@ -142,7 +142,6 @@ describe('Find Custom Delivery Option', () => {
 	describe('Find Japan Delivery Option', () => {
 		it('returns Japan HD delivery option', () => {
 			const expected = {
-				title: 'Hand delivery',
 				description:
 					'Enjoy delivery of the newspaper to your home or office address.',
 			};


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
This PR focuses on not displaying a delivery option title if the `title` property is not provided. In this case, `Japan` will not have a title for all delivery messages.

Tests were also updated to reflect this change.

### Ticket
<!-- Add link to the corresponding ticket -->
[ACQ-2876](https://financialtimes.atlassian.net/browse/ACQ-2876)

### Screenshots

| Before | After |
| ------ | ----- |
|![new](https://github.com/user-attachments/assets/20b494bc-0790-4946-ac0b-39b779318eaf)|![new](https://github.com/user-attachments/assets/fdcfa788-2be2-4b39-9e71-8a5b1555a1b2)|

### Semantic versioning
<!-- What is the proposed release type (i.e. major, minor, path) for these changes and the rationale? -->

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner


[ACQ-2876]: https://financialtimes.atlassian.net/browse/ACQ-2876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ