### PR TITLE
ACQ-2891: changed labels on delivery step and updated tests

### DIFF
--- a/components/__snapshots__/delivery-start-date.spec.js.snap
+++ b/components/__snapshots__/delivery-start-date.spec.js.snap
@@ -10,10 +10,10 @@ exports[`DeliveryStartDate renders with a custom date 1`] = `
     <span class="o-forms-title__main"
           id="start-date-picker-title-span"
     >
-      Delivery start date
+      Start date
     </span>
     <span class="o-forms-title__prompt">
-      Earliest available delivery date: 5th November 2019
+      The first print edition you will receive is: 5th November 2019
     </span>
   </span>
   <span class="o-forms-input o-forms-input--text">
@@ -29,12 +29,6 @@ exports[`DeliveryStartDate renders with a custom date 1`] = `
       Please select a valid start date
     </span>
   </span>
-  <p>
-    The first print edition you will receive is:
-    <strong class="js-start-date-text">
-      5th November 2019
-    </strong>
-  </p>
 </label>
 `;
 
@@ -48,10 +42,10 @@ exports[`DeliveryStartDate renders with a custom input max value 1`] = `
     <span class="o-forms-title__main"
           id="start-date-picker-title-span"
     >
-      Delivery start date
+      Start date
     </span>
     <span class="o-forms-title__prompt">
-      Earliest available delivery date: 2
+      The first print edition you will receive is: 2
     </span>
   </span>
   <span class="o-forms-input o-forms-input--text">
@@ -67,12 +61,6 @@ exports[`DeliveryStartDate renders with a custom input max value 1`] = `
       Please select a valid start date
     </span>
   </span>
-  <p>
-    The first print edition you will receive is:
-    <strong class="js-start-date-text">
-      2
-    </strong>
-  </p>
 </label>
 `;
 
@@ -86,10 +74,10 @@ exports[`DeliveryStartDate renders with a custom input min value 1`] = `
     <span class="o-forms-title__main"
           id="start-date-picker-title-span"
     >
-      Delivery start date
+      Start date
     </span>
     <span class="o-forms-title__prompt">
-      Earliest available delivery date:
+      The first print edition you will receive is:
     </span>
   </span>
   <span class="o-forms-input o-forms-input--text">
@@ -106,11 +94,6 @@ exports[`DeliveryStartDate renders with a custom input min value 1`] = `
       Please select a valid start date
     </span>
   </span>
-  <p>
-    The first print edition you will receive is:
-    <strong class="js-start-date-text">
-    </strong>
-  </p>
 </label>
 `;
 
@@ -124,10 +107,10 @@ exports[`DeliveryStartDate renders with a custom input value 1`] = `
     <span class="o-forms-title__main"
           id="start-date-picker-title-span"
     >
-      Delivery start date
+      Start date
     </span>
     <span class="o-forms-title__prompt">
-      Earliest available delivery date:
+      The first print edition you will receive is:
     </span>
   </span>
   <span class="o-forms-input o-forms-input--text">
@@ -143,11 +126,6 @@ exports[`DeliveryStartDate renders with a custom input value 1`] = `
       Please select a valid start date
     </span>
   </span>
-  <p>
-    The first print edition you will receive is:
-    <strong class="js-start-date-text">
-    </strong>
-  </p>
 </label>
 `;
 
@@ -161,10 +139,10 @@ exports[`DeliveryStartDate renders with a disabled input 1`] = `
     <span class="o-forms-title__main"
           id="start-date-picker-title-span"
     >
-      Delivery start date
+      Start date
     </span>
     <span class="o-forms-title__prompt">
-      Earliest available delivery date:
+      The first print edition you will receive is:
     </span>
   </span>
   <span class="o-forms-input o-forms-input--text">
@@ -181,11 +159,6 @@ exports[`DeliveryStartDate renders with a disabled input 1`] = `
       Please select a valid start date
     </span>
   </span>
-  <p>
-    The first print edition you will receive is:
-    <strong class="js-start-date-text">
-    </strong>
-  </p>
 </label>
 `;
 
@@ -199,10 +172,10 @@ exports[`DeliveryStartDate renders with an error 1`] = `
     <span class="o-forms-title__main"
           id="start-date-picker-title-span"
     >
-      Delivery start date
+      Start date
     </span>
     <span class="o-forms-title__prompt">
-      Earliest available delivery date:
+      The first print edition you will receive is:
     </span>
   </span>
   <span class="o-forms-input o-forms-input--text o-forms-input--invalid">
@@ -218,11 +191,6 @@ exports[`DeliveryStartDate renders with an error 1`] = `
       Please select a valid start date
     </span>
   </span>
-  <p>
-    The first print edition you will receive is:
-    <strong class="js-start-date-text">
-    </strong>
-  </p>
 </label>
 `;
 
@@ -236,10 +204,10 @@ exports[`DeliveryStartDate renders with appropriate start message when isAddress
     <span class="o-forms-title__main"
           id="start-date-picker-title-span"
     >
-      Delivery start date
+      Start date
     </span>
     <span class="o-forms-title__prompt">
-      Earliest available delivery date:
+      The first print edition you will receive is:
     </span>
   </span>
   <span class="o-forms-input o-forms-input--text">
@@ -273,10 +241,10 @@ exports[`DeliveryStartDate renders with country different than default 1`] = `
     <span class="o-forms-title__main"
           id="start-date-picker-title-span"
     >
-      Delivery start date
+      Start date
     </span>
     <span class="o-forms-title__prompt">
-      Earliest available delivery date:
+      The first print edition you will receive is:
     </span>
   </span>
   <span class="o-forms-input o-forms-input--text">
@@ -292,11 +260,6 @@ exports[`DeliveryStartDate renders with country different than default 1`] = `
       Please select a valid start date
     </span>
   </span>
-  <p>
-    The first print edition you will receive is:
-    <strong class="js-start-date-text">
-    </strong>
-  </p>
 </label>
 `;
 
@@ -310,10 +273,10 @@ exports[`DeliveryStartDate renders with default props 1`] = `
     <span class="o-forms-title__main"
           id="start-date-picker-title-span"
     >
-      Delivery start date
+      Start date
     </span>
     <span class="o-forms-title__prompt">
-      Earliest available delivery date:
+      The first print edition you will receive is:
     </span>
   </span>
   <span class="o-forms-input o-forms-input--text">
@@ -329,10 +292,5 @@ exports[`DeliveryStartDate renders with default props 1`] = `
       Please select a valid start date
     </span>
   </span>
-  <p>
-    The first print edition you will receive is:
-    <strong class="js-start-date-text">
-    </strong>
-  </p>
 </label>
 `;

--- a/components/delivery-start-date.jsx
+++ b/components/delivery-start-date.jsx
@@ -30,10 +30,6 @@ export function DeliveryStartDate({
 		defaultValue: value,
 	};
 
-	const startMessage = isAddressUpdate
-		? 'We’ll start delivering to this address from:'
-		: 'The first print edition you will receive is:';
-
 	return (
 		<label
 			id="deliveryStartDateField"
@@ -43,10 +39,10 @@ export function DeliveryStartDate({
 		>
 			<span className="o-forms-title">
 				<span className="o-forms-title__main" id="start-date-picker-title-span">
-					Delivery start date
+					Start date
 				</span>
 				<span className="o-forms-title__prompt">
-					Earliest available delivery date: {date}
+					The first print edition you will receive is: {date}
 				</span>
 			</span>
 
@@ -57,9 +53,12 @@ export function DeliveryStartDate({
 				</span>
 			</span>
 
-			<p>
-				{startMessage} <strong className="js-start-date-text">{date}</strong>
-			</p>
+			{isAddressUpdate && (
+				<p>
+					We’ll start delivering to this address from:{' '}
+					<strong className="js-start-date-text">{date}</strong>
+				</p>
+			)}
 		</label>
 	);
 }

--- a/utils/delivery-option-messages.js
+++ b/utils/delivery-option-messages.js
@@ -173,7 +173,7 @@ const deliveryOptionMessages = [
 		customId: 'ML',
 		flightMarket: true,
 		description:
-			'Enjoy delivery of the newspaper to your home or office address. Note this is a postal delivery - expect delivery after the day of publication. If you would prefer to read the newspaper on the day of publication, purchase an FT ePaper subscription, our digital replica of the each daily edition.',
+			'Enjoy delivery of the newspaper to your home or office address. Note this is a postal delivery - expect delivery after the day of publication. If you would prefer to read the newspaper on the day of publication, purchase an FT ePaper subscription, our digital replica of each daily edition.',
 	},
 	{
 		deliveryFrequency: [

--- a/utils/delivery-option-messages.spec.js
+++ b/utils/delivery-option-messages.spec.js
@@ -186,7 +186,7 @@ describe('Find Custom Delivery Option', () => {
 				title: 'Mail Delivery',
 				customId: 'ML',
 				description:
-					'Enjoy delivery of the newspaper to your home or office address. Note this is a postal delivery - expect delivery after the day of publication. If you would prefer to read the newspaper on the day of publication, purchase an FT ePaper subscription, our digital replica of the each daily edition.',
+					'Enjoy delivery of the newspaper to your home or office address. Note this is a postal delivery - expect delivery after the day of publication. If you would prefer to read the newspaper on the day of publication, purchase an FT ePaper subscription, our digital replica of each daily edition.',
 			};
 
 			const deliveryOption = getDeliveryOption(


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
This PR changes the following labels on `delivery` step:
- `Delivery Start Date` to `Start Date`
- `Earliest available delivery date:` to `The first print edition you will receive is:`
- One of the delivery messages had a typo:
  - `our digital replica of the each daily edition` to `our digital replica of each daily edition`

Tests were also updated.

### Ticket
<!-- Add link to the corresponding ticket -->
[ACQ-2891](https://financialtimes.atlassian.net/browse/ACQ-2891)

### Screenshots

| Before | After |
| ------ | ----- |
|![old](https://github.com/user-attachments/assets/7aca010b-7dfc-4ce6-8708-25010a9e7972)|![new](https://github.com/user-attachments/assets/9f93779a-f53a-44b2-b003-14e0d14834e9)|

### Semantic versioning
<!-- What is the proposed release type (i.e. major, minor, path) for these changes and the rationale? -->

### Reminder
Have you completed these common tasks (remove those that don't apply)?

- [ ] **Documentation** updated or created
- [x] **Tests** written for new or updated for existing functionality
- [ ] **Stories** updated to use this change
- [ ] **Accessibility** checked for screen readers and contrast
- [ ] **Design Review** ran past the designer
- [ ] **Product Review** ran past the product owner


[ACQ-2891]: https://financialtimes.atlassian.net/browse/ACQ-2891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ