### PR TITLE
chore:Add support for new design change for next profile changes

### DIFF
--- a/components/delivery-start-date.jsx
+++ b/components/delivery-start-date.jsx
@@ -10,6 +10,7 @@ export function DeliveryStartDate({
 	max = null,
 	isDisabled = false,
 	isAddressUpdate = false,
+	useNextProfileDesign = false,
 }) {
 	const inputWrapperClassNames = classNames([
 		'o-forms-input',
@@ -35,32 +36,72 @@ export function DeliveryStartDate({
 		: 'The first print edition you will receive is:';
 
 	return (
-		<label
-			id="deliveryStartDateField"
-			className="o-forms-field ncf__validation-error"
-			data-validate="required"
-			htmlFor={inputProps.id}
-		>
-			<span className="o-forms-title">
-				<span className="o-forms-title__main" id="start-date-picker-title-span">
-					Delivery start date
-				</span>
-				<span className="o-forms-title__prompt">
-					Earliest available delivery date: {date}
-				</span>
-			</span>
+		<>
+			{!useNextProfileDesign && (
+				<label
+					id="deliveryStartDateField"
+					className="o-forms-field ncf__validation-error"
+					data-validate="required"
+					htmlFor={inputProps.id}
+				>
+					<span className="o-forms-title">
+						<span
+							className="o-forms-title__main"
+							id="start-date-picker-title-span"
+						>
+							Delivery start date
+						</span>
+						<span className="o-forms-title__prompt">
+							Earliest available delivery date: {date}
+						</span>
+					</span>
 
-			<span className={inputWrapperClassNames}>
-				<input {...inputProps} />
-				<span className="o-forms-input__error">
-					Please select a valid start date
-				</span>
-			</span>
+					<span className={inputWrapperClassNames}>
+						<input {...inputProps} />
+						<span className="o-forms-input__error">
+							Please select a valid start date
+						</span>
+					</span>
 
-			<p>
-				{startMessage} <strong className="js-start-date-text">{date}</strong>
-			</p>
-		</label>
+					<p>
+						{startMessage}{' '}
+						<strong className="js-start-date-text">{date}</strong>
+					</p>
+				</label>
+			)}
+			{useNextProfileDesign && (
+				<label
+					id="deliveryStartDateField"
+					className="o-forms-field ncf__validation-error"
+					data-validate="required"
+					htmlFor={inputProps.id}
+				>
+					<span className="o-forms-title">
+						<span
+							className="o-forms-title__main"
+							id="start-date-picker-title-span"
+						>
+							Delivery start date
+						</span>
+					</span>
+					<span className={inputWrapperClassNames}>
+						<input {...inputProps} />
+						<span className="o-forms-input__error">
+							Please select a valid start date
+						</span>
+					</span>
+					<span className="o-forms-title__prompt delivery-start-date__early-message">
+						Earliest available delivery date: {date}
+					</span>
+					<p className="delivery-start-date__message">
+						{startMessage}{' '}
+						<strong className="js-start-date-text delivery-start-date--text">
+							{date}
+						</strong>
+					</p>
+				</label>
+			)}
+		</>
 	);
 }
 
@@ -72,4 +113,5 @@ DeliveryStartDate.propTypes = {
 	max: PropTypes.string,
 	isDisabled: PropTypes.bool,
 	isAddressUpdate: PropTypes.bool,
+	useNextProfileDesign: PropTypes.bool,
 };

--- a/styles/forms-additional-field-information.scss
+++ b/styles/forms-additional-field-information.scss
@@ -15,3 +15,16 @@
 .o-forms-title .o-forms-title__prompt + .o-forms-title__prompt {
 	padding-top: oSpacingByName('s2');
 }
+
+.delivery-start-date__early-message {
+    margin-top: oSpacingByName('s3');
+}
+
+.delivery-start-date__text {
+    color: oColorsByName('teal');
+}
+
+.delivery-start-date__message {
+    margin-top: oSpacingByName('s8');
+    margin-bottom: oSpacingByName('s2');
+}


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

This PR introduces a new variation of the start date component with an option to use the `useNextProfileDesign` flag. When set to true, it will display the new design. If false, it retains the current design.

This update is part of the changes being rolled out for next-profile print users.

### Ticket
<!-- Add link to the corresponding ticket -->
[Jira ticket](https://financialtimes.atlassian.net/browse/ACC-3231)
[Figma design](https://www.figma.com/design/JRFlyIZdtXvbz3HxfpSVkO/New-designs-for-accounts-%26-settings-hub---Pre-refinement?node-id=2529-4450&m=dev)


### Screenshots

#### Change when the `useNextProfileDesign` is false

<img width="1430" alt="Screenshot 2024-07-24 at 14 53 29" src="https://github.com/user-attachments/assets/70d19386-96a0-44d5-88d3-e4b6463a3d08">


#### Change when the `useNextProfileDesign` is true


<img width="723" alt="Screenshot 2024-07-24 at 14 50 02" src="https://github.com/user-attachments/assets/f9c1cb52-4730-48ae-9dc1-4b8e02b726a2">

#### Change usage in next-profile

<img width="1426" alt="Screenshot 2024-07-24 at 14 50 34" src="https://github.com/user-attachments/assets/a8e7bd76-cfef-4cd8-9a02-ccbe6c0e50ca">


### Semantic versioning
<!-- What is the proposed release type (i.e. major, minor, path) for these changes and the rationale? -->

**Proposed Release Type: Minor** - v37.1.0

**Rationale:**
This change introduces a new variation of an existing component without breaking any existing functionality. It adds optional new functionality (the `useNextProfileDesign` flag) that enhances the component for specific use cases, which aligns with a minor version update.

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [ ] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner
