### PR TITLE
Allow Message component to take additional className

### DIFF
--- a/components/message.jsx
+++ b/components/message.jsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 export function Message({
 	title,
 	message,
+	additionalClass,
 	additional = [],
 	actions = null,
 	name,
@@ -61,7 +62,14 @@ export function Message({
 	) : null;
 
 	return (
-		<div className={ncfClassNames} data-message-name={name}>
+		<div
+			className={
+				additionalClass
+					? `${ncfClassNames} ${additionalClass}`
+					: ncfClassNames
+			}
+			data-message-name={name}
+		>
 			<div className={oMessageClassNames} data-o-component="o-message">
 				<div className="o-message__container">
 					<div className="o-message__content">
@@ -93,6 +101,7 @@ const actionType = PropTypes.shape({
 Message.propTypes = {
 	title: PropTypes.string,
 	message: PropTypes.string.isRequired,
+	additionalClass: PropTypes.string,
 	additional: PropTypes.arrayOf(PropTypes.string),
 	actions: PropTypes.arrayOf(actionType),
 	name: PropTypes.string,


### PR DESCRIPTION
### Description
Extend the `Message` component to allow to pass an additional className. 

Note: This PR allows the Message component to allow one additional className only. Further work will be needed if a use case is found where client apps need to pass more than one additional className. 

### Ticket
[JIRA](https://financialtimes.atlassian.net/jira/software/c/projects/ACC/boards/1850?selectedIssue=ACC-3226)

### Semantic versioning
<!-- What is the proposed release type (i.e. major, minor, path) for these changes and the rationale? -->
There are no breaking changes, this will be a minor release. 
